### PR TITLE
DPR-319 remove spark-core from kinesis-asl dep reducing jar size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,9 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
-    implementation "org.apache.spark:spark-streaming-kinesis-asl_2.12:$sparkVersion"
+    implementation ("org.apache.spark:spark-streaming-kinesis-asl_2.12:$sparkVersion") {
+      exclude group: "org.apache.spark", module: "spark-core_2.12"
+    }
     implementation "info.picocli:picocli"
     implementation "io.micronaut.picocli:micronaut-picocli"
     implementation "io.micronaut:micronaut-jackson-databind"


### PR DESCRIPTION
Summary of changes
* Glue already adds Spark 3.3.0 to the classpath so we can remove spark-core from the jar which is pulled in transitively by the kinesis asl streaming library
* This reduces the jar size significantly from approx 160MiB to 36MiB