### PR TITLE
DPR-367 fix schema parsing issues

### DIFF
--- a/bin/check-fields
+++ b/bin/check-fields
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]
+then
+  cat <<USAGE
+
+Compare fields in a DMS table schema with fields from a json DMS record.
+
+Usage: check-fields <path to schema> <path to json file>
+
+USAGE
+  exit 1
+fi
+
+if ! [ -x "$(command -v jq)" ]
+then
+  cat <<INSTALL_JQ
+
+This command requires jq to be installed in order to parse json files.
+
+If you're using brew this should simply be a case of
+
+  > brew install jq
+
+INSTALL_JQ
+  exit 1
+fi
+
+schema=$1
+json=$2
+
+schema_fields=$(cat $schema | grep name | tr -d " " | cut -d ':' -f2 | tr -d '"' | tr -d ',' | sort)
+json_fields=$(cat $json | jq ".data" -M | tr -d ' ' | cut -d ':' -f1 | grep -v '{\|}' | tr -d '"' | tr -d ',' | sort)
+
+if diff -y --suppress-common-lines <(echo "$schema_fields") <(echo "$json_fields")
+then
+  echo -e "[\033[1;32mPASS\033[0m] Schema and DMS record fields agree"
+else
+  echo -e "[\033[1;31mFAIL\033[0m] Schema and DMS record fields agree"
+  exit 1
+fi

--- a/src/main/resources/schemas/oms_owner.agency_locations.schema.json
+++ b/src/main/resources/schemas/oms_owner.agency_locations.schema.json
@@ -265,6 +265,18 @@
       "type": "string",
       "nullable": true,
       "metadata": {}
+    },
+    {
+      "name": "AREA_CODE",
+      "type": "string",
+      "nullable": true,
+      "metadata": {}
+    },
+    {
+      "name": "PAYROLL_REGION",
+      "type": "string",
+      "nullable": true,
+      "metadata": {}
     }
   ]
 }

--- a/src/main/resources/schemas/oms_owner.offender_bookings.schema.json
+++ b/src/main/resources/schemas/oms_owner.offender_bookings.schema.json
@@ -74,7 +74,7 @@
       "metadata": {}
     },
     {
-      "name": "FINGERPRINTED_STAFF_ID",
+      "name": "FINGER_PRINTED_STAFF_ID",
       "type": "long",
       "nullable": true,
       "metadata": {}

--- a/src/test/java/uk/gov/justice/digital/job/udf/JsonValidatorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/udf/JsonValidatorTest.java
@@ -52,6 +52,13 @@ class JsonValidatorTest {
     }
 
     @Test
+    public void shouldPassValidJsonIrrespectiveOfFieldOrdering() throws JsonProcessingException {
+        val json = "{\"mandatory\":\"foo\",\"numeric\":1}";
+        val jsonWithReverseFieldOrder = "{\"numeric\":1,\"mandatory\":\"foo\"}";
+        assertTrue(underTest.validate(json, jsonWithReverseFieldOrder, schema));
+    }
+
+    @Test
     public void shouldFailJsonWithMissingMandatoryValue() throws JsonProcessingException {
         val json = createJsonForMapValues(Arrays.asList(
             entry(Fields.OPTIONAL, "anotherValue"),

--- a/src/test/resources/data/dms_data.json
+++ b/src/test/resources/data/dms_data.json
@@ -1,3 +1,0 @@
-{
-  "data": "{\"data\":{\"offender_id\":127,\"offender_name_seq\":254000,\"birth_date\":\"1932-10-26\",\"create_date\":\"2015-05-19\",\"modify_datetime\":\"2022-09-01T18:21:36.915241Z\",\"age\":89,\"create_datetime\":\"2022-09-01T18:21:36.915241Z\",\"audit_timestamp\":\"2022-09-01T18:21:36.915241Z\"},\"metadata\":{\"timestamp\":\"2023-03-12T18:48:45.172406Z\",\"record-type\":\"data\",\"operation\":\"load\",\"partition-key-type\":\"primary-key\",\"schema-name\":\"public\",\"table-name\":\"offenders\"}}"
-}

--- a/src/test/resources/data/dms_record.json
+++ b/src/test/resources/data/dms_record.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "offender_id": 127,
+    "offender_name_seq": 254000,
+    "birth_date": "1932-10-26",
+    "create_date": "2015-05-19",
+    "modify_datetime": "2022-09-01T18:21:36.915241Z",
+    "age": 89,
+    "create_datetime": "2022-09-01T18:21:36.915241Z",
+    "audit_timestamp": "2022-09-01T18:21:36.915241Z"
+  },
+  "metadata": {
+    "timestamp": "2023-03-12T18:48:45.172406Z",
+    "record-type": "data",
+    "operation": "load",
+    "partition-key-type": "primary-key",
+    "schema-name": "public",
+    "table-name": "offenders"
+  }
+}


### PR DESCRIPTION
Summary of changes
* updated nomis table schemas where latest T3 data differs (new fields or field renames)
* revised schema validation to ensure the parsed json includes null fields which matches the incoming json ensuring the basic structural match works correctly
* fixed an issue with parsing JSON from a file which caused the DMS test to fail after merging (we have a json format trigger that adds newlines - so the test now handles multiline json)
* added a script that compares the fields in a given schema and corresponding dms json file highlighting any differences (which came in handy when I was investigating validation failures after fixing the issue with null fields)
* other minor tidy ups e.g. removing unused imports etc..