### PR TITLE
NOJIRA add helper scripts for working with aws glue jobs

### DIFF
--- a/scripts/push-jar
+++ b/scripts/push-jar
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script to build the jobs jar and push it to a specified s3 bucket.
+#
+# Usage:
+#
+#   scripts/push-jar <s3-folder-uri>
+#
+#   e.g.
+#
+#   scripts/push-jar s3://dpr-jars/dev
+
+set -e
+
+s3_uri="$@"
+
+echo
+
+if [ -z "$s3_uri" ]
+then
+  echo "A destination s3 uri must be specified"
+  exit 1;
+fi
+
+echo "Building jar"
+echo
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+./gradlew clean shadowJar
+
+echo
+echo "Uploading jar to $s3_uri"
+echo
+aws s3 cp ./build/libs/digital-prison-reporting-jobs-1.0-SNAPSHOT-all.jar $s3_uri/digital-prison-reporting-jobs-1.0-SNAPSHOT-all.jar
+echo

--- a/scripts/push-jar
+++ b/scripts/push-jar
@@ -33,5 +33,5 @@ cd $script_dir/../
 echo
 echo "Uploading jar to $s3_uri"
 echo
-aws s3 cp ./build/libs/digital-prison-reporting-jobs-*-all.jar $s3_uri/digital-prison-reporting-jobs-1.0-SNAPSHOT-all.jar
+aws s3 cp ./build/libs/digital-prison-reporting-jobs-*-all.jar $s3_uri/
 echo

--- a/scripts/push-jar
+++ b/scripts/push-jar
@@ -12,6 +12,8 @@
 
 set -e
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 s3_uri="$@"
 
 echo
@@ -25,12 +27,11 @@ fi
 echo "Building jar"
 echo
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
+cd $script_dir/../
 ./gradlew clean shadowJar
 
 echo
 echo "Uploading jar to $s3_uri"
 echo
-aws s3 cp ./build/libs/digital-prison-reporting-jobs-1.0-SNAPSHOT-all.jar $s3_uri/digital-prison-reporting-jobs-1.0-SNAPSHOT-all.jar
+aws s3 cp ./build/libs/digital-prison-reporting-jobs-*-all.jar $s3_uri/digital-prison-reporting-jobs-1.0-SNAPSHOT-all.jar
 echo

--- a/scripts/start-and-tail-job
+++ b/scripts/start-and-tail-job
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script to start a given glue job and tail the logs using the tail-glue-logs
+# script.
+#
+# Usage:
+#
+#   scripts/start-and-tail-job <glue-job-name>
+#
+# Requires the aws cli to be installed and configured.
+
+set -e
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+job_name="$@"
+
+if [ -z "$job_name" ]
+then
+  echo "A glue job name must be specified"
+  exit 1;
+fi
+
+
+aws glue start-job-run --job-name $job_name > /dev/null
+$script_dir/tail-glue-logs $job_name

--- a/scripts/tail-glue-logs
+++ b/scripts/tail-glue-logs
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Script to tail the logs for the latest run of a given glue job.
+#
+# Uses a filter pattern to only show relevant log messages. This can be
+# extended as required.
+#
+# Usage:
+#
+#   scripts/tail-glue-logs <glue-job-name>
+
+set -e
+
+job_name="$@"
+
+if [ -z "$job_name" ]
+then
+  echo "A glue job name must be specified"
+  exit 1;
+fi
+
+run_id=$(aws glue get-job-runs --job-name $job_name --max-items 1 --output yaml | grep "Id:" | tr -d ' ' | cut -d ':' -f2)
+
+echo "Tailing logs for job: $job_name run-id: $run_id"
+
+# Default filter pattern includes messages from classes in the ...job.* and
+# ...zone.* packages. This can be extended to include other packages as work
+# progresses.
+#
+# See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
+# for further info about filter patterns.
+log_fiter_pattern="?job. ?zone."
+
+aws logs tail /aws-glue/jobs/error \
+  --follow --log-stream-name-prefix $run_id \
+  --filter-pattern "?job. ?zone." \
+  --format short


### PR DESCRIPTION
Summary of changes

Added the following scripts
 * push-jar - builds and pushes the project jar to an s3 folder uri
 * tail-glue-logs - tail the logs for a given job name
 * start-and-tail-job - starts a given job name and then tails the logs