### PR TITLE
NOJIRA - a little light refactoring

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/dynamodb/DynamoDBClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/dynamodb/DynamoDBClient.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobParameters;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
@@ -25,13 +26,12 @@ import static uk.gov.justice.digital.job.model.Columns.DATA;
 public class DynamoDBClient {
 
     private final static ObjectMapper mapper = new ObjectMapper();
+    private static final Logger logger = LoggerFactory.getLogger(DynamoDBClient.class);
 
     private final static String indexName = "secondaryId-type-index";
     private final static String sortKeyName = "secondaryId";
 
     private final AmazonDynamoDB dynamoDB;
-
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DynamoDBClient.class);
 
     @Inject
     public DynamoDBClient(JobParameters jobParameters) {

--- a/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.domain;
 
 import lombok.val;
-import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -12,7 +11,7 @@ import uk.gov.justice.digital.config.JobParameters;
 import uk.gov.justice.digital.domain.model.*;
 import uk.gov.justice.digital.domain.model.TableDefinition.TransformDefinition;
 import uk.gov.justice.digital.domain.model.TableDefinition.ViolationDefinition;
-import uk.gov.justice.digital.job.SparkSessionProvider;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DataStorageService;
 import java.util.*;
 import uk.gov.justice.digital.exception.DomainExecutorException;

--- a/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.domain;
 
+import lombok.val;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -7,33 +8,47 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.ExplainMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.config.JobParameters;
 import uk.gov.justice.digital.domain.model.*;
 import uk.gov.justice.digital.domain.model.TableDefinition.TransformDefinition;
 import uk.gov.justice.digital.domain.model.TableDefinition.ViolationDefinition;
-import uk.gov.justice.digital.job.Job;
+import uk.gov.justice.digital.job.SparkSessionProvider;
 import uk.gov.justice.digital.service.DataStorageService;
 import java.util.*;
 import uk.gov.justice.digital.exception.DomainExecutorException;
 
-public class DomainExecutor extends Job {
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class DomainExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(DomainExecutor.class);
 
     private final String sourceRootPath;
     private final String targetRootPath;
-    private final DomainDefinition domainDefinition;
     private final DataStorageService storage;
     private final SparkSession spark;
 
-    public DomainExecutor(final String sourceRootPath,
-                          final String targetRootPath,
-                          final DomainDefinition domain,
-                          final DataStorageService storage) {
+    @Inject
+    public DomainExecutor(JobParameters jobParameters,
+                          DataStorageService storage,
+                          SparkSessionProvider sparkSessionProvider
+                          ) {
+        this.sourceRootPath = jobParameters.getCuratedS3Path();
+        this.targetRootPath = jobParameters.getDomainTargetPath();
+        this.storage = storage;
+        this.spark = sparkSessionProvider.getConfiguredSparkSession();
+    }
+
+    public DomainExecutor(String sourceRootPath,
+                          String targetRootPath,
+                          DataStorageService storage,
+                          SparkSessionProvider sparkSessionProvider) {
         this.sourceRootPath = sourceRootPath;
         this.targetRootPath = targetRootPath;
-        this.domainDefinition = domain;
         this.storage = storage;
-        this.spark = getConfiguredSparkSession(new SparkConf());
+        this.spark = sparkSessionProvider.getConfiguredSparkSession();
     }
 
     public void saveFull(final TableInfo info, final Dataset<Row> dataFrame, final String domainOperation)
@@ -233,39 +248,46 @@ public class DomainExecutor extends Job {
         }
     }
 
-    public void doFull(final String domainName, final String domainTableName, final String domainOperation) {
+    public void doFull(DomainDefinition domainDefinition,
+                       String domainName,
+                       String domainTableName,
+                       String domainOperation) {
         try {
             if (domainOperation.equalsIgnoreCase("insert") ||
                     domainOperation.equalsIgnoreCase("update") ||
                     domainOperation.equalsIgnoreCase("sync")) {
-                final List<TableDefinition> tables = domainDefinition.getTables();
-                TableDefinition table = tables.stream()
+
+                val table = domainDefinition.getTables().stream()
                         .filter(t -> domainTableName.equals(t.getName()))
                         .findAny()
                         .orElse(null);
+
                 if (table == null) {
                     logger.error("Table " + domainTableName + " not found");
                     throw new DomainExecutorException("Table " + domainTableName + " not found");
                 } else {
                     // TODO no source table and df they are required only for unit testing
-                    final Dataset<Row> df_target = apply(table, null);
-                    saveFull(TableInfo.create(targetRootPath,  domainDefinition.getName(), table.getName()),
-                            df_target, domainOperation);
+                    val dfTarget = apply(table, null);
+                    saveFull(
+                        TableInfo.create(targetRootPath,  domainDefinition.getName(), table.getName()),
+                        dfTarget,
+                        domainOperation)
+                    ;
                 }
             } else if (domainOperation.equalsIgnoreCase("delete")) {
                 logger.info("domain operation is delete");
                 deleteFull(TableInfo.create(targetRootPath, domainName, domainTableName));
             } else {
-                logger.error("Unsupported domain operation");
-                throw new UnsupportedOperationException("Unsupported domain operation.");
+                val message = "Unsupported domain operation: '" + domainOperation + "'";
+                logger.error(message);
+                throw new UnsupportedOperationException(message);
             }
         } catch(Exception | DomainExecutorException e) {
-            logger.error("Domain executor failed: ", e);
+            logger.error("Domain executor failed", e);
         }
     }
 
-
-    protected boolean schemaContains(final Dataset<Row> dataFrame, final String field) {
+    private boolean schemaContains(final Dataset<Row> dataFrame, final String field) {
         return Arrays.asList(dataFrame.schema().fieldNames()).contains(field);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
@@ -5,6 +5,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.ExplainMode;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.domain.model.*;
 import uk.gov.justice.digital.domain.model.TableDefinition.TransformDefinition;
@@ -16,17 +17,13 @@ import uk.gov.justice.digital.exception.DomainExecutorException;
 
 public class DomainExecutor extends Job {
 
-    // core initialised values
-    // sourceRootPath
-    // targetRootPath
-    // domainDefinition
-    protected String sourceRootPath;
-    protected String targetRootPath;
-    protected DomainDefinition domainDefinition;
-    protected DataStorageService storage;
-    protected SparkSession spark;
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DomainExecutor.class);
+    private static final Logger logger = LoggerFactory.getLogger(DomainExecutor.class);
 
+    private final String sourceRootPath;
+    private final String targetRootPath;
+    private final DomainDefinition domainDefinition;
+    private final DataStorageService storage;
+    private final SparkSession spark;
 
     public DomainExecutor(final String sourceRootPath,
                           final String targetRootPath,

--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -31,7 +31,7 @@ import static uk.gov.justice.digital.job.model.Columns.*;
  */
 @Singleton
 @Command(name = "DataHubJob")
-public class DataHubJob extends Job implements Runnable {
+public class DataHubJob implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(DataHubJob.class);
 
@@ -40,6 +40,7 @@ public class DataHubJob extends Job implements Runnable {
     private final StructuredZone structuredZone;
     private final CuratedZone curatedZone;
     private final Converter converter;
+    private final SparkSessionProvider sparkSessionProvider;
 
     @Inject
     public DataHubJob(
@@ -47,13 +48,15 @@ public class DataHubJob extends Job implements Runnable {
         RawZone rawZone,
         StructuredZone structuredZone,
         CuratedZone curatedZone,
-        @Named("converterForDMS_3_4_6") Converter converter
+        @Named("converterForDMS_3_4_6") Converter converter,
+        SparkSessionProvider sparkSessionProvider
     ) {
         this.kinesisReader = kinesisReader;
         this.rawZone = rawZone;
         this.structuredZone = structuredZone;
         this.curatedZone = curatedZone;
         this.converter = converter;
+        this.sparkSessionProvider = sparkSessionProvider;
     }
 
     public static void main(String[] args) {
@@ -69,7 +72,7 @@ public class DataHubJob extends Job implements Runnable {
 
             val startTime = System.currentTimeMillis();
 
-            val spark = getConfiguredSparkSession(batch.context().getConf());
+            val spark = sparkSessionProvider.getConfiguredSparkSession(batch.context().getConf());
             val rowRdd = batch.map(d -> RowFactory.create(new String(d, StandardCharsets.UTF_8)));
             val dataFrame = converter.convert(rowRdd, spark);
 

--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import uk.gov.justice.digital.client.kinesis.KinesisReader;
 import uk.gov.justice.digital.converter.Converter;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.zone.CuratedZone;
 import uk.gov.justice.digital.zone.RawZone;
 import uk.gov.justice.digital.zone.StructuredZone;

--- a/src/main/java/uk/gov/justice/digital/job/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/job/SparkSessionProvider.java
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.job;
 
+import jakarta.inject.Singleton;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 
-public abstract class Job {
-    protected static SparkSession getConfiguredSparkSession(SparkConf sparkConf) {
+@Singleton
+public class SparkSessionProvider {
+
+    public SparkSession getConfiguredSparkSession(SparkConf sparkConf) {
         sparkConf
                 .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
                 .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
@@ -16,6 +19,10 @@ public abstract class Job {
         return SparkSession.builder()
                 .config(sparkConf)
                 .getOrCreate();
+    }
+
+    public SparkSession getConfiguredSparkSession() {
+        return getConfiguredSparkSession(new SparkConf());
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.job;
+package uk.gov.justice.digital.provider;
 
 import jakarta.inject.Singleton;
 import org.apache.spark.SparkConf;

--- a/src/main/java/uk/gov/justice/digital/repository/DomainRepository.java
+++ b/src/main/java/uk/gov/justice/digital/repository/DomainRepository.java
@@ -15,10 +15,9 @@ public class DomainRepository {
     private final DynamoDBClient dynamoDBClient;
 
     @Inject
-    public DomainRepository(final DynamoDBClient dynamoDBClient) {
+    public DomainRepository(DynamoDBClient dynamoDBClient) {
         this.dynamoDBClient = dynamoDBClient;
     }
-
 
     public Set<DomainDefinition> getForName(final String domainRegistry, final String domainId)
             throws PatternSyntaxException {

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -1,19 +1,20 @@
 package uk.gov.justice.digital.service;
 
 import io.delta.tables.DeltaTable;
-import io.micronaut.context.annotation.Bean;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.domain.model.TableInfo;
 
+import javax.inject.Singleton;
 
-@Bean
+@Singleton
 public class DataStorageService {
 
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DataStorageService.class);
+    private static final Logger logger = LoggerFactory.getLogger(DataStorageService.class);
 
     public boolean exists(final SparkSession spark, final TableInfo info) {
         return DeltaTable.isDeltaTable(spark, getTablePath(info.getPrefix(), info.getSchema(), info.getTable()));

--- a/src/main/java/uk/gov/justice/digital/service/DomainService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DomainService.java
@@ -1,69 +1,73 @@
 package uk.gov.justice.digital.service;
 
+import lombok.val;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.client.dynamodb.DynamoDBClient;
 import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.job.Job;
 import uk.gov.justice.digital.repository.DomainRepository;
+
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
+@Singleton
 public class DomainService extends Job {
 
-    protected String sourcePath;
-    protected String targetPath;
-    protected DomainRepository repo;
+    private final DomainRepository repo;
+    private final DomainExecutor executor;
 
     protected DataStorageService storage;
 
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DomainService.class);
+    private static final Logger logger = LoggerFactory.getLogger(DomainService.class);
 
     @Inject
-    public DomainService(final String sourcePath,
-                         final String targetPath,
-                         final DynamoDBClient dynamoDBClient,
-                         final DataStorageService storage) {
-        this.sourcePath = sourcePath;
-        this.targetPath = targetPath;
-        this.repo = new DomainRepository(dynamoDBClient);
+    public DomainService(DomainRepository repository,
+                         DataStorageService storage,
+                         DomainExecutor executor) {
+        this.repo = repository;
         this.storage = storage;
+        this.executor = executor;
     }
 
-    public void run(final String domainRegistry, final String domainTableName, final String domainName,
-                    final String domainOperation) throws PatternSyntaxException{
-        if (!domainOperation.equalsIgnoreCase("delete")) {
-            Set<DomainDefinition> domains = getDomains(domainRegistry, domainName);
-            logger.info("Located " + domains.size() + " domains for name '" + domainName + "'");
-            for(final DomainDefinition domain : domains) {
-                processDomain(domain, domain.getName(), domainTableName, domainOperation);
-            }
-        } else {
-            processDomain(null, domainName, domainTableName, domainOperation);
+    public void run(
+        String domainRegistry,
+        String domainTableName,
+        String domainName,
+        String domainOperation
+    ) throws PatternSyntaxException {
+        if (domainOperation.equalsIgnoreCase("delete")) {
+            processDomain(domainName, domainTableName, domainOperation);
         }
+        else {
+            val domains = getDomains(domainRegistry, domainName);
+            logger.info("Located " + domains.size() + " domains for name '" + domainName + "'");
+            for(DomainDefinition domain : domains) {
+                processDomain(domain.getName(), domainTableName, domainOperation);
+            }
+        }
+
     }
 
-    protected Set<DomainDefinition> getDomains(final String domainRegistry, final String domainName)
+    protected Set<DomainDefinition> getDomains(String domainRegistry, String domainName)
             throws PatternSyntaxException {
-        return this.repo.getForName(domainRegistry, domainName);
+        return repo.getForName(domainRegistry, domainName);
     }
 
-    protected void processDomain(final DomainDefinition domain, final String domainName, final String domainTableName,
-                                 final String domainOperation) {
+    protected void processDomain(
+        String domainName,
+        String domainTableName,
+        String domainOperation
+    ) {
         try {
             logger.info("processing of domain '" + domainName + "' started");
-            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, domain, storage);
             executor.doFull(domainName, domainTableName, domainOperation);
             logger.info("processing of domain '" + domainName + "' completed");
         } catch(Exception e) {
-            logger.error("processing of domain '" + domainName + "' failed");
-            handleError(e);
+            logger.error("processing of domain '" + domainName + "' failed", e);
         }
-    }
-
-    protected void handleError(final Exception e) {
-        logger.error("processing of domain failed", e);
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/zone/Zone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/Zone.java
@@ -3,18 +3,15 @@ package uk.gov.justice.digital.zone;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import java.util.List;
+
 import static org.apache.spark.sql.functions.col;
 import static uk.gov.justice.digital.job.model.Columns.*;
 
 public abstract class Zone {
 
-    private static final Logger logger = LoggerFactory.getLogger(Zone.class);
-
     public abstract Dataset<Row> process(SparkSession spark, Dataset<Row> dataFrame, Row row);
-
 
     // These rows are used to select only those records corresponding to a specific source and table that has loads
     // events in the batch being processed.

--- a/src/test/java/uk/gov/justice/digital/config/BaseSparkTest.java
+++ b/src/test/java/uk/gov/justice/digital/config/BaseSparkTest.java
@@ -1,19 +1,10 @@
 package uk.gov.justice.digital.config;
 
 
-import org.apache.commons.io.FileUtils;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class BaseSparkTest {
 
@@ -34,44 +25,14 @@ public class BaseSparkTest {
 	}
 
 	@BeforeAll
-	public static void getOrCreateSparkSession() {
+	public static void createSession() {
 		spark = createSparkSession();
 		Assertions.assertNotNull(spark);
     }
 
-
 	@AfterAll
-	public static void stopSparkSession() {
+	public static void stopSession() {
 		spark.stop();
-	}
-
-	protected Dataset<Row> loadParquetDataframe(final String resource, final String filename) throws IOException {
-		return createSparkSession().read().parquet(createFileFromResource(resource, filename).toString());
-	}
-
-	protected Path createFileFromResource(final String resource, final String filename) throws IOException {
-		final InputStream stream = getStream(resource);
-		final File f = Paths.get(filename).toFile();
-		FileUtils.copyInputStreamToFile(stream, f);
-		return Paths.get(f.getAbsolutePath());
-	}
-
-	protected static InputStream getStream(final String resource) {
-		InputStream stream = System.class.getResourceAsStream(resource);
-		if(stream == null) {
-			stream = System.class.getResourceAsStream("/src/test/resources" + resource);
-			if(stream == null) {
-				stream = System.class.getResourceAsStream("/target/test-classes" + resource);
-				if(stream == null) {
-					Path root = Paths.get(".").normalize().toAbsolutePath();
-					stream = System.class.getResourceAsStream(root + "/src/test/resources" + resource);
-					if(stream == null) {
-						stream = BaseSparkTest.class.getResourceAsStream(resource);
-					}
-				}
-			}
-		}
-		return stream;
 	}
 
 }

--- a/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.domain.model.TableDefinition;
 import uk.gov.justice.digital.domain.model.TableInfo;
 import uk.gov.justice.digital.domain.model.TableTuple;
 import uk.gov.justice.digital.exception.DomainExecutorException;
-import uk.gov.justice.digital.job.SparkSessionProvider;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.service.SparkTestHelpers;
 

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.DomainExecutorTest;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableInfo;
-import uk.gov.justice.digital.job.SparkSessionProvider;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.DomainExecutorTest;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableInfo;
+import uk.gov.justice.digital.job.SparkSessionProvider;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,23 +29,10 @@ public class DomainServiceTest extends BaseSparkTest {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private final SparkTestHelpers utils = new SparkTestHelpers(spark);
+    private static final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
 
     @TempDir
     private Path folder;
-
-
-//    @Test
-//    public void getString_MatchesValuePassedToDomainRefreshService() {
-//        final String sourcePath = this.folder.toFile().getAbsolutePath()  + "domain/source";
-//        final String targetPath = this.folder.toFile().getAbsolutePath()  + "domain/target";
-//        String expectedResult = this.folder.toFile().getAbsolutePath()  + "domain/source";
-//        final DataStorageService storage = new DataStorageService();
-//
-//        DomainService service = new DomainService(sourcePath, targetPath, null, storage);
-//        String result = service.sourcePath;
-//        assertEquals(expectedResult, result);
-//    }
-
 
     @Test
     public void test_incident_domain() throws IOException {
@@ -63,8 +51,8 @@ public class DomainServiceTest extends BaseSparkTest {
 
         try {
             logger.info("DomainRefresh::process('" + domain.getName() + "') started");
-            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, domain, storage);
-            executor.doFull(domain.getName(), domainTableName, domainOperation);
+            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, storage, sparkSessionProvider);
+            executor.doFull(domain, domain.getName(), domainTableName, domainOperation);
             File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
             if (emptyCheck.isDirectory()) {
                 logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
@@ -96,8 +84,8 @@ public class DomainServiceTest extends BaseSparkTest {
 
         try {
             logger.info("Domain Refresh process '" + domain.getName() + "' started");
-            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, domain, storage);
-            executor.doFull(domain.getName(), domainTableName, domainOperation);
+            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, storage, sparkSessionProvider);
+            executor.doFull(domain, domain.getName(), domainTableName, domainOperation);
             File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
             if (emptyCheck.isDirectory()) {
                 logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
@@ -129,8 +117,8 @@ public class DomainServiceTest extends BaseSparkTest {
 
         try {
             logger.info("DomainRefresh::process('" + domain.getName() + "') started");
-            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, domain, storage);
-            executor.doFull(domain.getName(), domainTableName, domainOperation);
+            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, storage, sparkSessionProvider);
+            executor.doFull(domain, domain.getName(), domainTableName, domainOperation);
             File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
             if (emptyCheck.isDirectory()) {
                 logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
@@ -162,8 +150,8 @@ public class DomainServiceTest extends BaseSparkTest {
 
         try {
             logger.info("DomainRefresh::process('" + domain.getName() + "') update started");
-            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, domain, storage);
-            executor.doFull(domain.getName(), domainTableName, domainOperation);
+            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, storage, sparkSessionProvider);
+            executor.doFull(domain, domain.getName(), domainTableName, domainOperation);
             File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
             if (emptyCheck.isDirectory()) {
                 logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
@@ -195,8 +183,8 @@ public class DomainServiceTest extends BaseSparkTest {
 
         try {
             logger.info("DomainRefresh::process('" + domain.getName() + "') delete started");
-            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, domain, storage);
-            executor.doFull(domain.getName(), domainTableName, domainOperation);
+            final DomainExecutor executor = new DomainExecutor(sourcePath, targetPath, storage, sparkSessionProvider);
+            executor.doFull(domain, domain.getName(), domainTableName, domainOperation);
             File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
             if (emptyCheck.isDirectory()) {
                 logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -1,68 +1,49 @@
 package uk.gov.justice.digital.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.ResourceLoader;
 import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.DomainExecutorTest;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableInfo;
-import uk.gov.justice.digital.exception.DomainExecutorException;
+
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Objects;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DomainRefreshServiceTest {
+public class DomainServiceTest extends BaseSparkTest {
 
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DomainRefreshServiceTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(DomainServiceTest.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-
-    private static TestUtil utils = null;
+    private final SparkTestHelpers utils = new SparkTestHelpers(spark);
 
     @TempDir
     private Path folder;
 
 
-    @BeforeAll
-    public static void setUp() {
-        logger.info("setup method");
-        //instantiate and populate the dependencies
-        utils = new TestUtil();
-    }
-
-    @Test
-    public void test_tempFolder() {
-        assertNotNull(this.folder);
-    }
-
-    protected DomainDefinition getDomain(final String resource) throws IOException {
-        final ObjectMapper mapper = new ObjectMapper();
-        final String json = ResourceLoader.getResource(DomainExecutorTest.class, resource);
-        return mapper.readValue(json, DomainDefinition.class);
-    }
-
-
-    @Test
-    public void getString_MatchesValuePassedToDomainRefreshService() {
-        final String sourcePath = this.folder.toFile().getAbsolutePath()  + "domain/source";
-        final String targetPath = this.folder.toFile().getAbsolutePath()  + "domain/target";
-        String expectedResult = this.folder.toFile().getAbsolutePath()  + "domain/source";
-        final DataStorageService storage = new DataStorageService();
-
-        DomainService service = new DomainService(sourcePath, targetPath, null, storage);
-        String result = service.sourcePath;
-        assertEquals(expectedResult, result);
-    }
+//    @Test
+//    public void getString_MatchesValuePassedToDomainRefreshService() {
+//        final String sourcePath = this.folder.toFile().getAbsolutePath()  + "domain/source";
+//        final String targetPath = this.folder.toFile().getAbsolutePath()  + "domain/target";
+//        String expectedResult = this.folder.toFile().getAbsolutePath()  + "domain/source";
+//        final DataStorageService storage = new DataStorageService();
+//
+//        DomainService service = new DomainService(sourcePath, targetPath, null, storage);
+//        String result = service.sourcePath;
+//        assertEquals(expectedResult, result);
+//    }
 
 
     @Test
@@ -228,19 +209,9 @@ public class DomainRefreshServiceTest {
         }
     }
 
-
-    @Test
-    public void test_handle_error() {
-        try {
-            throw new DomainExecutorException("test message");
-        } catch (DomainExecutorException e){
-            final StringWriter sw = new StringWriter();
-            final PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            System.err.print(sw.getBuffer().toString());
-            assertTrue(true);
-        } finally {
-            logger.info("Test Completed");
-        }
+    private DomainDefinition getDomain(final String resource) throws IOException {
+        val json = ResourceLoader.getResource(DomainExecutorTest.class, resource);
+        return mapper.readValue(json, DomainDefinition.class);
     }
+
 }

--- a/src/test/java/uk/gov/justice/digital/service/SparkTestHelpers.java
+++ b/src/test/java/uk/gov/justice/digital/service/SparkTestHelpers.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.service;
 
+import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
@@ -101,31 +102,10 @@ public class SparkTestHelpers {
         return spark.read().parquet(createFileFromResource(resource, filename).toString());
     }
 
-    // TODO - simpliy this?
     private Path createFileFromResource(final String resource, final String filename) throws IOException {
-        final InputStream stream = getStream(resource);
-        final File f = Paths.get(filename).toFile();
-        FileUtils.copyInputStreamToFile(stream, f);
+        val f = Paths.get(filename).toFile();
+        FileUtils.copyInputStreamToFile(System.class.getResourceAsStream(resource), f);
         return Paths.get(f.getAbsolutePath());
     }
-
-    protected static InputStream getStream(final String resource) {
-        InputStream stream = System.class.getResourceAsStream(resource);
-        if(stream == null) {
-            stream = System.class.getResourceAsStream("/src/test/resources" + resource);
-            if(stream == null) {
-                stream = System.class.getResourceAsStream("/target/test-classes" + resource);
-                if(stream == null) {
-                    Path root = Paths.get(".").normalize().toAbsolutePath();
-                    stream = System.class.getResourceAsStream(root + "/src/test/resources" + resource);
-                    if(stream == null) {
-                        stream = BaseSparkTest.class.getResourceAsStream(resource);
-                    }
-                }
-            }
-        }
-        return stream;
-    }
-
 
 }


### PR DESCRIPTION
Addresses some of the issues raised in the recent PR that was merged covering
* Job has now become `SparkSessionProvider` which is a singleton that can be wired in by micronaut DI where used
* Other classes that needed to use micronaut DI have been revised so that it's now used to instantiate/wire in dependencies where applicable which necessitated some API changes
* Other minor changes e.g. logging, removing println etc..

Note - this PR introduces some TODOs that can be addressed later since there's some scope for further improvements but this can be addressed later. 