### PR TITLE
DPR-408 build now depends on shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,3 +99,7 @@ test {
     }
     maxParallelForks = Runtime.runtime.availableProcessors()
 }
+
+assemble {
+  dependsOn shadowJar
+}


### PR DESCRIPTION
This change ensures that shadowJar will get triggered when `build` is run in order to create the 'fat' jar with all required dependencies bundled. 