### PR TITLE
DPR-408 enable gradle caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
Summary of changes
* enable gradle caching
* enable gradle parallelism for add gradle tasks (previously was test only)

Note
* gradle caching will cache the result of successful operations so they're only run once
* for example running the tests twice, the second attempt will complete immediately because the first run passed
* if you need to force a task to run for whatever reason just add the `--rerun-tasks` option to your gradle command