### PR TITLE
DPR-422 address remaining code quality issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
     junitVersion = '5.8.1'
     log4jVersion = '2.20.0'
     micronautVersion = '3.8.7'
+    mockitoVersion = '4.11.0'
     sparkVersion = '3.3.0'
 }
 
@@ -67,10 +68,9 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "org.apache.spark:spark-sql_2.12:$sparkVersion"
-    // We are targetting Java 8 so must use mockito 4.x since 5.x requires Java 11 or later.
-    testImplementation 'org.mockito:mockito-core:4.11.0'
-    testImplementation "io.mockk:mockk:1.13.5"
-
+    // We are targeting Java 8 so must use mockito 4.x since 5.x requires Java 11 or later.
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }

--- a/src/main/java/uk/gov/justice/digital/client/ClientProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/ClientProvider.java
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.client;
+
+public interface ClientProvider<T> {
+    T getClient();
+}

--- a/src/main/java/uk/gov/justice/digital/client/glue/GlueClientProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/GlueClientProvider.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.client.glue;
+
+import com.amazonaws.services.glue.AWSGlue;
+import jakarta.inject.Singleton;
+import uk.gov.justice.digital.client.ClientProvider;
+
+@Singleton
+public class GlueClientProvider implements ClientProvider<AWSGlue> {
+
+    @Override
+    public AWSGlue getClient() {
+        return null;
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/client/glue/GlueClientProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/GlueClientProvider.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.client.glue;
 
 import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.AWSGlueClientBuilder;
 import jakarta.inject.Singleton;
 import uk.gov.justice.digital.client.ClientProvider;
 
@@ -9,7 +10,7 @@ public class GlueClientProvider implements ClientProvider<AWSGlue> {
 
     @Override
     public AWSGlue getClient() {
-        return null;
+        return AWSGlueClientBuilder.defaultClient();
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/client/glue/JobClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/JobClient.java
@@ -28,10 +28,4 @@ public class JobClient {
         return result.getJob().getDefaultArguments();
     }
 
-    // TODO - remove this
-    @Deprecated
-    public AWSGlue getGlueClient() {
-        return glueClient;
-    }
-
 }

--- a/src/main/java/uk/gov/justice/digital/client/glue/JobClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/JobClient.java
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.client.glue;
 
 import com.amazonaws.services.glue.AWSGlue;
-import com.amazonaws.services.glue.AWSGlueClientBuilder;
 import com.amazonaws.services.glue.model.GetJobRequest;
 import com.amazonaws.services.glue.model.GetJobResult;
-import uk.gov.justice.digital.config.Properties;
+import uk.gov.justice.digital.config.JobProperties;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -17,18 +16,10 @@ public class JobClient {
     private final String jobName;
 
     @Inject
-    public JobClient(GlueClientProvider glueClientProvider) {
-        this(glueClientProvider.getClient());
-    }
-
-    @Deprecated
-    public JobClient() {
-        this(AWSGlueClientBuilder.defaultClient());
-    }
-
-    private JobClient(AWSGlue client) {
-        glueClient = client;
-        jobName = Properties.getSparkJobName();
+    public JobClient(GlueClientProvider glueClientProvider,
+                     JobProperties jobProperties) {
+        this.jobName = jobProperties.getSparkJobName();
+        this.glueClient = glueClientProvider.getClient();
     }
 
     public Map<String, String> getJobParameters() {
@@ -37,6 +28,7 @@ public class JobClient {
         return result.getJob().getDefaultArguments();
     }
 
+    // TODO - remove this
     @Deprecated
     public AWSGlue getGlueClient() {
         return glueClient;

--- a/src/main/java/uk/gov/justice/digital/client/glue/JobClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/JobClient.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.glue.model.GetJobRequest;
 import com.amazonaws.services.glue.model.GetJobResult;
 import uk.gov.justice.digital.config.Properties;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Map;
 
@@ -15,6 +16,12 @@ public class JobClient {
     private final AWSGlue glueClient;
     private final String jobName;
 
+    @Inject
+    public JobClient(GlueClientProvider glueClientProvider) {
+        this(glueClientProvider.getClient());
+    }
+
+    @Deprecated
     public JobClient() {
         this(AWSGlueClientBuilder.defaultClient());
     }
@@ -30,6 +37,7 @@ public class JobClient {
         return result.getJob().getDefaultArguments();
     }
 
+    @Deprecated
     public AWSGlue getGlueClient() {
         return glueClient;
     }

--- a/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisReader.java
+++ b/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisReader.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.reflect.ClassTag$;
 import uk.gov.justice.digital.config.JobParameters;
-import uk.gov.justice.digital.config.Properties;
+import uk.gov.justice.digital.config.JobProperties;
 
 @Bean
 public class KinesisReader {
@@ -24,8 +24,9 @@ public class KinesisReader {
     private final JavaDStream<byte[]> kinesisStream;
 
     @Inject
-    public KinesisReader(JobParameters jobParameters) {
-        String jobName = Properties.getSparkJobName();
+    public KinesisReader(JobParameters jobParameters,
+                         JobProperties jobProperties) {
+        String jobName = jobProperties.getSparkJobName();
 
         streamingContext = new JavaStreamingContext(
             new SparkConf().setAppName(jobName),

--- a/src/main/java/uk/gov/justice/digital/config/JobProperties.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobProperties.java
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.config;
 
+import javax.inject.Singleton;
 import java.util.Optional;
 
-public class Properties {
+@Singleton
+public class JobProperties {
 
     private static final String SPARK_JOB_NAME_PROPERTY = "spark.glue.JOB_NAME";
 
-    public static String getSparkJobName() {
+    public String getSparkJobName() {
         return Optional
             .ofNullable(System.getProperty(SPARK_JOB_NAME_PROPERTY))
             .orElseThrow(() -> new IllegalStateException("Property " + SPARK_JOB_NAME_PROPERTY + " not set"));

--- a/src/main/java/uk/gov/justice/digital/config/Properties.java
+++ b/src/main/java/uk/gov/justice/digital/config/Properties.java
@@ -12,4 +12,5 @@ public class Properties {
             .orElseThrow(() -> new IllegalStateException("Property " + SPARK_JOB_NAME_PROPERTY + " not set"));
     }
 
+
 }

--- a/src/main/java/uk/gov/justice/digital/domain/model/TableInfo.java
+++ b/src/main/java/uk/gov/justice/digital/domain/model/TableInfo.java
@@ -2,13 +2,15 @@ package uk.gov.justice.digital.domain.model;
 
 import lombok.Data;
 
+// TODO - review name
 @Data
 public class TableInfo {
-    protected String prefix;
-    protected String schema;
-    protected String table;
-    protected String database;
+    private final String prefix;
+    private final String schema;
+    private final String table;
+    private final String database;
 
+    // TODO - remove this - @Data provides this
     protected TableInfo(final String prefix, final String database, final String schema, final String table) {
         this.prefix = prefix;
         this.database = database;
@@ -16,7 +18,7 @@ public class TableInfo {
         this.table = table;
     }
 
-
+    // TODO - remove this - not necessary
     public static TableInfo create(final String prefix, final String database, final String schema, final String table) {
         return new TableInfo(prefix, database, schema, table);
     }

--- a/src/main/java/uk/gov/justice/digital/service/DomainSchemaService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DomainSchemaService.java
@@ -2,62 +2,55 @@ package uk.gov.justice.digital.service;
 
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.*;
+import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.client.glue.JobClient;
+import uk.gov.justice.digital.client.glue.GlueClientProvider;
 import uk.gov.justice.digital.domain.model.TableInfo;
 import uk.gov.justice.digital.exception.DomainSchemaException;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
+// TODO - this should not use the glueClient directly
 @Singleton
 public class DomainSchemaService {
 
-    protected final AWSGlue glueClient;
+    private static final Logger logger = LoggerFactory.getLogger(DomainSchemaService.class);
 
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DomainSchemaService.class);
+    private final AWSGlue glueClient;
 
     @Inject
-    public DomainSchemaService(JobClient jobClient) {
-        // TODO - fix this
-        this(jobClient.getGlueClient());
+    public DomainSchemaService(GlueClientProvider glueClientProvider) {
+        this.glueClient = glueClientProvider.getClient();
     }
-
-    protected DomainSchemaService(AWSGlue client) {
-        this.glueClient = client;
-    }
-
 
     public boolean databaseExists(String databaseName) {
         GetDatabaseRequest request = new GetDatabaseRequest().withName(databaseName);
+        GetDatabaseResult result = glueClient.getDatabase(request);
 
-        try {
-            GetDatabaseResult result = glueClient.getDatabase(request);
-            Database db = result.getDatabase();
-            if (db != null && db.getName().equals(databaseName)) {
-                logger.info("Hive Catalog Database '" + databaseName + "' found");
-                return Boolean.TRUE;
-            }
-        } catch (Exception e) {
-            logger.error("Hive Catalog Database check failed :" + e.getMessage());
-            return Boolean.FALSE;
-        }
-        return Boolean.FALSE;
+        return Optional.ofNullable(result.getDatabase())
+            .map(Database::getName)
+            .filter(n -> n.equals(databaseName))
+            .isPresent();
     }
 
+    // TODO - is the entire method only needed for testing or some condition within it?
     // This is needed only for unit testing
-    public void create(final TableInfo info, final String path, final Dataset<Row> dataFrame)
-            throws DomainSchemaException {
-        if (this.databaseExists(info.getDatabase())) {
+    public void create(TableInfo info, String path, Dataset<Row> dataFrame) throws DomainSchemaException {
+        if (databaseExists(info.getDatabase())) {
             logger.info("Hive Schema insert started for " + info.getDatabase());
-            if (!this.tableExists(info.getDatabase(),
+            if (!tableExists(info.getDatabase(),
                     info.getSchema() + "." + info.getTable())) {
-                this.createTable(info.getDatabase(),
+                createTable(info.getDatabase(),
                         info.getSchema() + "." + info.getTable(), path, dataFrame);
                 logger.info("Creating hive schema completed:" + info.getSchema() + "." + info.getTable());
             } else {
@@ -68,13 +61,12 @@ public class DomainSchemaService {
         }
     }
 
-    public void replace(final TableInfo info, final String path, final Dataset<Row> dataFrame)
-            throws DomainSchemaException {
-        if (this.databaseExists(info.getDatabase())) {
+    public void replace(TableInfo info, String path, Dataset<Row> dataFrame) throws DomainSchemaException {
+        if (databaseExists(info.getDatabase())) {
             logger.info("Hive Schema insert started for " + info.getDatabase());
-            if (this.tableExists(info.getDatabase(),
+            if (tableExists(info.getDatabase(),
                     info.getSchema() + "." + info.getTable())) {
-                this.updateTable(info.getDatabase(),
+                updateTable(info.getDatabase(),
                         info.getSchema() + "." + info.getTable(), path, dataFrame);
                 logger.info("Replacing Hive Schema completed " + info.getSchema() + "." + info.getTable());
             } else {
@@ -85,11 +77,11 @@ public class DomainSchemaService {
         }
     }
 
-    public void drop(final TableInfo info) throws DomainSchemaException {
-        if (this.databaseExists(info.getDatabase())) {
-            if (this.tableExists(info.getDatabase(),
+    public void drop(TableInfo info) throws DomainSchemaException {
+        if (databaseExists(info.getDatabase())) {
+            if (tableExists(info.getDatabase(),
                     info.getSchema() + "." + info.getTable())) {
-                this.deleteTable(info.getDatabase(), info.getSchema() + "." + info.getTable());
+                deleteTable(info.getDatabase(), info.getSchema() + "." + info.getTable());
                 logger.info("Dropping Hive Schema completed " +  info.getSchema() + "." + info.getTable());
             } else {
                 throw new DomainSchemaException("Glue catalog table '" + info.getTable() + "' doesn't exist");
@@ -113,15 +105,13 @@ public class DomainSchemaService {
         }
     }
 
-    protected void updateTable(final String databaseName, final String tableName, final String path,
-                               final Dataset<Row> dataframe) {
-        // First delete the table
+    public void updateTable(String databaseName, String tableName, String path, Dataset<Row> dataframe) {
+        // TODO - what if create fails? do we have transactional semantics here?
         deleteTable(databaseName, tableName);
-        // then recreate
         createTable(databaseName, tableName, path, dataframe);
     }
 
-    protected void deleteTable(final String databaseName, final String tableName) {
+    public void deleteTable(final String databaseName, final String tableName) {
         DeleteTableRequest deleteTableRequest = new DeleteTableRequest()
                 .withDatabaseName(databaseName)
                 .withName(tableName);
@@ -132,7 +122,6 @@ public class DomainSchemaService {
         }
     }
 
-    @SuppressWarnings("serial")
     public void createTable(final String databaseName, final String tableName, final String path,
                             final Dataset<Row> dataframe) {
         // Create a CreateTableRequest
@@ -140,25 +129,24 @@ public class DomainSchemaService {
                 .withDatabaseName(databaseName)
                 .withTableInput(new TableInput()
                         .withName(tableName)
-                        .withParameters(new java.util.HashMap<String, String>())
                         .withTableType("EXTERNAL_TABLE")
                         .withParameters(Collections.singletonMap("classification", "parquet"))
-                        .withStorageDescriptor(new StorageDescriptor()
-                                .withColumns(getColumns(dataframe.schema()))
+                        .withStorageDescriptor(
+                            new StorageDescriptor()
+                                .withColumns(getColumnsAndModifyTypes(dataframe.schema()))
                                 .withLocation(path + "/_symlink_format_manifest")
                                 .withInputFormat("org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat")
                                 .withOutputFormat("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat")
-                                .withSerdeInfo(new SerDeInfo()
+                                .withSerdeInfo(
+                                    new SerDeInfo()
                                         .withSerializationLibrary("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
-                                        .withParameters(new java.util.HashMap<String, String>() {{
-                                            put("serialization.format", ",");
-                                        }}))
+                                        .withParameters(Collections.singletonMap("serialization.format", ","))
+                                )
                                 .withCompressed(false)
                                 .withNumberOfBuckets(0)
                                 .withStoredAsSubDirectories(false)
                         )
                 );
-
 
         // Create the table in the AWS Glue Data Catalog
         try {
@@ -169,15 +157,14 @@ public class DomainSchemaService {
         }
     }
 
-    private static java.util.List<Column> getColumns(StructType schema) {
-        java.util.List<Column> columns = new java.util.ArrayList<Column>();
+    private List<Column> getColumnsAndModifyTypes(StructType schema) {
+        val columns = new ArrayList<Column>();
         for (StructField field : schema.fields()) {
-            Column col = new Column()
+            val col = new Column()
                     .withName(field.name())
-                    .withType(field.dataType().typeName())
-                    .withComment("");
-            // Null type not supported in AWS Glue Catalog
-            // numerical types mapping should be explicit and not automatically picks
+                    .withType(field.dataType().typeName());
+            // Null type not supported in AWS Glue Catalog.
+            // Numerical type mappings should be explicit and not automatically selected.
             if (col.getType().equals("long")) {
                 col.setType("bigint");
             } else if (col.getType().equals("short")) {

--- a/src/main/java/uk/gov/justice/digital/service/DomainSchemaService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DomainSchemaService.java
@@ -18,14 +18,13 @@ import java.util.Collections;
 @Singleton
 public class DomainSchemaService {
 
-    private static final long serialVersionUID = 1L;
-
     protected final AWSGlue glueClient;
 
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DomainSchemaService.class);
 
     @Inject
     public DomainSchemaService(JobClient jobClient) {
+        // TODO - fix this
         this(jobClient.getGlueClient());
     }
 

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,6 +1,6 @@
 # Configuration for local development.
 #
-# AWS Glue provides its own log4j properties so this configuration will not be
+# AWS Glue provides its own log4j jobProperties so this configuration will not be
 # used by our glue jobs when run on AWS.
 
 status = info

--- a/src/test/java/uk/gov/justice/digital/client/glue/JobClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/glue/JobClientTest.java
@@ -5,36 +5,39 @@ import com.amazonaws.services.glue.model.GetJobRequest;
 import com.amazonaws.services.glue.model.GetJobResult;
 import com.amazonaws.services.glue.model.Job;
 import io.micronaut.test.annotation.MockBean;
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import lombok.val;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.JobProperties;
 
-import javax.inject.Inject;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-@MicronautTest
+@ExtendWith(MockitoExtension.class)
 class JobClientTest {
 
     private static final String SPARK_JOB_NAME = "SomeTestJob";
 
-    private static final AWSGlue mockClient = mock(AWSGlue.class);
-    private static final GlueClientProvider mockClientProvider = mock(GlueClientProvider.class);
-    private static final JobProperties mockJobProperties = mock(JobProperties.class);
+    @Mock
+    private AWSGlue mockClient = mock(AWSGlue.class);
+    @Mock
+    private GlueClientProvider mockClientProvider = mock(GlueClientProvider.class);
+    @Mock
+    private JobProperties mockJobProperties = mock(JobProperties.class);
 
-    @Inject
-    public JobClient underTest;
+    private JobClient underTest;
 
-    @BeforeAll
-    public static void setupMocks() {
+    @BeforeEach
+    public void setupMocks() {
         when(mockClientProvider.getClient()).thenReturn(mockClient);
         when(mockJobProperties.getSparkJobName()).thenReturn(SPARK_JOB_NAME);
+        underTest = new JobClient(mockClientProvider, mockJobProperties);
     }
 
     @Test
@@ -48,6 +51,8 @@ class JobClientTest {
         val result = underTest.getJobParameters();
 
         assertEquals(fakeJobParameters, result);
+
+        verify(mockClient, times(1)).getJob(eq(expectedRequest));
     }
 
     @MockBean(GlueClientProvider.class)

--- a/src/test/java/uk/gov/justice/digital/client/glue/JobClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/glue/JobClientTest.java
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.client.glue;
+
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.GetJobRequest;
+import com.amazonaws.services.glue.model.GetJobResult;
+import com.amazonaws.services.glue.model.Job;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import lombok.val;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+class JobClientTest {
+
+    private static final AWSGlue mockClient = mock(AWSGlue.class);
+
+    // TODO - verify that this is safe
+    private static final String SPARK_JOB_NAME_KEY = "spark.glue.JOB_NAME";
+    private static final String SPARK_JOB_NAME = "SomeTestJob";
+
+    @Inject
+    public JobClient underTest;
+
+    private static final GlueClientProvider mockClientProvider = mock(GlueClientProvider.class);
+
+    @BeforeAll
+    public static void setup() {
+        System.setProperty(SPARK_JOB_NAME_KEY, SPARK_JOB_NAME);
+        when(mockClientProvider.getClient()).thenReturn(mockClient);
+    }
+
+    @AfterAll
+    public static void clearProperties() {
+        System.clearProperty(SPARK_JOB_NAME_KEY);
+    }
+
+    @Test
+    public void getJobParametersShouldReturnParametersConfiguredForJob() {
+        val expectedRequest = new GetJobRequest().withJobName(SPARK_JOB_NAME);
+        val fakeJobParameters = Collections.singletonMap("foo", "bar");
+        val fakeJobResult = new GetJobResult().withJob(new Job().withDefaultArguments(fakeJobParameters));
+
+        when(mockClient.getJob(eq(expectedRequest))).thenReturn(fakeJobResult);
+
+        val result = underTest.getJobParameters();
+
+        assertEquals(fakeJobParameters, result);
+    }
+
+    @MockBean(GlueClientProvider.class)
+    public GlueClientProvider glueClientProvider() {
+        return mockClientProvider;
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/client/glue/JobClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/glue/JobClientTest.java
@@ -7,9 +7,9 @@ import com.amazonaws.services.glue.model.Job;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import lombok.val;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import uk.gov.justice.digital.config.JobProperties;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -22,26 +22,19 @@ import static org.mockito.Mockito.when;
 @MicronautTest
 class JobClientTest {
 
-    private static final AWSGlue mockClient = mock(AWSGlue.class);
-
-    // TODO - verify that this is safe
-    private static final String SPARK_JOB_NAME_KEY = "spark.glue.JOB_NAME";
     private static final String SPARK_JOB_NAME = "SomeTestJob";
+
+    private static final AWSGlue mockClient = mock(AWSGlue.class);
+    private static final GlueClientProvider mockClientProvider = mock(GlueClientProvider.class);
+    private static final JobProperties mockJobProperties = mock(JobProperties.class);
 
     @Inject
     public JobClient underTest;
 
-    private static final GlueClientProvider mockClientProvider = mock(GlueClientProvider.class);
-
     @BeforeAll
-    public static void setup() {
-        System.setProperty(SPARK_JOB_NAME_KEY, SPARK_JOB_NAME);
+    public static void setupMocks() {
         when(mockClientProvider.getClient()).thenReturn(mockClient);
-    }
-
-    @AfterAll
-    public static void clearProperties() {
-        System.clearProperty(SPARK_JOB_NAME_KEY);
+        when(mockJobProperties.getSparkJobName()).thenReturn(SPARK_JOB_NAME);
     }
 
     @Test
@@ -60,6 +53,11 @@ class JobClientTest {
     @MockBean(GlueClientProvider.class)
     public GlueClientProvider glueClientProvider() {
         return mockClientProvider;
+    }
+
+    @MockBean(JobProperties.class)
+    public JobProperties jobProperties() {
+        return mockJobProperties;
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/config/JobPropertiesTest.java
+++ b/src/test/java/uk/gov/justice/digital/config/JobPropertiesTest.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class PropertiesTest {
+class JobPropertiesTest {
 
     private static final String SPARK_JOB_NAME_KEY = "spark.glue.JOB_NAME";
     private static final String SPARK_JOB_NAME = "SomeTestJob";
+
+    private static final JobProperties underTest = new JobProperties();
 
     @BeforeEach
     public void setupProperties() {
@@ -23,12 +25,12 @@ class PropertiesTest {
 
     @Test
     public void shouldReturnJobNameWhenPropertySet() {
-       assertEquals(SPARK_JOB_NAME, Properties.getSparkJobName());
+       assertEquals(SPARK_JOB_NAME, underTest.getSparkJobName());
     }
 
     @Test
     public void shouldThrowExceptionWhenJobNamePropertyNotSet() {
         System.clearProperty(SPARK_JOB_NAME_KEY);
-        assertThrows(IllegalStateException.class, Properties::getSparkJobName);
+        assertThrows(IllegalStateException.class, underTest::getSparkJobName);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/config/ResourceLoader.java
+++ b/src/test/java/uk/gov/justice/digital/config/ResourceLoader.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 
 import org.apache.commons.io.IOUtils;
 
+// TODO - review usage of this code
 public class ResourceLoader {
 	
 	@SuppressWarnings("deprecation")
@@ -23,7 +24,7 @@ public class ResourceLoader {
 				stream = System.class.getResourceAsStream("/target/test-classes" + resource);
 				if(stream == null) {
 					Path root = Paths.get(".").normalize().toAbsolutePath();
-					stream = System.class.getResourceAsStream(root.toString() + "/src/test/resources" + resource);
+					stream = System.class.getResourceAsStream(root + "/src/test/resources" + resource);
 					if(stream == null) {
 						stream = clazz.getResourceAsStream(resource);
 					}

--- a/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.domain;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
@@ -22,11 +21,12 @@ import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.service.DomainSchemaService;
 import uk.gov.justice.digital.service.SparkTestHelpers;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
-import org.mockito.Mock;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -36,30 +36,15 @@ public class DomainExecutorTest extends BaseSparkTest {
     private static final SparkTestHelpers helpers = new SparkTestHelpers(spark);
     private static final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
     private static final String hiveDatabaseName = "test_db";
-    @Mock
-    private static DomainSchemaService schemaService = mock(DomainSchemaService.class);
 
+    private static final DomainSchemaService schemaService = mock(DomainSchemaService.class);
 
     @TempDir
     private Path folder;
 
     @BeforeAll
-    public static void setUp() {
-        //instantiate and populate the dependencies
+    public static void setupCommonMocks() {
         when(schemaService.databaseExists(any())).thenReturn(true);
-    }
-
-    @AfterAll
-    public static void tearDown() {
-    }
-
-    @Test
-    public void test_tempFolder() {
-        assertNotNull(this.folder);
-    }
-
-    private DomainExecutor createExecutor(final String source, final String target, final DataStorageService storage) {
-        return new DomainExecutor(source, target, storage, schemaService, hiveDatabaseName, sparkSessionProvider);
     }
 
     @Test
@@ -465,7 +450,7 @@ public class DomainExecutorTest extends BaseSparkTest {
                 "young")));
     }
 
-    protected Dataset<Row> doTransform(final DomainExecutor executor, final Dataset<Row> df,
+    private Dataset<Row> doTransform(final DomainExecutor executor, final Dataset<Row> df,
                                        final TableDefinition.TransformDefinition transform, final String source) {
         try {
             Map<String, Dataset<Row>> inputs = new HashMap<>();
@@ -499,5 +484,10 @@ public class DomainExecutorTest extends BaseSparkTest {
 
         return CollectionUtils.subtract(al, bl).size() == 0;
     }
+
+    private DomainExecutor createExecutor(String source, String target, DataStorageService storage) {
+        return new DomainExecutor(source, target, storage, schemaService, hiveDatabaseName, sparkSessionProvider);
+    }
+
 
 }

--- a/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
@@ -73,12 +73,12 @@ public class DomainExecutorTest extends BaseSparkTest {
         List<TableDefinition> tables = domainDefinition.getTables();
 
         final Dataset<Row> df_offender_bookings = helpers.getOffenderBookings(folder);
-        helpers.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName,
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName,
                         "nomis", "offender_bookings"),
                 df_offender_bookings);
 
         final Dataset<Row> df_offenders = helpers.getOffenders(folder);
-        helpers.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName,
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName,
                 "nomis", "offenders"),
                 df_offenders);
 
@@ -271,7 +271,7 @@ public class DomainExecutorTest extends BaseSparkTest {
         final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
         // save a source
         final Dataset<Row> df_offenders = helpers.getOffenders(folder);
-        helpers.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName,
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName,
                 "source", "table"), df_offenders);
         final String domainTableName = "prisoner";
         // Insert first
@@ -301,10 +301,10 @@ public class DomainExecutorTest extends BaseSparkTest {
         final DomainDefinition domain2 = getDomain("/sample/domain/sample-domain-execution-join.json");
         // save a source
         final Dataset<Row> df_offenders = helpers.getOffenders(folder);
-        helpers.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName,
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName,
                 "nomis", "offenders"), df_offenders);
         final Dataset<Row> df_offenderBookings = helpers.getOffenderBookings(folder);
-        helpers.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName,
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName,
                 "nomis", "offender_bookings"), df_offenderBookings);
 
         // do Full Materialize of source to target
@@ -340,7 +340,7 @@ public class DomainExecutorTest extends BaseSparkTest {
         final DomainDefinition domain = getDomain("/sample/domain/sample-domain-execution-bad-source-table.json");
         final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
         final Dataset<Row> df_offenders = helpers.getOffenders(folder);
-        helpers.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName,
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName,
                 "source", "table"), df_offenders);
         final String domainOperation = "insert";
         final String domainTableName = "prisoner";

--- a/src/test/java/uk/gov/justice/digital/service/DomainSchemaServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainSchemaServiceTest.java
@@ -59,7 +59,6 @@ public class DomainSchemaServiceTest extends BaseSparkTest {
 
     @Test
     public void shouldReturnFalseIfTableDoesntExist() {
-        final GetTableResult result = new GetTableResult();
         when(mockGlueClient.getTable(any())).thenThrow(new EntityNotFoundException("message"));
         final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
         assertFalse(service.tableExists("name", "table"));

--- a/src/test/java/uk/gov/justice/digital/service/DomainSchemaServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainSchemaServiceTest.java
@@ -1,145 +1,141 @@
 package uk.gov.justice.digital.service;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import com.amazonaws.services.glue.AWSGlueClient;
+import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.*;
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import uk.gov.justice.digital.config.BaseSparkTest;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.justice.digital.client.glue.GlueClientProvider;
 import uk.gov.justice.digital.domain.model.TableInfo;
 import uk.gov.justice.digital.exception.DomainSchemaException;
 
-@MicronautTest
-public class DomainSchemaServiceTest extends BaseSparkTest {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+// Allow common mocks to be defined before each test.
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DomainSchemaServiceTest {
 
     @Mock
-    public AWSGlueClient mockGlueClient = mock(AWSGlueClient.class);
+    private AWSGlue mockClient;
+    @Mock
+    private GlueClientProvider mockClientProvider;
+    @Mock
+    private Dataset<Row> mockDataframe;
+    @Mock
+    private StructType mockSchema;
 
-    @Test
-    public void shouldCreateDomainSchemaService() {
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        assertNotNull(service);
+    private DomainSchemaService underTest;
+
+    @BeforeEach
+    public void setupMocks() {
+        when(mockSchema.fields()).thenReturn(new StructField[0]);
+        when(mockDataframe.schema()).thenReturn(mockSchema);
+        when(mockClientProvider.getClient()).thenReturn(mockClient);
+        underTest = new DomainSchemaService(mockClientProvider);
     }
 
     @Test
     public void shouldReturnTrueWhenADatabaseExists() {
-        final GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("name"));
-        when(mockGlueClient.getDatabase(any())).thenReturn(result);
+        GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("name"));
+        when(mockClient.getDatabase(any())).thenReturn(result);
 
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        assertTrue(service.databaseExists("name"));
-        verify(mockGlueClient, times(1)).getDatabase(any());
+        assertTrue(underTest.databaseExists("name"));
+        verify(mockClient, times(1)).getDatabase(any());
     }
 
     @Test
     public void shouldReturnFalseWhenADatabaseDoesntExist() {
-        final GetDatabaseResult result = new GetDatabaseResult().withDatabase(null);
-        when(mockGlueClient.getDatabase(any())).thenReturn(result);
+        GetDatabaseResult result = new GetDatabaseResult().withDatabase(null);
+        when(mockClient.getDatabase(any())).thenReturn(result);
 
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        assertFalse(service.databaseExists("name"));
-        verify(mockGlueClient, times(1)).getDatabase(any());
+        assertFalse(underTest.databaseExists("name"));
+        verify(mockClient, times(1)).getDatabase(any());
     }
 
     @Test
     public void shouldReturnTrueIfTableExists() {
-        final GetTableResult result = new GetTableResult();
-        when(mockGlueClient.getTable(any())).thenReturn(result);
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        assertTrue(service.tableExists("name", "table"));
-        verify(mockGlueClient, times(1)).getTable(any());
+        GetTableResult result = new GetTableResult();
+        when(mockClient.getTable(any())).thenReturn(result);
+        assertTrue(underTest.tableExists("name", "table"));
+        verify(mockClient, times(1)).getTable(any());
     }
 
     @Test
     public void shouldReturnFalseIfTableDoesntExist() {
-        when(mockGlueClient.getTable(any())).thenThrow(new EntityNotFoundException("message"));
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        assertFalse(service.tableExists("name", "table"));
-        verify(mockGlueClient, times(1)).getTable(any());
+        when(mockClient.getTable(any())).thenThrow(new EntityNotFoundException("message"));
+        assertFalse(underTest.tableExists("name", "table"));
+        verify(mockClient, times(1)).getTable(any());
     }
 
     @Test
     public void shouldCreateATableWhenDataFrameProvided() {
-        when(mockGlueClient.createTable(any())).thenReturn(new CreateTableResult());
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        final Dataset<Row> df = spark.emptyDataFrame();
-        service.createTable("database", "table", "path", df);
-        verify(mockGlueClient, times(1)).createTable(any());
+        when(mockClient.createTable(any())).thenReturn(new CreateTableResult());
+        underTest.createTable("database", "table", "path", mockDataframe);
+        verify(mockClient, times(1)).createTable(any());
     }
 
     @Test
     public void shouldUpdateATableWhenPreviouslyExistsAndDataFrameProvided() {
-        when(mockGlueClient.createTable(any())).thenReturn(new CreateTableResult());
-        when(mockGlueClient.deleteTable(any())).thenReturn(new DeleteTableResult());
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        final Dataset<Row> df = spark.emptyDataFrame();
-        service.updateTable("database", "table", "path", df);
-        verify(mockGlueClient, times(1)).createTable(any());
-        verify(mockGlueClient, times(1)).deleteTable(any());
+        when(mockClient.createTable(any())).thenReturn(new CreateTableResult());
+        when(mockClient.deleteTable(any())).thenReturn(new DeleteTableResult());
+        underTest.updateTable("database", "table", "path", mockDataframe);
+        verify(mockClient, times(1)).createTable(any());
+        verify(mockClient, times(1)).deleteTable(any());
     }
 
     @Test
     public void shouldDeleteATableWhenDataFrameProvided() {
-        when(mockGlueClient.deleteTable(any())).thenReturn(new DeleteTableResult());
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        final Dataset<Row> df = spark.emptyDataFrame();
-        service.deleteTable("database", "table");
-        verify(mockGlueClient, times(1)).deleteTable(any());
+        when(mockClient.deleteTable(any())).thenReturn(new DeleteTableResult());
+        underTest.deleteTable("database", "table");
+        verify(mockClient, times(1)).deleteTable(any());
     }
 
     @Test
     public void shouldCreateATableWhenCreateIsCalled() throws DomainSchemaException {
-
-        final GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("database"));
-        when(mockGlueClient.getDatabase(any())).thenReturn(result);
-        when(mockGlueClient.getTable(any())).thenThrow(new EntityNotFoundException(""));
-        when(mockGlueClient.createTable(any())).thenReturn(new CreateTableResult());
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        final Dataset<Row> df = spark.emptyDataFrame();
+        GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("database"));
+        when(mockClient.getDatabase(any())).thenReturn(result);
+        when(mockClient.getTable(any())).thenThrow(new EntityNotFoundException(""));
+        when(mockClient.createTable(any())).thenReturn(new CreateTableResult());
         TableInfo info = TableInfo.create("prefix", "database", "schema", "table");
-        service.create(info, "table", df);
-        verify(mockGlueClient, times(1)).createTable(any());
-        verify(mockGlueClient, times(0)).deleteTable(any());
-
+        underTest.create(info, "table", mockDataframe);
+        verify(mockClient, times(1)).createTable(any());
+        verify(mockClient, times(0)).deleteTable(any());
     }
 
     @Test
     public void shouldReplaceATableWhenReplaceIsCalled() throws DomainSchemaException {
-
-        final GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("database"));
-        when(mockGlueClient.getDatabase(any())).thenReturn(result);
-        when(mockGlueClient.getTable(any())).thenReturn(new GetTableResult());
-        when(mockGlueClient.createTable(any())).thenReturn(new CreateTableResult());
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        final Dataset<Row> df = spark.emptyDataFrame();
+        GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("database"));
+        when(mockClient.getDatabase(any())).thenReturn(result);
+        when(mockClient.getTable(any())).thenReturn(new GetTableResult());
+        when(mockClient.createTable(any())).thenReturn(new CreateTableResult());
         TableInfo info = TableInfo.create("prefix", "database", "schema", "table");
-        service.replace(info, "table", df);
-        verify(mockGlueClient, times(1)).createTable(any());
-        verify(mockGlueClient, times(1)).deleteTable(any());
-
+        underTest.replace(info, "table", mockDataframe);
+        verify(mockClient, times(1)).createTable(any());
+        verify(mockClient, times(1)).deleteTable(any());
     }
 
 
     @Test
     public void shouldDropATableWhenDropIsCalled() throws DomainSchemaException {
-
-        final GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("database"));
-        when(mockGlueClient.getDatabase(any())).thenReturn(result);
-        when(mockGlueClient.getTable(any())).thenReturn(new GetTableResult());
-        when(mockGlueClient.createTable(any())).thenReturn(new CreateTableResult());
-        final DomainSchemaService service = new DomainSchemaService(mockGlueClient);
-        final Dataset<Row> df = spark.emptyDataFrame();
+        GetDatabaseResult result = new GetDatabaseResult().withDatabase(new Database().withName("database"));
+        when(mockClient.getDatabase(any())).thenReturn(result);
+        when(mockClient.getTable(any())).thenReturn(new GetTableResult());
         TableInfo info = TableInfo.create("prefix", "database", "schema", "table");
-        service.drop(info);
-        verify(mockGlueClient, times(0)).createTable(any());
-        verify(mockGlueClient, times(1)).deleteTable(any());
-
+        underTest.drop(info);
+        verify(mockClient, times(0)).createTable(any());
+        verify(mockClient, times(1)).deleteTable(any());
     }
+
 }

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -33,15 +33,16 @@ public class DomainServiceTest extends BaseSparkTest {
     private static final Logger logger = LoggerFactory.getLogger(DomainServiceTest.class);
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final String hiveDatabaseName = "test_db";
-    private static final DomainSchemaService schemaService = mock(DomainSchemaService.class);
     private static final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
     private static final SparkTestHelpers helpers = new SparkTestHelpers(spark);
+
+    private static final DomainSchemaService schemaService = mock(DomainSchemaService.class);
 
     @TempDir
     private Path folder;
 
     @BeforeAll
-    public static void setUp() {
+    public static void setupCommonMocks() {
         when(schemaService.databaseExists(any())).thenReturn(true);
         when(schemaService.tableExists(any(), any())).thenReturn(true);
     }

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -17,57 +16,35 @@ import uk.gov.justice.digital.domain.DomainExecutorTest;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableInfo;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class DomainServiceTest extends BaseSparkTest {
 
     private static final Logger logger = LoggerFactory.getLogger(DomainServiceTest.class);
     private static final ObjectMapper mapper = new ObjectMapper();
-    private final SparkTestHelpers utils = new SparkTestHelpers(spark);
     private static final String hiveDatabaseName = "test_db";
-
     private static final DomainSchemaService schemaService = mock(DomainSchemaService.class);
     private static final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
     private static final SparkTestHelpers helpers = new SparkTestHelpers(spark);
-
 
     @TempDir
     private Path folder;
 
     @BeforeAll
     public static void setUp() {
-        logger.info("setup method");
-        //instantiate and populate the dependencies
         when(schemaService.databaseExists(any())).thenReturn(true);
         when(schemaService.tableExists(any(), any())).thenReturn(true);
     }
-
-    @AfterAll
-    public static void tearDown() {
-    }
-
-    @Test
-    public void test_tempFolder() {
-        assertNotNull(this.folder);
-    }
-
-    private DomainExecutor createExecutor(final String source, final String target, final DataStorageService storage) {
-        return new DomainExecutor(source, target, storage, schemaService, hiveDatabaseName, sparkSessionProvider);
-    }
-
-    private DomainDefinition getDomain(final String resource) throws IOException {
-        val json = ResourceLoader.getResource(DomainExecutorTest.class, resource);
-        return mapper.readValue(json, DomainDefinition.class);
-    }
-
 
     @Test
     public void test_incident_domain() throws IOException {
@@ -78,12 +55,12 @@ public class DomainServiceTest extends BaseSparkTest {
         final DomainDefinition domain = getDomain("/sample/domain/incident_domain.json");
         final DataStorageService storage = new DataStorageService();
 
-        final Dataset<Row> df_offenders = utils.getOffenders(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "offenders"),
+        final Dataset<Row> df_offenders = helpers.getOffenders(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "offenders"),
                 df_offenders);
 
-        final Dataset<Row> df_offenderBookings = utils.getOffenderBookings(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "offender_bookings"),
+        final Dataset<Row> df_offenderBookings = helpers.getOffenderBookings(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "offender_bookings"),
                 df_offenderBookings);
 
         try {
@@ -100,7 +77,6 @@ public class DomainServiceTest extends BaseSparkTest {
             logger.info("DomainRefresh::process('" + domain.getName() + "') failed");
             fail();
         } finally {
-            // Delete the table from Hive
             schemaService.deleteTable(hiveDatabaseName, domain.getName() + "." + domainTableName);
         }
     }
@@ -114,12 +90,12 @@ public class DomainServiceTest extends BaseSparkTest {
         final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
         final DataStorageService storage = new DataStorageService();
 
-        final Dataset<Row> df_agency_locations = utils.getAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
+        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
                 df_agency_locations);
 
-        final Dataset<Row> df_internal_agency_locations = utils.getInternalAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis",
+        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis",
                         "agency_internal_locations"),
                 df_internal_agency_locations);
 
@@ -152,12 +128,12 @@ public class DomainServiceTest extends BaseSparkTest {
         final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
         final DataStorageService storage = new DataStorageService();
 
-        final Dataset<Row> df_agency_locations = utils.getAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
+        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
                 df_agency_locations);
 
-        final Dataset<Row> df_internal_agency_locations = utils.getInternalAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
+        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
                 df_internal_agency_locations);
 
         try {
@@ -188,12 +164,12 @@ public class DomainServiceTest extends BaseSparkTest {
         final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
         final DataStorageService storage = new DataStorageService();
 
-        final Dataset<Row> df_agency_locations = utils.getAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
+        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
                 df_agency_locations);
 
-        final Dataset<Row> df_internal_agency_locations = utils.getInternalAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
+        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
                 df_internal_agency_locations);
 
         try {
@@ -224,12 +200,12 @@ public class DomainServiceTest extends BaseSparkTest {
         final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
         final DataStorageService storage = new DataStorageService();
 
-        final Dataset<Row> df_agency_locations = utils.getAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
+        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
                 df_agency_locations);
 
-        final Dataset<Row> df_internal_agency_locations = utils.getInternalAgencyLocations(folder);
-        utils.saveDataToDisk(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
+        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
+        helpers.persistDataset(TableInfo.create(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
                 df_internal_agency_locations);
 
         try {
@@ -254,6 +230,15 @@ public class DomainServiceTest extends BaseSparkTest {
         Dataset<Row> df_test = helpers.createSchemaForTest();
         schemaService.createTable(hiveDatabaseName, "test.table", targetPath, df_test);
         schemaService.tableExists(hiveDatabaseName, "test.table");
+    }
+
+    private DomainExecutor createExecutor(String source, String target, DataStorageService storage) {
+        return new DomainExecutor(source, target, storage, schemaService, hiveDatabaseName, sparkSessionProvider);
+    }
+
+    private DomainDefinition getDomain(String resource) throws IOException {
+        val json = ResourceLoader.getResource(DomainExecutorTest.class, resource);
+        return mapper.readValue(json, DomainDefinition.class);
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/service/SparkTestHelpers.java
+++ b/src/test/java/uk/gov/justice/digital/service/SparkTestHelpers.java
@@ -9,12 +9,9 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.domain.model.TableInfo;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -56,7 +53,7 @@ public class SparkTestHelpers {
                 "updates.parquet");
     }
 
-    public void saveDataToDisk(final TableInfo location, final Dataset<Row> df) {
+    public void persistDataset(TableInfo location, Dataset<Row> df) {
         DataStorageService deltaService = new DataStorageService();
         String tablePath = deltaService.getTablePath(location.getPrefix(), location.getSchema(), location.getTable());
         deltaService.replace(tablePath, df);


### PR DESCRIPTION
Summary of changes
* introduce `ClientProvider<T>` interface and provide implementation for `AWSGlue` client instance
* revise `JobClient` to use `GlueClientProvider` to obtain an instance of the `AWSGlue` client
* revise `DomainSchemaService` to use `GlueClientProvider`
* revise `Properties` class, now a singleton renamed to `JobProperties` with classes using this now injecting in an instance
* revise tests to provide mock collaborators (in this case for ClientProvider and underlying AWSGlue client instance along with the JobProperties singleton)
* revise `DomainSchemaService` tests to use mocked collaborators including mocked `Dataframe` and `Schema` instances so the test no longer depends on a running spark instance
* other minor changes including some tidying, rename of `saveToDisk` to `persistDataset`