### PR TITLE
DPR-422 tidy up DomainService test and speed up builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,17 @@ workflows:
           app_artifacts_directory: build/libs/
           bucket_prefix: dpr-artifact-store
           sync_args: "--exclude '*' --include '*-all*jar'"
-          deploy_script: true          
+          deploy_script: true
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts
+          command: shadowJar # Skip tests when building jar, they've already run
           filters:
             branches:
               only: /.*/
             tags:
               ignore: /.*/
-          ref: << pipeline.git.branch >><< pipeline.git.tag >>  
+          ref: << pipeline.git.branch >><< pipeline.git.tag >>
           context:
             - hmpps-reporting-common
             - hmpps-reporting-orb

--- a/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobParameters;
-import uk.gov.justice.digital.config.ResourceLoader;
+import uk.gov.justice.digital.test.ResourceLoader;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableIdentifier;
 import uk.gov.justice.digital.domain.model.TableDefinition;
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.exception.DomainExecutorException;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.service.DomainSchemaService;
-import uk.gov.justice.digital.service.SparkTestHelpers;
+import uk.gov.justice.digital.test.SparkTestHelpers;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobParameters;
-import uk.gov.justice.digital.config.ResourceLoader;
+import uk.gov.justice.digital.test.ResourceLoader;
 import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableIdentifier;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
+import uk.gov.justice.digital.test.SparkTestHelpers;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -160,8 +160,6 @@ public class DomainServiceTest extends BaseSparkTest {
     }
 
     private void assertTargetDirectoryNotEmpty() {
-        val foo = new File(targetPath());
-        System.out.println("Checking file: " + foo.getAbsolutePath());
         assertTrue(Objects.requireNonNull(new File(targetPath()).list()).length > 0);
     }
 

--- a/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DomainServiceTest.java
@@ -3,13 +3,10 @@ package uk.gov.justice.digital.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobParameters;
 import uk.gov.justice.digital.config.ResourceLoader;
@@ -25,20 +22,21 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DomainServiceTest extends BaseSparkTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(DomainServiceTest.class);
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final String hiveDatabaseName = "test_db";
     private static final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
     private static final SparkTestHelpers helpers = new SparkTestHelpers(spark);
 
     private static final DomainSchemaService schemaService = mock(DomainSchemaService.class);
+    private static final DataStorageService storage = new DataStorageService();
+
+    private DomainExecutor executor;
 
     @TempDir
     private Path folder;
@@ -49,203 +47,129 @@ public class DomainServiceTest extends BaseSparkTest {
         when(schemaService.tableExists(any(), any())).thenReturn(true);
     }
 
+    @BeforeEach
+    public void setup() {
+        val mockJobParameters = mock(JobParameters.class);
+        when(mockJobParameters.getCuratedS3Path()).thenReturn(sourcePath());
+        when(mockJobParameters.getDomainTargetPath()).thenReturn(targetPath());
+        when(mockJobParameters.getCatalogDatabase()).thenReturn(Optional.of(hiveDatabaseName));
+        executor = new DomainExecutor(mockJobParameters, storage, schemaService, sparkSessionProvider);
+    }
+
     @Test
     public void test_incident_domain() throws IOException {
-        final String domainOperation = "insert";
-        final String domainTableName = "demographics";
-        final String sourcePath = this.folder.toFile().getAbsolutePath() + "/source";
-        final String targetPath = this.folder.toFile().getAbsolutePath() + "/target";
-        final DomainDefinition domain = getDomain("/sample/domain/incident_domain.json");
-        final DataStorageService storage = new DataStorageService();
+        val domainOperation = "insert";
+        val domainTableName = "demographics";
+        val domain = getDomain("/sample/domain/incident_domain.json");
 
-        final Dataset<Row> df_offenders = helpers.getOffenders(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "offenders"),
-                df_offenders);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "offenders"),
+            helpers.getOffenders(folder)
+        );
 
-        final Dataset<Row> df_offenderBookings = helpers.getOffenderBookings(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "offender_bookings"),
-                df_offenderBookings);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "offender_bookings"),
+            helpers.getOffenderBookings(folder)
+        );
 
-        try {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') started");
-            final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
-            executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
-            File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
-            if (emptyCheck.isDirectory()) {
-                logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
-                assertTrue(Objects.requireNonNull(emptyCheck.list()).length > 0);
-            }
-            logger.info("DomainRefresh::process('" + domain.getName() + "') completed");
-        } catch (Exception e) {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') failed");
-            fail();
-        } finally {
-            schemaService.deleteTable(hiveDatabaseName, domain.getName() + "." + domainTableName);
-        }
+        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
+        assertTargetDirectoryNotEmpty();
     }
 
     @Test
     public void test_establishment_domain_insert() throws IOException {
-        final String domainOperation = "insert";
-        final String domainTableName = "establishment";
-        final String sourcePath = this.folder.toFile().getAbsolutePath() + "/source";
-        final String targetPath = this.folder.toFile().getAbsolutePath() + "/target";
-        final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
-        final DataStorageService storage = new DataStorageService();
+        val domainOperation = "insert";
+        val domainTableName = "establishment";
+        val domain = getDomain("/sample/domain/establishment.domain.json");
 
-        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
-                df_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_locations"),
+            helpers.getAgencyLocations(folder)
+        );
 
-        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis",
-                        "agency_internal_locations"),
-                df_internal_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_internal_locations"),
+            helpers.getInternalAgencyLocations(folder)
+        );
 
-        try {
-            logger.info("Domain Refresh process '" + domain.getName() + "' started");
-            final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
-            executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
-            File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
-            if (emptyCheck.isDirectory()) {
-                logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
-                assertTrue(Objects.requireNonNull(emptyCheck.list()).length > 0);
-            }
-            logger.info("Domain Refresh process'" + domain.getName() + "' completed");
-        } catch (Exception e) {
-            logger.info("Domain Refresh process '" + domain.getName() + "' failed");
-            fail();
-        } finally {
-            // Delete the table from Hive
-            schemaService.deleteTable(hiveDatabaseName, domain.getName() + "." + domainTableName);
-        }
-
+        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
+        assertTargetDirectoryNotEmpty();
     }
 
     @Test
     public void test_living_unit_domain_insert() throws IOException {
-        final String domainOperation = "insert";
-        final String domainTableName = "living_unit";
-        final String sourcePath = this.folder.toFile().getAbsolutePath() + "/source";
-        final String targetPath = this.folder.toFile().getAbsolutePath() + "/target";
-        final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
-        final DataStorageService storage = new DataStorageService();
+        val domainOperation = "insert";
+        val domainTableName = "living_unit";
+        val domain = getDomain("/sample/domain/establishment.domain.json");
 
-        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
-                df_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_locations"),
+            helpers.getAgencyLocations(folder)
+        );
 
-        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
-                df_internal_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_internal_locations"),
+            helpers.getInternalAgencyLocations(folder)
+        );
 
-        try {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') started");
-            final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
-            executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
-            File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
-            if (emptyCheck.isDirectory()) {
-                logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
-                assertTrue(Objects.requireNonNull(emptyCheck.list()).length > 0);
-            }
-            logger.info("DomainRefresh::process('" + domain.getName() + "') completed");
-        } catch (Exception e) {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') failed");
-            fail();
-        } finally {
-            // Delete the table from Hive
-            schemaService.deleteTable(hiveDatabaseName, domain.getName() + "." + domainTableName);
-        }
+        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
+        assertTargetDirectoryNotEmpty();
     }
 
     @Test
     public void test_living_unit_domain_update() throws IOException {
-        final String domainOperation = "update";
-        final String domainTableName = "living_unit";
-        final String sourcePath = this.folder.toFile().getAbsolutePath() + "/source";
-        final String targetPath = this.folder.toFile().getAbsolutePath() + "/target";
-        final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
-        final DataStorageService storage = new DataStorageService();
+        val domainOperation = "update";
+        val domainTableName = "living_unit";
+        val domain = getDomain("/sample/domain/establishment.domain.json");
 
-        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
-                df_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_locations"),
+            helpers.getAgencyLocations(folder)
+        );
 
-        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
-                df_internal_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_internal_locations"),
+            helpers.getInternalAgencyLocations(folder)
+        );
 
-        try {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') update started");
-            final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
-            executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
-            File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
-            if (emptyCheck.isDirectory()) {
-                logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
-                assertTrue(Objects.requireNonNull(emptyCheck.list()).length > 0);
-            }
-            logger.info("DomainRefresh::process('" + domain.getName() + "') update completed");
-        } catch (Exception e) {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') failed");
-            fail();
-        } finally {
-            // Delete the table from Hive
-            schemaService.deleteTable(hiveDatabaseName, domain.getName() + "." + domainTableName);
-        }
+        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
     }
 
     @Test
     public void test_establishment_domain_delete() throws IOException {
-        final String domainOperation = "delete";
-        final String domainTableName = "living_unit";
-        final String sourcePath = this.folder.toFile().getAbsolutePath() + "/source";
-        final String targetPath = this.folder.toFile().getAbsolutePath() + "/target";
-        final DomainDefinition domain = getDomain("/sample/domain/establishment.domain.json");
-        final DataStorageService storage = new DataStorageService();
+        val domainOperation = "delete";
+        val domainTableName = "living_unit";
+        val domain = getDomain("/sample/domain/establishment.domain.json");
 
-        final Dataset<Row> df_agency_locations = helpers.getAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_locations"),
-                df_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_locations"),
+            helpers.getAgencyLocations(folder)
+        );
 
-        final Dataset<Row> df_internal_agency_locations = helpers.getInternalAgencyLocations(folder);
-        helpers.persistDataset(new TableIdentifier(sourcePath, hiveDatabaseName, "nomis", "agency_internal_locations"),
-                df_internal_agency_locations);
+        helpers.persistDataset(
+            new TableIdentifier(sourcePath(), hiveDatabaseName, "nomis", "agency_internal_locations"),
+            helpers.getInternalAgencyLocations(folder)
+        );
 
-        try {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') delete started");
-            final DomainExecutor executor = createExecutor(sourcePath, targetPath, storage);
-            executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
-            File emptyCheck = new File(this.folder.toFile().getAbsolutePath() + "/target");
-            if (emptyCheck.isDirectory()) {
-                logger.info(String.valueOf(Objects.requireNonNull(emptyCheck.list()).length));
-                assertTrue(Objects.requireNonNull(emptyCheck.list()).length > 0);
-            }
-            logger.info("DomainRefresh::process('" + domain.getName() + "') delete completed");
-        } catch (Exception e) {
-            logger.info("DomainRefresh::process('" + domain.getName() + "') failed");
-            fail();
-        }
-    }
-
-    @Test
-    public void test_hive_create_table()  {
-        final String targetPath = this.folder.toFile().getAbsolutePath() + "/target/test/table";
-        Dataset<Row> df_test = helpers.createSchemaForTest();
-        schemaService.createTable(hiveDatabaseName, "test.table", targetPath, df_test);
-        schemaService.tableExists(hiveDatabaseName, "test.table");
-    }
-
-    // TODO - consider moving this into a shared location
-    private DomainExecutor createExecutor(String source, String target, DataStorageService storage) {
-        val mockJobParameters = mock(JobParameters.class);
-        when(mockJobParameters.getCuratedS3Path()).thenReturn(source);
-        when(mockJobParameters.getDomainTargetPath()).thenReturn(target);
-        when(mockJobParameters.getCatalogDatabase()).thenReturn(Optional.of(hiveDatabaseName));
-        return new DomainExecutor(mockJobParameters, storage, schemaService, sparkSessionProvider);
+        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, domainOperation);
     }
 
     private DomainDefinition getDomain(String resource) throws JsonProcessingException {
         return mapper.readValue(ResourceLoader.getResource(resource), DomainDefinition.class);
+    }
+
+    private void assertTargetDirectoryNotEmpty() {
+        val foo = new File(targetPath());
+        System.out.println("Checking file: " + foo.getAbsolutePath());
+        assertTrue(Objects.requireNonNull(new File(targetPath()).list()).length > 0);
+    }
+
+    private String sourcePath() {
+        return folder.toFile().getAbsolutePath() + "/source";
+    }
+
+    private String targetPath() {
+        return folder.toFile().getAbsolutePath() + "/target";
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/test/ResourceLoader.java
+++ b/src/test/java/uk/gov/justice/digital/test/ResourceLoader.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.config;
+package uk.gov.justice.digital.test;
 
 import java.io.InputStream;
 import java.util.Optional;

--- a/src/test/java/uk/gov/justice/digital/test/SchemaTestHelpers.java
+++ b/src/test/java/uk/gov/justice/digital/test/SchemaTestHelpers.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.service;
+package uk.gov.justice.digital.test;
 
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.AlreadyExistsException;

--- a/src/test/java/uk/gov/justice/digital/test/SparkTestHelpers.java
+++ b/src/test/java/uk/gov/justice/digital/test/SparkTestHelpers.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.service;
+package uk.gov.justice.digital.test;
 
 import lombok.val;
 import org.apache.commons.io.FileUtils;
@@ -10,6 +10,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import uk.gov.justice.digital.domain.model.TableIdentifier;
+import uk.gov.justice.digital.service.DataStorageService;
 
 import java.io.IOException;
 import java.nio.file.Path;


### PR DESCRIPTION
Summary of changes
* revise build config so we skip the second test run currently active during packaging the jar (this isn't necessary)
* tidied up `DomainServiceTest` removing repetition etc..
* moved test helpers into a separate `test` package

In working on this I tried a few different ways to speed up the test runs, none of which yielded any significant speed ups. The approaches tried were
* persisting data before the tests run
* using pre-loaded tables (the idea was to save on the time it takes to persist)
* using a single spark instance shared across tests
so the changeset is limited to the refactoring I applied before looking into this. 