### PR TITLE
DPR-422 ensure both standard jar and fat jar are built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts
-          command: shadowJar # Skip tests when building jar, they've already run
+          command: jar shadowJar # Skip tests when building jar, they've already run
           filters:
             branches:
               only: /.*/


### PR DESCRIPTION
This fixes an issue with artifact tagging which expects the standard jar to be present as well as the 'fat' jar built by shadowJar. 