### PR TITLE
NOJIRA - reinstate info level logging

### DIFF
--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.provider;
 
+import io.micronaut.logging.LogLevel;
 import jakarta.inject.Singleton;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 
 @Singleton
 public class SparkSessionProvider {
-
-    private static final String WARN = "WARN";
-    private static final String ERROR = "ERROR";
 
     public SparkSession getConfiguredSparkSession(SparkConf sparkConf) {
         sparkConf
@@ -24,7 +22,7 @@ public class SparkSessionProvider {
                                 .enableHiveSupport()
                                 .getOrCreate();
 
-        session.sparkContext().setLogLevel(WARN);
+        session.sparkContext().setLogLevel(LogLevel.INFO.name());
 
         return session;
     }

--- a/src/main/java/uk/gov/justice/digital/zone/StructuredZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/StructuredZone.java
@@ -96,7 +96,7 @@ public class StructuredZone extends Zone {
                 sourceReference.getTable()
         );
 
-        handleInValidRecords(
+        handleInvalidRecords(
                 spark,
                 validatedDataFrame,
                 sourceReference.getSource(),
@@ -140,11 +140,11 @@ public class StructuredZone extends Zone {
         } else return createEmptyDataFrame(dataFrame);
     }
 
-    private void handleInValidRecords(SparkSession spark,
-                                        Dataset<Row> dataFrame,
-                                        String source,
-                                        String table,
-                                        String destinationPath) throws DataStorageException {
+    private void handleInvalidRecords(SparkSession spark,
+                                      Dataset<Row> dataFrame,
+                                      String source,
+                                      String table,
+                                      String destinationPath) throws DataStorageException {
 
         val errorString = String.format("Record does not match schema %s/%s", source, table);
 


### PR DESCRIPTION
Summary of changes
* explicitly set log level to INFO
* use micronaut LogLevel enum instead of local strings
* fix naming of `handleInvalidRecords` method