### PR TITLE
DPR-478 some refactoring before working on the SourceReferenceService

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClient.java
@@ -68,10 +68,11 @@ public class DomainDefinitionClient {
         if (response != null) {
             for (Map<String, AttributeValue> items : response.getItems()) {
                 try {
-                    String data = items.get(dataField).getS();
+                    val data = items.get(dataField).getS();
                     domainDef = mapper.readValue(data, DomainDefinition.class);
                     if (tableName != null)
                         domainDef.getTables().removeIf(table -> !table.getName().equalsIgnoreCase(tableName));
+
                 } catch (JsonProcessingException e) {
                     throw new DatabaseClientException("JSON Processing failed ", e);
                 }

--- a/src/main/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClient.java
@@ -35,6 +35,7 @@ public class DomainDefinitionClient {
         this.mapper = mapper;
     }
 
+    // TODO - parse should be part of the internal API
     public DomainDefinition parse(QueryResult response, String tableName) throws DatabaseClientException {
         DomainDefinition domainDef = null;
         if (response != null) {

--- a/src/main/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClient.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.val;
+import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.exception.DatabaseClientException;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 @Singleton
@@ -22,21 +24,46 @@ public class DomainDefinitionClient {
     private static final String sortKeyName = "secondaryId";
     private static final String dataField = "data";
 
-    private final AmazonDynamoDB dynamoDB;
-    private final ObjectMapper mapper;
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final AmazonDynamoDB client;
+    private final String tableName;
 
     @Inject
-    public DomainDefinitionClient(DynamoDBClientProvider dynamoDBClientProvider) {
-        this(dynamoDBClientProvider.getClient(), new ObjectMapper());
+    public DomainDefinitionClient(DynamoDBClientProvider dynamoDBClientProvider,
+                                  JobArguments jobArguments) {
+        this(dynamoDBClientProvider.getClient(), jobArguments.getDomainRegistry());
     }
 
-    public DomainDefinitionClient(AmazonDynamoDB dynamoDB, ObjectMapper mapper) {
-        this.dynamoDB = dynamoDB;
-        this.mapper = mapper;
+    public DomainDefinitionClient(AmazonDynamoDB dynamoDB, String tableName) {
+        this.client = dynamoDB;
+        this.tableName = tableName;
     }
 
-    // TODO - parse should be part of the internal API
-    public DomainDefinition parse(QueryResult response, String tableName) throws DatabaseClientException {
+    public DomainDefinition getDomainDefinition(String domainName, String tableName) throws DatabaseClientException {
+        val result = makeRequest(domainName);
+        return parseResponse(result, tableName);
+    }
+
+
+    private QueryResult makeRequest(String domainName) throws DatabaseClientException {
+        // Set up mapping of the partition name with the value
+        val attributeValues = Collections.singletonMap(":" + sortKeyName, new AttributeValue().withS(domainName));
+        try {
+            QueryRequest queryReq = new QueryRequest()
+                    .withTableName(tableName)
+                    .withIndexName(indexName)
+                    .withKeyConditionExpression(sortKeyName + " = :" + sortKeyName)
+                    .withExpressionAttributeValues(attributeValues);
+            return client.query(queryReq);
+        } catch (AmazonDynamoDBException e) {
+            throw new DatabaseClientException("DynamoDB client request failed", e);
+        }
+
+    }
+
+    // TODO - the table filtering should happen in the service
+    private DomainDefinition parseResponse(QueryResult response, String tableName) throws DatabaseClientException {
         DomainDefinition domainDef = null;
         if (response != null) {
             for (Map<String, AttributeValue> items : response.getItems()) {
@@ -55,21 +82,4 @@ public class DomainDefinitionClient {
         return domainDef;
     }
 
-    public QueryResult executeQuery(final String domainTableName, final String domainName)
-            throws DatabaseClientException {
-        // Set up mapping of the partition name with the value
-        HashMap<String, AttributeValue> attrValues = new HashMap<>();
-        attrValues.put(":" + sortKeyName, new AttributeValue().withS(domainName));
-        try {
-            QueryRequest queryReq = new QueryRequest()
-                    .withTableName(domainTableName)
-                    .withIndexName(indexName)
-                    .withKeyConditionExpression(sortKeyName + " = :" + sortKeyName)
-                    .withExpressionAttributeValues(attrValues);
-            return dynamoDB.query(queryReq);
-        } catch (AmazonDynamoDBException e) {
-            throw new DatabaseClientException("Query execution failed", e);
-        }
-
-    }
 }

--- a/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
@@ -302,19 +302,25 @@ public class DomainExecutor {
         }
     }
 
+    public void doDomainDelete(String domainName, String domainTableName) throws DomainExecutorException {
+        val tableId = new TableIdentifier(targetRootPath, hiveDatabaseName, domainName, domainTableName);
+        logger.info("Executing delete for {}", tableId);
+        deleteTable(tableId);
+    }
 
     public void doFullDomainRefresh(DomainDefinition domainDefinition,
-                                    String domainName,
                                     String domainTableName,
-                                    String domainOperation) throws DomainExecutorException {
-        if (domainOperation.equalsIgnoreCase("insert") ||
-                domainOperation.equalsIgnoreCase("update") ||
-                domainOperation.equalsIgnoreCase("sync")) {
+                                    String operation) throws DomainExecutorException {
+
+        if (operation.equalsIgnoreCase("insert") ||
+                operation.equalsIgnoreCase("update") ||
+                operation.equalsIgnoreCase("sync")) {
 
             val table = domainDefinition.getTables().stream()
                     .filter(t -> domainTableName.equals(t.getName()))
                     .findAny()
                     .orElse(null);
+
             if (table == null) {
                 logger.error("Table " + domainTableName + " not found");
                 throw new DomainExecutorException("Table " + domainTableName + " not found");
@@ -330,22 +336,15 @@ public class DomainExecutor {
                                     table.getName()
                             ),
                             dfTarget,
-                            domainOperation
+                            operation
                     );
                 } catch (DataStorageException e) {
                     throw new DomainExecutorException(e.getMessage());
                 }
             }
-        } else if (domainOperation.equalsIgnoreCase("delete")) {
-            logger.info("domain operation is delete");
-            deleteTable(new TableIdentifier(
-                    targetRootPath,
-                    hiveDatabaseName,
-                    domainName,
-                    domainTableName
-            ));
-        } else {
-            val message = "Unsupported domain operation: '" + domainOperation + "'";
+        }
+        else {
+            val message = "Unsupported domain operation: '" + operation + "'";
             logger.error(message);
             throw new DomainExecutorException(message);
         }

--- a/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
@@ -31,6 +31,8 @@ public class DomainExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(DomainExecutor.class);
 
+    private static final List<String> fullRefreshOperations = Arrays.asList("insert", "update", "sync");
+
     private final String sourceRootPath;
     private final String targetRootPath;
     private final DataStorageService storage;
@@ -312,36 +314,34 @@ public class DomainExecutor {
                                     String domainTableName,
                                     String operation) throws DomainExecutorException {
 
-        if (operation.equalsIgnoreCase("insert") ||
-                operation.equalsIgnoreCase("update") ||
-                operation.equalsIgnoreCase("sync")) {
-
+        if (fullRefreshOperations.contains(operation.toLowerCase())) {
             val table = domainDefinition.getTables().stream()
                     .filter(t -> domainTableName.equals(t.getName()))
                     .findAny()
-                    .orElse(null);
+                    .orElseThrow(() -> new DomainExecutorException(
+                            "Table '" + domainTableName +
+                                    "' not present in definition for domain: " +
+                                    domainDefinition.getName()));
 
-            if (table == null) {
-                logger.error("Table " + domainTableName + " not found");
-                throw new DomainExecutorException("Table " + domainTableName + " not found");
-            } else {
-                // no source table and df they are required only for unit testing
-                val dfTarget = apply(table, null);
-                try {
-                    saveTable(
-                            new TableIdentifier(
-                                    targetRootPath,
-                                    hiveDatabaseName,
-                                    domainDefinition.getName(),
-                                    table.getName()
-                            ),
-                            dfTarget,
-                            operation
-                    );
-                } catch (DataStorageException e) {
-                    throw new DomainExecutorException(e.getMessage());
-                }
+
+            // no source table and df they are required only for unit testing
+            val dfTarget = apply(table, null);
+
+            try {
+                saveTable(
+                        new TableIdentifier(
+                                targetRootPath,
+                                hiveDatabaseName,
+                                domainDefinition.getName(),
+                                table.getName()
+                        ),
+                        dfTarget,
+                        operation
+                );
+            } catch (DataStorageException e) {
+                throw new DomainExecutorException(e.getMessage(), e);
             }
+
         }
         else {
             val message = "Unsupported domain operation: '" + operation + "'";

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -78,7 +78,7 @@ public class DataStorageService {
     }
 
     public void delete(SparkSession spark, TableIdentifier tableId) throws DataStorageException {
-        logger.info("deleting Delta table..." + tableId.getSchema() + "." + tableId.getTable());
+        logger.info("Deleting Delta table..." + tableId.getSchema() + "." + tableId.getTable());
         val deltaTable = getTable(spark, tableId.toPath());
         if (deltaTable != null) {
             deltaTable.delete();

--- a/src/main/java/uk/gov/justice/digital/service/DomainService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DomainService.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.service;
 
-import com.amazonaws.services.dynamodbv2.model.QueryResult;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.val;
@@ -11,10 +10,9 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.exception.DatabaseClientException;
+import uk.gov.justice.digital.exception.DomainExecutorException;
 import uk.gov.justice.digital.exception.DomainServiceException;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
 @Singleton
@@ -35,7 +33,7 @@ public class DomainService {
         this.executor = executor;
     }
 
-    public void run() throws DomainServiceException {
+    public void run() throws DomainServiceException, DomainExecutorException {
         runInternal(
                 parameters.getDomainRegistry(),
                 parameters.getDomainTableName(),
@@ -49,25 +47,13 @@ public class DomainService {
             String domainTableName,
             String domainName,
             String domainOperation
-    ) throws PatternSyntaxException, DomainServiceException {
-        if (domainOperation.equalsIgnoreCase("delete")) {
-            // TODO - instead of passing null private an alternate method/overload
-            processDomain(null, domainName, domainTableName, domainOperation);
-        } else {
-            val domains = getDomains(domainRegistry, domainName, domainTableName);
-            logger.info("Located " + domains.size() + " domains for name '" + domainName + "'");
-            for (val domain : domains) {
-                processDomain(domain, domain.getName(), domainTableName, domainOperation);
-            }
+    ) throws PatternSyntaxException, DomainServiceException, DomainExecutorException {
+        if (domainOperation.equalsIgnoreCase("delete"))
+            executor.doDomainDelete(domainName, domainTableName);
+        else {
+            val domain = getDomainDefinition(domainRegistry, domainName, domainTableName);
+            processDomain(domain, domain.getName(), domainTableName, domainOperation);
         }
-    }
-
-    public Set<DomainDefinition> getDomains(String domainRegistry, String domainName, String domainTableName)
-            throws PatternSyntaxException, DomainServiceException {
-        //TODO: The purpose of the Set<> is to have multiple domains. Need change to this code later
-        Set<DomainDefinition> domains = new HashSet<>();
-        domains.add(getDomainDefinition(domainRegistry, domainName, domainTableName));
-        return domains;
     }
 
     private void processDomain(
@@ -80,19 +66,22 @@ public class DomainService {
 
         try {
             logger.info(prefix + "started");
-            executor.doFullDomainRefresh(domain, domainName, domainTableName, domainOperation);
+            executor.doFullDomainRefresh(domain, domainTableName, domainOperation);
             logger.info(prefix + "completed");
         } catch (Exception e) {
             logger.error(prefix + "failed", e);
         }
     }
 
-    private DomainDefinition getDomainDefinition(final String domainRegistry,
-                                                 final String domainName, final String tableName)
+    private DomainDefinition getDomainDefinition(String domainRegistry,
+                                                 String domainName,
+                                                 String tableName)
             throws DomainServiceException {
         try {
-            QueryResult response = dynamoDB.executeQuery(domainRegistry, domainName);
-            return dynamoDB.parse(response, tableName);
+            val response = dynamoDB.executeQuery(domainRegistry, domainName);
+            val domainDefinition = dynamoDB.parse(response, tableName);
+            logger.info("Retrieved domain definition for '{}'", domainName);
+            return domainDefinition;
         } catch (DatabaseClientException e) {
             logger.error("DynamoDB request failed: " + e.getMessage());
             throw new DomainServiceException("DynamoDB request failed: ", e);

--- a/src/main/java/uk/gov/justice/digital/zone/CuratedZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/CuratedZone.java
@@ -65,7 +65,7 @@ public class CuratedZone extends Zone {
             logger.info("Append completed successfully");
             storage.updateDeltaManifestForTable(spark, curatedTablePath);
 
-            logger.info("Processed dataframe with {} rows in {}ms",
+            logger.info("Processed batch with {} records in {}ms",
                     count,
                     System.currentTimeMillis() - startTime
             );

--- a/src/main/java/uk/gov/justice/digital/zone/RawZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/RawZone.java
@@ -35,14 +35,14 @@ public class RawZone extends Zone {
     @Override
     public Dataset<Row> process(SparkSession spark, Dataset<Row> dataFrame, Row table) throws DataStorageException {
 
-        logger.info("Processing data frame with {} rows", dataFrame.count());
+        logger.info("Processing batch with {} records", dataFrame.count());
 
         val startTime = System.currentTimeMillis();
 
         String rowSource = table.getAs(SOURCE);
         String rowTable = table.getAs(TABLE);
         String rowOperation = table.getAs(OPERATION);
-        // TODO - review table path construction here
+
         val tablePath = SourceReferenceService.getSourceReference(rowSource, rowTable)
                 .map(r -> createValidatedPath(rawS3Path, r.getSource(), r.getTable(), rowOperation))
                 // Revert to source and table from row where no match exists in the schema reference service.
@@ -55,7 +55,7 @@ public class RawZone extends Zone {
         logger.info("Append completed successfully");
         storage.updateDeltaManifestForTable(spark, tablePath);
 
-        logger.info("Processed data frame with {} rows in {}ms",
+        logger.info("Processed batch with {} records in {}ms",
                 rawDataFrame.count(),
                 System.currentTimeMillis() - startTime
         );

--- a/src/main/java/uk/gov/justice/digital/zone/StructuredZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/StructuredZone.java
@@ -65,7 +65,7 @@ public class StructuredZone extends Zone {
                 ? handleSchemaFound(spark, dataFrame, sourceReference.get())
                 : handleNoSchemaFound(spark, dataFrame, sourceName, tableName);
 
-        logger.info("Processed data frame with {} rows in {}ms",
+        logger.info("Processed batch with {} rows in {}ms",
                 rowCount,
                 System.currentTimeMillis() - startTime
         );

--- a/src/test/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/dynamodb/DomainDefinitionClientTest.java
@@ -7,28 +7,24 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.amazonaws.services.dynamodbv2.model.QueryResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.domain.DomainExecutor;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.exception.DatabaseClientException;
-import uk.gov.justice.digital.exception.DomainServiceException;
-import uk.gov.justice.digital.service.DomainService;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 class DomainDefinitionClientTest {
 
-
-    private static DomainDefinitionClient domainDefinitionService;
-    private static DomainService domainService;
+    private static DomainDefinitionClient underTest;
     private static AmazonDynamoDB dynamoDB;
     private static ObjectMapper mapper;
 
@@ -37,87 +33,58 @@ class DomainDefinitionClientTest {
     public void setUp() {
         dynamoDB = mock(AmazonDynamoDB.class);
         mapper = mock(ObjectMapper.class);
-        domainDefinitionService = new DomainDefinitionClient(dynamoDB, mapper);
-        domainService = new DomainService(mock(JobArguments.class), domainDefinitionService,
-                mock(DomainExecutor.class));
+        underTest = new DomainDefinitionClient(dynamoDB, mapper);
     }
 
     @Test
     public void shouldExecuteQueryForGivenDomain() throws DatabaseClientException {
-        String domainTableName = "test";
-        String domainName = "incident";
-        QueryResult result = mock(QueryResult.class);
+        val domainTableName = "test";
+        val domainName = "incident";
+        val result = mock(QueryResult.class);
         when(dynamoDB.query(any(QueryRequest.class))).thenReturn(result);
-        QueryResult expected_result = domainDefinitionService.executeQuery(domainTableName, domainName);
-        assertTrue(expected_result.getItems().isEmpty());
+        val queryResult = underTest.executeQuery(domainTableName, domainName);
+        assertTrue(queryResult.getItems().isEmpty());
     }
 
     @Test
     public void shouldReturnErrorIfDomainTableDoesntExists() {
-        String domainTableName = "test";
-        String domainName = "incident";
+        val domainTableName = "test";
+        val domainName = "incident";
         when(dynamoDB.query(any(QueryRequest.class))).thenThrow(AmazonDynamoDBException.class);
         assertThrows(
                 DatabaseClientException.class,
-                () -> domainDefinitionService.executeQuery(domainTableName, domainName),
+                () -> underTest.executeQuery(domainTableName, domainName),
                 "Expected executeQuery() to throw, but it didn't"
         );
     }
 
-
-    @Test
-    public void shouldReturnDomainDefinitionForGivenDomain() throws DatabaseClientException, DomainServiceException,
-            JsonProcessingException {
-        DomainDefinition domainDef = new DomainDefinition();
-        domainDef.setName("test name");
-        domainDef.setId("123");
-        domainDef.setDescription("test description");
-        QueryResult result = mock(QueryResult.class);
-        when(domainDefinitionService.executeQuery("test", "incident")).thenReturn(result);
-        List<Map<String, AttributeValue>> l = Collections
-                .singletonList(
-                        Collections.singletonMap("data", new AttributeValue()
-                                .withS("{\"id\": \"123\", \"name\": \"test name\", " +
-                                        "\"description\": \"test description\"}")));
-        when(result.getItems()).thenReturn(l);
-        String data = l.get(0).get("data").getS();
-        when(mapper.readValue(data, DomainDefinition.class)).thenReturn(domainDef);
-        when(domainDefinitionService.parse(result, null)).thenReturn(domainDef);
-        Set<DomainDefinition> actualDomains = domainService.getDomains("test",
-                "incident", "demographics");
-        verify(mapper, times(1)).readValue(data, DomainDefinition.class);
-        for (DomainDefinition actualDomain : actualDomains)
-            assertEquals("test name", actualDomain.getName());
-    }
-
-
     @Test
     public void shouldParseQueryResultForGivenDomainName() throws IOException, DatabaseClientException {
-        QueryResult result = mock(QueryResult.class);
-        DomainDefinition domainDef = new DomainDefinition();
+        val result = mock(QueryResult.class);
+        val domainDef = new DomainDefinition();
         domainDef.setName("test name");
         domainDef.setId("123");
         domainDef.setDescription("test description");
-        List<Map<String, AttributeValue>> l = Collections
+        val l = Collections
                 .singletonList(
                         Collections.singletonMap("data", new AttributeValue()
                                 .withS("{\"id\": \"123\", \"name\": \"test name\", " +
                                         "\"description\": \"test description\"}")));
         when(result.getItems()).thenReturn(l);
-        String data = l.get(0).get("data").getS();
+        val data = l.get(0).get("data").getS();
         when(mapper.readValue(data, DomainDefinition.class)).thenReturn(domainDef);
-        DomainDefinition expectedDomainDef = domainDefinitionService.parse(result, null);
+        val expectedDomainDef = underTest.parse(result, null);
         assertEquals("test name", expectedDomainDef.getName());
     }
 
     @Test
     public void shouldParseQueryResultForGivenDomainAndTableName() throws IOException, DatabaseClientException {
-        QueryResult result = mock(QueryResult.class);
-        DomainDefinition domainDef = new DomainDefinition();
+        val result = mock(QueryResult.class);
+        val domainDef = new DomainDefinition();
         domainDef.setName("living_unit");
         domainDef.setId("123");
         domainDef.setDescription("test description");
-        List<Map<String, AttributeValue>> l = Collections
+        val l = Collections
                 .singletonList(
                         Collections.singletonMap("data", new AttributeValue()
                                 .withS("{\"id\": \"123\", \"name\": \"demographics\"," +
@@ -125,30 +92,30 @@ class DomainDefinitionClientTest {
                                 .withS("{\"id\": \"123\", \"name\": \"living_unit\", " +
                                         "\"description\": \"test description\"}")));
         when(result.getItems()).thenReturn(l);
-        String data = l.get(0).get("data").getS();
+        val data = l.get(0).get("data").getS();
         when(mapper.readValue(data, DomainDefinition.class)).thenReturn(domainDef);
-        DomainDefinition expectedDomainDef = domainDefinitionService.parse(result, "demographics");
+        val expectedDomainDef = underTest.parse(result, "demographics");
         assertEquals("living_unit", expectedDomainDef.getName());
     }
 
     @Test
     public void shouldParseQueryResultProducesException() throws IOException {
-        QueryResult result = mock(QueryResult.class);
-        DomainDefinition domainDef = new DomainDefinition();
+        val result = mock(QueryResult.class);
+        val domainDef = new DomainDefinition();
         domainDef.setName("test name");
         domainDef.setId("123");
         domainDef.setDescription("test description");
-        List<Map<String, AttributeValue>> l = Collections
+        val l = Collections
                 .singletonList(
                         Collections.singletonMap("data", new AttributeValue()
                                 .withS("{\"id\": \"123\", \"name\": \"test name\"," +
                                         " \"description\": \"test description\"}")));
         when(result.getItems()).thenReturn(l);
-        String data = l.get(0).get("data").getS();
+        val data = l.get(0).get("data").getS();
         when(mapper.readValue(data, DomainDefinition.class)).thenThrow(JsonProcessingException.class);
         assertThrows(
                 DatabaseClientException.class,
-                () -> domainDefinitionService.parse(result, null),
+                () -> underTest.parse(result, null),
                 "Expected parse() to throw, but it didn't"
         );
     }

--- a/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/domain/DomainExecutorTest.java
@@ -254,7 +254,6 @@ class DomainExecutorTest extends BaseSparkTest {
         val domainDefinition = getDomain("/sample/domain/incident_domain.json");
         executor.doFullDomainRefresh(
                 domainDefinition,
-                domainDefinition.getName(),
                 "demographics",
                 "insert"
         );
@@ -285,9 +284,9 @@ class DomainExecutorTest extends BaseSparkTest {
 
         val domainTableName = "prisoner";
         // Insert first
-        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, "insert");
+        executor.doFullDomainRefresh(domain, domainTableName, "insert");
         // then update
-        executor.doFullDomainRefresh(domain, domain.getName(), domainTableName, "update");
+        executor.doFullDomainRefresh(domain, domainTableName, "update");
         verify(testSchemaService, times(1)).create(any(), any(), any());
         verify(testSchemaService, times(1)).replace(any(), any(), any());
 
@@ -319,7 +318,7 @@ class DomainExecutorTest extends BaseSparkTest {
         val testSchemaService = mock(DomainSchemaService.class);
         val executor = createExecutor(sourcePath(), targetPath(), storage, testSchemaService);
 
-        executor.doFullDomainRefresh(domain1, domain1.getName(), domainTableName, "insert");
+        executor.doFullDomainRefresh(domain1, domainTableName, "insert");
 
         verify(testSchemaService, times(1)).create(any(), any(), any());
 
@@ -330,7 +329,7 @@ class DomainExecutorTest extends BaseSparkTest {
         assertEquals(1, storage.load(spark, info).count());
 
         // now the reverse
-        executor.doFullDomainRefresh(domain2, domain2.getName(), domainTableName, "update");
+        executor.doFullDomainRefresh(domain2, domainTableName, "update");
         verify(testSchemaService, times(1)).replace(any(), any(), any());
 
         // there should be a target table
@@ -340,7 +339,7 @@ class DomainExecutorTest extends BaseSparkTest {
     }
 
     @Test
-    public void shouldRunWith0ChangesIfTableIsNotInDomain() throws Exception {
+    public void shouldRunWithNoChangesIfTableIsNotInDomain() throws Exception {
 
         val domain = getDomain("/sample/domain/sample-domain-execution-bad-source-table.json");
         val testSchemaService = mock(DomainSchemaService.class);
@@ -353,8 +352,7 @@ class DomainExecutorTest extends BaseSparkTest {
 
         assertThrows(
                 DomainExecutorException.class,
-                () -> executor.doFullDomainRefresh(domain, domain.getName(),
-                        "prisoner", "insert")
+                () -> executor.doFullDomainRefresh(domain, "prisoner", "insert")
         );
 
         // there shouldn't be a target table
@@ -480,7 +478,6 @@ class DomainExecutorTest extends BaseSparkTest {
                 Arrays.equals(a.collectAsList().toArray(), b.collectAsList().toArray());
     }
 
-    // TODO - this also exists in DomainServiceTest
     private DomainExecutor createExecutor(String source, String target, DataStorageService storage,
                                           DomainSchemaService schemaService) {
         val mockJobParameters = mock(JobArguments.class);


### PR DESCRIPTION
Summary of changes
* introduce separate `doDomainDelete()` method on the executor so we have a clear separation of this functionality with a cleaner API that no-longer means we need to pass nulls in the parameter list
* internalised the dynamo db table name so that the caller is not required to pass this in anymore - this is an internal concern of the client and shouldn't be exposed
* revised the DomainService tests so they actually test the DomainService (not the DomainExecutor which is already tested elsewhere) using mocked collaborators
* revised the public API of the DomainDefinitionClient so the caller simply makes one method call to get a domain definition (getting the result and parsing it are both internal concerns of the client)
* log messages now use consistent language in Zone classes
* other minor tidying