### PR TITLE
DPR-478 add avro to spark schema converter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     implementation "com.amazonaws:aws-java-sdk-glue:$glueSdkVersion" // transitively brings in java-sdk-core
 
+    implementation "org.apache.spark:spark-avro_2.12:$sparkVersion"
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"

--- a/src/main/java/uk/gov/justice/digital/converter/Converter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/Converter.java
@@ -1,73 +1,7 @@
 package uk.gov.justice.digital.converter;
 
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.StructType;
+public interface Converter<I, O> {
 
-import java.util.Arrays;
-import java.util.Optional;
-
-import static org.apache.spark.sql.types.DataTypes.StringType;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
-
-public abstract class Converter {
-
-    private static final boolean NOT_NULL = false;
-    private static final boolean IS_NULL = true;
-
-    // TODO - at the moment we haven't really formalised the idea of our internal format which we could do instead of
-    //        defining the fields and the struct here.
-
-    // Constants defining the fields used in the common output format.
-    public static class ParsedDataFields {
-        public static final String RAW = "raw"; // the raw incoming value, unchanged
-        public static final String DATA = "data"; // the payload. Not always present
-        public static final String METADATA = "metadata"; // the payload metadata. Always present
-
-        // From the metadata. By default we use _ as a differentiator so that payloads with
-        // metadata fields do not get overwritten
-        public static final String TIMESTAMP = "_timestamp";
-        public static final String KEY = "_key";
-        public static final String DATA_TYPE = "_datatype";
-        public static final String OPERATION = "_operation";
-        public static final String SOURCE = "_source";
-        public static final String TABLE = "_table";
-        public static final String CONVERTER = "_converter";
-    }
-
-    public enum Operation {
-        Load("load"),
-        Insert("insert"),
-        Update("update"),
-        Delete("delete");
-
-        private String name;
-        Operation(String name) { this.name = name; }
-
-        public String getName() {
-            return name;
-        }
-
-        public static Optional<Operation> getOperation(String operation) {
-            return Arrays.stream(values()).filter(it -> it.name().equalsIgnoreCase(operation)).findAny();
-        }
-    };
-
-    // This schema defines the common output format to be created from the incoming data.
-    protected static final StructType PARSED_DATA_SCHEMA = new StructType()
-        .add(RAW, StringType, NOT_NULL)
-        .add(DATA, StringType, IS_NULL)
-        .add(METADATA, StringType, NOT_NULL)
-        .add(TIMESTAMP, StringType, NOT_NULL)
-        .add(KEY, StringType, NOT_NULL)
-        .add(DATA_TYPE, StringType, NOT_NULL)
-        .add(SOURCE, StringType, NOT_NULL)
-        .add(TABLE, StringType, NOT_NULL)
-        .add(OPERATION, StringType, NOT_NULL)
-        .add(CONVERTER, StringType, NOT_NULL);
-
-    public abstract Dataset<Row> convert(JavaRDD<Row> input, SparkSession spark);
+    O convert(I input);
 
 }

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -5,6 +5,7 @@ import org.apache.avro.Schema;
 import org.apache.spark.sql.avro.SchemaConverters;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
+import uk.gov.justice.digital.converter.Converter;
 
 import java.util.Optional;
 
@@ -18,8 +19,9 @@ import java.util.Optional;
  * See <a href="https://spark.apache.org/docs/3.3.0/sql-data-sources-avro.html#supported-types-for-avro---spark-sql-conversion">Avro to Spark Schema Conversion Documentation</a>
  */
 @Singleton
-public class AvroToSparkSchemaConverter {
+public class AvroToSparkSchemaConverter implements Converter<String, StructType> {
 
+    @Override
     public StructType convert(String avroSchemaString) {
         return Optional.of(avroSchemaString)
                 .map(this::toAvroSchema)

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -83,10 +83,9 @@ public class AvroToSparkSchemaConverter {
         val name = node.get("name").asText();
         val nullable = node.get("nullable").asBoolean();
         val typeNode = node.get("type");
-        // TODO - review this - what if it's another type
-        val type = (typeNode.isTextual())
-                ? typeNode.asText()
-                : typeNode.get("logicalType").asText();
+        val type = (typeNode.isObject())
+                ? typeNode.get("logicalType").asText()
+                : typeNode.asText();
 
         if (isSimpleType(type)) {
             return new StructField(

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -3,24 +3,66 @@ package uk.gov.justice.digital.converter.avro;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Singleton;
 import lombok.val;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.spark.sql.types.*;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+@Singleton
 public class AvroToSparkSchemaConverter {
+
+    // TODO - revert to new SimpleEntry<> as per the tests - mapEntry isn't really adding much
+    private static final Map<String, DataType> avroSimpleTypeNameToSparkType = Stream.of(
+            mapEntry(Schema.Type.BOOLEAN,   DataTypes.BooleanType),
+            mapEntry(Schema.Type.BYTES,     DataTypes.ByteType),
+            mapEntry(Schema.Type.DOUBLE,    DataTypes.DoubleType),
+            mapEntry(Schema.Type.FLOAT,     DataTypes.FloatType),
+            mapEntry(Schema.Type.INT,       DataTypes.IntegerType),
+            mapEntry(Schema.Type.LONG,      DataTypes.LongType),
+            mapEntry(Schema.Type.NULL,      DataTypes.NullType),
+            mapEntry(Schema.Type.STRING,    DataTypes.StringType)
+    ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    private static final Map<String, DataType> avroLogicalTypeNameToSparkType = Stream.of(
+            mapEntry(LogicalTypes.date(),               DataTypes.DateType),
+            mapEntry(LogicalTypes.timestampMicros(),    DataTypes.TimestampType),
+            mapEntry(LogicalTypes.timestampMillis(),    DataTypes.TimestampType),
+            // TODO - there is no time type in spark so for now we use the timestamp type.
+            //      - conversion will need to be handled later during the normalisation stage.
+            mapEntry(LogicalTypes.timeMillis(),         DataTypes.TimestampType),
+            mapEntry(LogicalTypes.timeMicros(),         DataTypes.TimestampType)
+    ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public StructType convert(String avroSchema) throws JsonProcessingException {
-        val parsedSchema = objectMapper.readTree(avroSchema);
-        val avroFields = parsedSchema.get("fields").elements();
-        return buildStructTypeFromAvroFields(avroFields);
+    public StructType convert(String avroSchema) {
+        try {
+            val parsedSchema = objectMapper.readTree(avroSchema);
+            val avroFields = parsedSchema.get("fields").elements();
+            return buildStructTypeFromAvroFields(avroFields);
+        }
+        catch (JsonProcessingException jpe) {
+            // TODO - define a custom RTE e.g. SchemaConverterError?
+            throw new RuntimeException("Unexpected error when processing schema", jpe);
+        }
+    }
+
+    private static SimpleEntry<String, DataType> mapEntry(Schema.Type avroType, DataType sparkType) {
+        return new SimpleEntry<>(avroType.getName(), sparkType);
+    }
+
+    private static SimpleEntry<String, DataType> mapEntry(LogicalType avroType, DataType sparkType) {
+        return new SimpleEntry<>(avroType.getName(), sparkType);
     }
 
     private StructType buildStructTypeFromAvroFields(Iterator<JsonNode> fields) {
@@ -39,17 +81,43 @@ public class AvroToSparkSchemaConverter {
 
     private StructField toStructField(JsonNode node) {
         val name = node.get("name").asText();
-        val type = node.get("type").asText();
         val nullable = node.get("nullable").asBoolean();
+        val typeNode = node.get("type");
+        // TODO - review this - what if it's another type
+        val type = (typeNode.isTextual())
+                ? typeNode.asText()
+                : typeNode.get("logicalType").asText();
 
-        if (type.equals("string")) {
+        if (isSimpleType(type)) {
             return new StructField(
                     name,
-                    DataTypes.StringType,
+                    avroSimpleTypeNameToSparkType.get(type),
+                    nullable,
+                    Metadata.empty());
+        }
+        else if (isEnumType(type)) {
+            throw new RuntimeException("ENUM handling ot implemented yet");
+        }
+        else if (isLogicalType(type)) {
+            return new StructField(
+                    name,
+                    avroLogicalTypeNameToSparkType.get(type),
                     nullable,
                     Metadata.empty());
         }
         else throw new RuntimeException("Unsupported avro field type: " + type);
+    }
+
+    private boolean isSimpleType(String type) {
+        return avroSimpleTypeNameToSparkType.containsKey(type);
+    }
+
+    private boolean isEnumType(String type) {
+        return Schema.Type.ENUM.getName().equals(type);
+    }
+
+    private boolean isLogicalType(String logicalType) {
+        return avroLogicalTypeNameToSparkType.containsKey(logicalType);
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -8,6 +8,15 @@ import org.apache.spark.sql.types.StructType;
 
 import java.util.Optional;
 
+/**
+ * Avro Schema to Spark Schema (StructType) converter.
+ * <p>
+ * Makes use of the SchemaConverters class provided by spark-avro.
+ * <p>
+ * Avro types are converted to Spark types as per the documentation.
+ * <p>
+ * See <a href="https://spark.apache.org/docs/3.3.0/sql-data-sources-avro.html#supported-types-for-avro---spark-sql-conversion">Avro to Spark Schema Conversion Documentation</a>
+ */
 @Singleton
 public class AvroToSparkSchemaConverter {
 

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.converter.avro;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class AvroToSparkSchemaConverter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public StructType convert(String avroSchema) throws JsonProcessingException {
+        val parsedSchema = objectMapper.readTree(avroSchema);
+        val avroFields = parsedSchema.get("fields").elements();
+        return buildStructTypeFromAvroFields(avroFields);
+    }
+
+    private StructType buildStructTypeFromAvroFields(Iterator<JsonNode> fields) {
+        val structFieldArray =
+                toStream(fields)
+                        .map(this::toStructField)
+                        .toArray(StructField[]::new);
+
+        return new StructType(structFieldArray);
+    }
+
+    private <T> Stream<T> toStream(Iterator<T> i) {
+        Iterable<T> iterable = () -> i;
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private StructField toStructField(JsonNode node) {
+        val name = node.get("name").asText();
+        val type = node.get("type").asText();
+        val nullable = node.get("nullable").asBoolean();
+
+        if (type.equals("string")) {
+            return new StructField(
+                    name,
+                    DataTypes.StringType,
+                    nullable,
+                    Metadata.empty());
+        }
+        else throw new RuntimeException("Unsupported avro field type: " + type);
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -1,122 +1,43 @@
 package uk.gov.justice.digital.converter.avro;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Singleton;
-import lombok.val;
-import org.apache.avro.LogicalType;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.avro.SchemaConverters;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
 
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 @Singleton
 public class AvroToSparkSchemaConverter {
 
-    // TODO - revert to new SimpleEntry<> as per the tests - mapEntry isn't really adding much
-    private static final Map<String, DataType> avroSimpleTypeNameToSparkType = Stream.of(
-            mapEntry(Schema.Type.BOOLEAN,   DataTypes.BooleanType),
-            mapEntry(Schema.Type.BYTES,     DataTypes.ByteType),
-            mapEntry(Schema.Type.DOUBLE,    DataTypes.DoubleType),
-            mapEntry(Schema.Type.FLOAT,     DataTypes.FloatType),
-            mapEntry(Schema.Type.INT,       DataTypes.IntegerType),
-            mapEntry(Schema.Type.LONG,      DataTypes.LongType),
-            mapEntry(Schema.Type.NULL,      DataTypes.NullType),
-            mapEntry(Schema.Type.STRING,    DataTypes.StringType)
-    ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-    private static final Map<String, DataType> avroLogicalTypeNameToSparkType = Stream.of(
-            mapEntry(LogicalTypes.date(),               DataTypes.DateType),
-            mapEntry(LogicalTypes.timestampMicros(),    DataTypes.TimestampType),
-            mapEntry(LogicalTypes.timestampMillis(),    DataTypes.TimestampType),
-            // TODO - there is no time type in spark so for now we use the timestamp type.
-            //      - conversion will need to be handled later during the normalisation stage.
-            mapEntry(LogicalTypes.timeMillis(),         DataTypes.TimestampType),
-            mapEntry(LogicalTypes.timeMicros(),         DataTypes.TimestampType)
-    ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    public StructType convert(String avroSchema) {
-        try {
-            val parsedSchema = objectMapper.readTree(avroSchema);
-            val avroFields = parsedSchema.get("fields").elements();
-            return buildStructTypeFromAvroFields(avroFields);
-        }
-        catch (JsonProcessingException jpe) {
-            // TODO - define a custom RTE e.g. SchemaConverterError?
-            throw new RuntimeException("Unexpected error when processing schema", jpe);
-        }
+    public StructType convert(String avroSchemaString) {
+        return Optional.of(avroSchemaString)
+                .map(this::toAvroSchema)
+                .map(this::toSparkDataType)
+                .flatMap(this::castToStructType)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("Unable to cast DataType to StructType schema: '" + avroSchemaString + "'")
+                );
     }
 
-    private static SimpleEntry<String, DataType> mapEntry(Schema.Type avroType, DataType sparkType) {
-        return new SimpleEntry<>(avroType.getName(), sparkType);
+    private Schema toAvroSchema(String avro) {
+        // The Avro Schema Parser is stateful and will cache parsed schemas. We choose not to benefit from this since
+        // the parser also prevents an existing definition from being updated and will throw a SchemaParseException.
+        // This allows us to handle new versions of a schema as and when they are published.
+        return new Schema.Parser().parse(avro);
     }
 
-    private static SimpleEntry<String, DataType> mapEntry(LogicalType avroType, DataType sparkType) {
-        return new SimpleEntry<>(avroType.getName(), sparkType);
+    private DataType toSparkDataType(Schema avroSchema) {
+        return SchemaConverters
+                .toSqlType(avroSchema)
+                .dataType();
     }
 
-    private StructType buildStructTypeFromAvroFields(Iterator<JsonNode> fields) {
-        val structFieldArray =
-                toStream(fields)
-                        .map(this::toStructField)
-                        .toArray(StructField[]::new);
-
-        return new StructType(structFieldArray);
-    }
-
-    private <T> Stream<T> toStream(Iterator<T> i) {
-        Iterable<T> iterable = () -> i;
-        return StreamSupport.stream(iterable.spliterator(), false);
-    }
-
-    private StructField toStructField(JsonNode node) {
-        val name = node.get("name").asText();
-        val nullable = node.get("nullable").asBoolean();
-        val typeNode = node.get("type");
-        val type = (typeNode.isObject())
-                ? typeNode.get("logicalType").asText()
-                : typeNode.asText();
-
-        if (isSimpleType(type)) {
-            return new StructField(
-                    name,
-                    avroSimpleTypeNameToSparkType.get(type),
-                    nullable,
-                    Metadata.empty());
-        }
-        else if (isEnumType(type)) {
-            throw new RuntimeException("ENUM handling ot implemented yet");
-        }
-        else if (isLogicalType(type)) {
-            return new StructField(
-                    name,
-                    avroLogicalTypeNameToSparkType.get(type),
-                    nullable,
-                    Metadata.empty());
-        }
-        else throw new RuntimeException("Unsupported avro field type: " + type);
-    }
-
-    private boolean isSimpleType(String type) {
-        return avroSimpleTypeNameToSparkType.containsKey(type);
-    }
-
-    private boolean isEnumType(String type) {
-        return Schema.Type.ENUM.getName().equals(type);
-    }
-
-    private boolean isLogicalType(String logicalType) {
-        return avroLogicalTypeNameToSparkType.containsKey(logicalType);
+    private Optional<StructType> castToStructType(DataType sparkDataType) {
+        return Optional.of(sparkDataType)
+                .filter(StructType.class::isInstance)
+                .map(StructType.class::cast);
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
+++ b/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
@@ -12,8 +12,10 @@ import uk.gov.justice.digital.provider.SparkSessionProvider;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.types.DataTypes.StringType;
@@ -22,7 +24,7 @@ import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 /**
  * Converter that takes raw data from DMS v3.4.6 and converts it into the standardised data representation for
  * onward processing. See Converter.PARSED_DATA_SCHEMA
- *
+ * <p>
  * This converter will fail with an exception if
  *   o invalid json is encountered that cannot be parsed
  *   o after parsing, any of the fields in the standard format are null
@@ -31,31 +33,65 @@ import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 @Named("converterForDMS_3_4_6")
 public class DMS_3_4_6 implements Converter<JavaRDD<Row>, Dataset<Row>> {
 
+    public static final String CONVERTER_VERSION = "dms:3.4.6";
+    public static final String ORIGINAL = "original";
+    public static final String JSON_DATA = "jsonData";
+
     private static final boolean NOT_NULL = false;
+    private static final boolean IS_NULLABLE = true;
 
     // TODO - at the moment we haven't really formalised the idea of our internal format which we could do instead of
     //        defining the fields and the struct here.
 
     // Constants defining the fields used in the common output format.
     public static class ParsedDataFields {
-        public static final String DATA = "data";
-        public static final String METADATA = "metadata";
-        public static final String OPERATION = "operation";
-        public static final String SOURCE = "source";
-        public static final String TABLE = "table";
+        public static final String RAW = "raw"; // the raw incoming value, unchanged
+        public static final String DATA = "data"; // the payload. Not always present
+        public static final String METADATA = "metadata"; // the payload metadata. Always present
+
+        // From the metadata. By default we use _ as a differentiator so that payloads with
+        // metadata fields do not get overwritten
+        public static final String TIMESTAMP = "_timestamp";
+        public static final String KEY = "_key";
+        public static final String DATA_TYPE = "_datatype";
+        public static final String OPERATION = "_operation";
+        public static final String SOURCE = "_source";
+        public static final String TABLE = "_table";
+        public static final String CONVERTER = "_converter";
+    }
+
+    public enum Operation {
+        Load("load"),
+        Insert("insert"),
+        Update("update"),
+        Delete("delete");
+
+        private final String name;
+
+        Operation(String name) { this.name = name; }
+
+        public String getName() {
+            return name;
+        }
+
+        public static Optional<Operation> getOperation(String operation) {
+            return Arrays.stream(values()).filter(it -> it.name().equalsIgnoreCase(operation)).findAny();
+        }
     }
 
     // This schema defines the common output format to be created from the incoming data.
-    private static final StructType PARSED_DATA_SCHEMA = new StructType()
-            .add(DATA, StringType, NOT_NULL)
+    protected static final StructType PARSED_DATA_SCHEMA = new StructType()
+            .add(RAW, StringType, NOT_NULL)
+            .add(DATA, StringType, IS_NULLABLE)
             .add(METADATA, StringType, NOT_NULL)
+            .add(TIMESTAMP, StringType, NOT_NULL)
+            .add(KEY, StringType, NOT_NULL)
+            .add(DATA_TYPE, StringType, NOT_NULL)
             .add(SOURCE, StringType, NOT_NULL)
             .add(TABLE, StringType, NOT_NULL)
-            .add(OPERATION, StringType, NOT_NULL);
+            .add(OPERATION, StringType, NOT_NULL)
+            .add(CONVERTER, StringType, NOT_NULL);
 
-    public static final String CONVERTER_VERSION = "dms:3.4.6";
-    public static final String ORIGINAL = "original";
-    public static final String JSON_DATA = "jsonData";
 
     private static final StructType eventsSchema =
         new StructType()
@@ -63,8 +99,8 @@ public class DMS_3_4_6 implements Converter<JavaRDD<Row>, Dataset<Row>> {
 
     private static final StructType recordSchema =
         new StructType()
-            .add(DATA, StringType, true) // Data varies per table, so we leave parsing to the StructuredZone.
-            .add(METADATA, new StructType()
+                .add(DATA, StringType, IS_NULLABLE) // Data varies per table, so we leave parsing to the StructuredZone.
+                .add(METADATA, new StructType()
                 .add("timestamp", StringType)
                 .add("record-type", StringType)
                 .add("operation", StringType)
@@ -87,17 +123,15 @@ public class DMS_3_4_6 implements Converter<JavaRDD<Row>, Dataset<Row>> {
     @Override
     public Dataset<Row> convert(JavaRDD<Row> rdd) {
         val df = spark.createDataFrame(rdd, eventsSchema)
-                .withColumn(RAW, col(ORIGINAL))
+            .withColumn(RAW, col(ORIGINAL))
             .withColumn(JSON_DATA, from_json(col(ORIGINAL), recordSchema, jsonOptions))
             .select(RAW,JSON_DATA + ".*")
             .select(RAW, DATA, METADATA, METADATA + ".*")
-
-                // Construct a dataframe that aligns to the parsed data schema
+            // Construct a dataframe that aligns to the parsed data schema
             .select(
                 col(RAW),
                 col(DATA),
                 to_json(col(METADATA)).as(METADATA),
-
                 col("timestamp").as(TIMESTAMP),
                 col("partition-key-value").as(KEY),
                 col("record-type").as(DATA_TYPE),

--- a/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
+++ b/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.converter.dms;
 
+import jakarta.inject.Inject;
 import lombok.val;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
@@ -7,6 +8,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 import uk.gov.justice.digital.converter.Converter;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -15,7 +17,9 @@ import java.util.Map;
 
 import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.types.DataTypes.StringType;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.DATA;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.TABLE;
 
 /**
  * Converter that takes raw data from DMS v3.4.6 and converts it into the standardised data representation for
@@ -27,7 +31,29 @@ import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
  */
 @Singleton
 @Named("converterForDMS_3_4_6")
-public class DMS_3_4_6 extends Converter {
+public class DMS_3_4_6 implements Converter<JavaRDD<Row>, Dataset<Row>> {
+
+    private static final boolean NOT_NULL = false;
+
+    // TODO - at the moment we haven't really formalised the idea of our internal format which we could do instead of
+    //        defining the fields and the struct here.
+
+    // Constants defining the fields used in the common output format.
+    public static class ParsedDataFields {
+        public static final String DATA = "data";
+        public static final String METADATA = "metadata";
+        public static final String OPERATION = "operation";
+        public static final String SOURCE = "source";
+        public static final String TABLE = "table";
+    }
+
+    // This schema defines the common output format to be created from the incoming data.
+    private static final StructType PARSED_DATA_SCHEMA = new StructType()
+            .add(DATA, StringType, NOT_NULL)
+            .add(METADATA, StringType, NOT_NULL)
+            .add(SOURCE, StringType, NOT_NULL)
+            .add(TABLE, StringType, NOT_NULL)
+            .add(OPERATION, StringType, NOT_NULL);
 
     public static final String CONVERTER_VERSION = "dms:3.4.6";
     public static final String ORIGINAL = "original";
@@ -53,8 +79,15 @@ public class DMS_3_4_6 extends Converter {
     // Allow parse errors to fail silently when parsing the raw JSON string to allow control records to be filtered.
     private static final Map<String, String> jsonOptions = Collections.singletonMap("mode", "PERMISSIVE");
 
+    private final SparkSession spark;
+
+    @Inject
+    public DMS_3_4_6(SparkSessionProvider sparkSessionProvider) {
+        this.spark = sparkSessionProvider.getConfiguredSparkSession();
+    }
+
     @Override
-    public Dataset<Row> convert(JavaRDD<Row> rdd, SparkSession spark) {
+    public Dataset<Row> convert(JavaRDD<Row> rdd) {
         val df = spark.createDataFrame(rdd, eventsSchema)
                 .withColumn(RAW, col(ORIGINAL))
             .withColumn(JSON_DATA, from_json(col(ORIGINAL), recordSchema, jsonOptions))

--- a/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
+++ b/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.converter.Converter;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 

--- a/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
+++ b/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.converter.Converter;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 

--- a/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
+++ b/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
-import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.DATA;
-import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.TABLE;
 
 /**
  * Converter that takes raw data from DMS v3.4.6 and converts it into the standardised data representation for

--- a/src/main/java/uk/gov/justice/digital/zone/CuratedZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/CuratedZone.java
@@ -15,8 +15,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.SOURCE;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.TABLE;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.SOURCE;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.TABLE;
 
 @Singleton
 public class CuratedZone extends Zone {

--- a/src/main/java/uk/gov/justice/digital/zone/RawZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/RawZone.java
@@ -7,7 +7,7 @@ import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.converter.Converter;
+import uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.service.DataStorageService;
@@ -48,7 +48,7 @@ public class RawZone extends Zone {
 
         String rowSource = table.getAs(SOURCE);
         String rowTable = table.getAs(TABLE);
-        Optional<Converter.Operation> rowOperation = Converter.Operation.getOperation(table.getAs(OPERATION));
+        Optional<Operation> rowOperation = Operation.getOperation(table.getAs(OPERATION));
 
         if(rowOperation.isPresent()) {
 

--- a/src/main/java/uk/gov/justice/digital/zone/RawZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/RawZone.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import static org.apache.spark.sql.functions.*;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 
 @Singleton
 public class RawZone extends Zone {

--- a/src/main/java/uk/gov/justice/digital/zone/StructuredZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/StructuredZone.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import static org.apache.spark.sql.functions.*;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 
 @Singleton
 public class StructuredZone extends Zone {

--- a/src/test/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterTest.java
+++ b/src/test/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterTest.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.converter.avro;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.val;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AvroToSparkSchemaConverterTest {
+
+    private static final AvroToSparkSchemaConverter underTest = new AvroToSparkSchemaConverter();
+
+    @Test
+    public void shouldConvertAValidSchemaWithASimpleTypeDeclaration() throws JsonProcessingException {
+
+        val fakeSchema = "{ " +
+                "\"fields\": [ " +
+                    "{ " +
+                    "\"name\": \"some-field\", " +
+                    "\"type\": \"string\", " +
+                    "\"nullable\": false " +
+                    " }]} ";
+
+        val result = underTest.convert(fakeSchema);
+        val expectedSchema = new StructType().add("some-field", "string", false);
+
+        assertEquals(expectedSchema, result);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterTest.java
+++ b/src/test/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterTest.java
@@ -1,9 +1,15 @@
 package uk.gov.justice.digital.converter.avro;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.val;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -12,20 +18,69 @@ class AvroToSparkSchemaConverterTest {
     private static final AvroToSparkSchemaConverter underTest = new AvroToSparkSchemaConverter();
 
     @Test
-    public void shouldConvertAValidSchemaWithASimpleTypeDeclaration() throws JsonProcessingException {
+    public void shouldConvertAllSimpleFieldTypesToCorrectSparkType() {
+        val typeMappings = Stream.of(
+                new SimpleEntry<>("boolean", DataTypes.BooleanType),
+                new SimpleEntry<>("bytes",   DataTypes.ByteType),
+                new SimpleEntry<>("double",  DataTypes.DoubleType),
+                new SimpleEntry<>("float",   DataTypes.FloatType),
+                new SimpleEntry<>("int",     DataTypes.IntegerType),
+                new SimpleEntry<>("long",    DataTypes.LongType),
+                new SimpleEntry<>("null",    DataTypes.NullType),
+                new SimpleEntry<>("string",  DataTypes.StringType)
+        ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+        typeMappings.forEach((avroType, sparkType) -> {
+            val avroSchema = avroSchemaWithSimpleType(avroType);
+            val expectedSchema = sparkSchemaWithType(sparkType);
+            val result = underTest.convert(avroSchema);
+            assertEquals(expectedSchema, result);
+        });
+    }
+
+    @Test
+    public void shouldConvertAllLogicalFieldTypesToCorrectSparkType() {
+        val typeMappings = Stream.of(
+                new SimpleEntry<>("date",             DataTypes.DateType),
+                new SimpleEntry<>("timestamp-millis", DataTypes.TimestampType),
+                new SimpleEntry<>("timestamp-micros", DataTypes.TimestampType),
+                new SimpleEntry<>("time-micros",      DataTypes.TimestampType),
+                new SimpleEntry<>("time-millis",      DataTypes.TimestampType)
+        ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        typeMappings.forEach((avroType, sparkType) -> {
+            val avroSchema = avroSchemaWithLogicalType(avroType);
+            val expectedSchema = sparkSchemaWithType(sparkType);
+            val result = underTest.convert(avroSchema);
+            assertEquals(expectedSchema, result);
+        });
+    }
+
+    private String avroSchemaWithSimpleType(String type) {
         val fakeSchema = "{ " +
-                "\"fields\": [ " +
-                    "{ " +
-                    "\"name\": \"some-field\", " +
-                    "\"type\": \"string\", " +
+                "\"fields\": [{ " +
+                    "\"name\": \"aField\", " +
+                    "\"type\": \"TYPE\", " +
                     "\"nullable\": false " +
-                    " }]} ";
+                " }]} ";
+       return fakeSchema.replace("TYPE", type);
+    }
 
-        val result = underTest.convert(fakeSchema);
-        val expectedSchema = new StructType().add("some-field", "string", false);
+    private String avroSchemaWithLogicalType(String type) {
+        val fakeSchema = "{ " +
+                "\"fields\": [{ " +
+                    "\"name\": \"aField\", " +
+                    "\"type\": { " +
+                        "\"type\": \"int\", " +
+                        "\"logicalType\": \"TYPE\" " +
+                    "}, " +
+                    "\"nullable\": false " +
+                " }]} ";
+        return fakeSchema.replace("TYPE", type);
+    }
 
-        assertEquals(expectedSchema, result);
+    private StructType sparkSchemaWithType(DataType type) {
+        return new StructType().add("aField", type, false);
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6_ConverterTest.java
+++ b/src/test/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6_ConverterTest.java
@@ -35,8 +35,6 @@ class DMS_3_4_6_ConverterTest extends BaseSparkTest {
 
         val converted = underTest.convert(rdd);
 
-        converted.show(false);
-
         val columnNames = Arrays.asList(converted.columns());
 
         assertTrue(columnNames.contains(RAW));
@@ -51,7 +49,9 @@ class DMS_3_4_6_ConverterTest extends BaseSparkTest {
         assertTrue(columnNames.contains(CONVERTER));
 
         assertFalse(converted.isEmpty());
+
         val row = converted.first();
+
         assertNotNull(row);
 
         assertNotNull(row.getAs(RAW));
@@ -73,8 +73,6 @@ class DMS_3_4_6_ConverterTest extends BaseSparkTest {
 
         val converted = underTest.convert(rdd);
 
-        converted.show(false);
-
         val columnNames = Arrays.asList(converted.columns());
 
         assertTrue(columnNames.contains(RAW));
@@ -89,7 +87,9 @@ class DMS_3_4_6_ConverterTest extends BaseSparkTest {
         assertTrue(columnNames.contains(CONVERTER));
 
         assertFalse(converted.isEmpty());
+
         val row = converted.first();
+
         assertNotNull(row);
 
         assertNotNull(row.getAs(RAW));

--- a/src/test/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6_ConverterTest.java
+++ b/src/test/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6_ConverterTest.java
@@ -5,26 +5,25 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.config.BaseSparkTest;
-
 import java.util.Arrays;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 
 import static org.apache.spark.sql.functions.col;
 import static org.junit.jupiter.api.Assertions.*;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 
 class DMS_3_4_6_ConverterTest extends BaseSparkTest {
 
     private static final String DATA_PATH = "src/test/resources/data/dms_record.json";
     private static final String CONTROL_PATH = "src/test/resources/data/null-data-dms-record.json";
-    private static final DMS_3_4_6 underTest = new DMS_3_4_6();
-
+    private static final DMS_3_4_6 underTest = new DMS_3_4_6(new SparkSessionProvider());
 
     @Test
     void shouldConvertValidDataCorrectly() {
         // Load JSON as text and slurp in the context of the whole file so we can read multiline JSON files.
         val rdd = getData(DATA_PATH);
 
-        val converted = underTest.convert(rdd, spark);
+        val converted = underTest.convert(rdd);
 
         // Strict schema validation is applied so checking accounts agree should be sufficient here.
         assertEquals(rdd.count(), converted.count());
@@ -34,8 +33,7 @@ class DMS_3_4_6_ConverterTest extends BaseSparkTest {
     void shouldConvertARawDataRecordIntoTheCorrectColumns() {
         val rdd = getData(DATA_PATH);
 
-        val converted = underTest.convert(rdd, spark);
-        System.out.println("3.4.6 Dataframe");
+        val converted = underTest.convert(rdd);
 
         converted.show(false);
 
@@ -73,8 +71,7 @@ class DMS_3_4_6_ConverterTest extends BaseSparkTest {
     void shouldConvertARawControlRecordIntoTheCorrectColumns() {
         val rdd = getData(CONTROL_PATH);
 
-        val converted = underTest.convert(rdd, spark);
-        System.out.println("3.4.6 Dataframe");
+        val converted = underTest.convert(rdd);
 
         converted.show(false);
 

--- a/src/test/java/uk/gov/justice/digital/zone/Fixtures.java
+++ b/src/test/java/uk/gov/justice/digital/zone/Fixtures.java
@@ -4,7 +4,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.types.StructType;
 
 import static org.apache.spark.sql.types.DataTypes.StringType;
-import static uk.gov.justice.digital.converter.Converter.ParsedDataFields.*;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 
 public class Fixtures {
 


### PR DESCRIPTION
Summary of changes
* added converter that takes an avro schema and converts it into a spark schema using the spark-avro support
* added tests to cover conversion of all declared types
* simplified converter so we have an interface with a single method and refactored