### PR TITLE
DPR-521 Allow dates represented as datetimes to pass validation if time value is zeroed

### DIFF
--- a/src/test/java/uk/gov/justice/digital/job/udf/JsonValidatorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/udf/JsonValidatorTest.java
@@ -146,6 +146,18 @@ class JsonValidatorTest {
         );
     }
 
+    @Test
+    public void shouldFailWithoutThrowingExceptionsForAnInvalidValue() throws JsonProcessingException {
+        val rawJson = createJsonFromEntries(Collections.singletonList(entry(Fields.DATE, "fooTbar")));
+        // Parsing the invalid string as a Date would yield a null result which we represent as an empty string here.
+        val parsedJson = createJsonFromEntries(Collections.singletonList(entry(Fields.DATE, "")));
+
+        assertFalse(
+                underTest.validate(rawJson, parsedJson, schemaWithDate),
+                "Validator should fail when raw string contains an invalid value."
+        );
+    }
+
     private static SimpleEntry<String, Object> entry(String key, Object value) {
         return new SimpleEntry<>(key, value);
     }


### PR DESCRIPTION
Summary of changes
* revised the json comparision so we compare the data using Maps which contain the original and parsed data (where the avro schema has been applied)
* validator now reformats datetime strings in the original data where
  * the date string contains a `T`indicating that it might be an ISO 8601 date time string
  * the time part contains no digits except 0
  * otherwise the date value is left as is
 * the validator then continues as before comparing the original data with reformatted dates against the parsed data
 * this will then allow validation to pass where some dates were originally represented using date times
 * test updates to cover the new work