### PR TITLE
DPR-198: Use extracted dataframe as input to structured zone

### DIFF
--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -87,15 +87,15 @@ public class DataHubJob implements Runnable {
             getTablesInBatch(dataFrame).forEach(table -> {
                 try {
                     val dataFrameForTable = extractDataFrameForSourceTable(dataFrame, table);
+                    dataFrameForTable.persist();
 
-                    val rawDataFrame = rawZone.process(spark, dataFrameForTable, table);
-                    rawDataFrame.persist();
+                    rawZone.process(spark, dataFrameForTable, table);
 
-                    val structuredDataFrame = structuredZone.processLoad(spark, rawDataFrame, table);
-                    curatedZone.processLoad(spark, structuredDataFrame, table);
+                    val structuredLoadDataFrame = structuredZone.processLoad(spark, dataFrameForTable, table);
+                    curatedZone.processLoad(spark, structuredLoadDataFrame, table);
 
-                    val structuredIncrementalDataFrame = structuredZone.processCDC(spark, rawDataFrame, table);
-                    curatedZone.processCDC(spark, structuredIncrementalDataFrame, table);
+                    val structuredCDCDataFrame = structuredZone.processCDC(spark, dataFrameForTable, table);
+                    curatedZone.processCDC(spark, structuredCDCDataFrame, table);
                 } catch (Exception e) {
                     logger.error("Caught unexpected exception", e);
                     throw new RuntimeException("Caught unexpected exception", e);


### PR DESCRIPTION
This PR uses the extracted dataframe to create the structured zone data.
This was wrongly changed to use the raw zone data in my previous [PR](https://github.com/ministryofjustice/digital-prison-reporting-jobs/pull/89/files#diff-3a476dcab1d8f8a05ec230340802b150d53cc79770505951e96d4af5ccb2c6d4L93-R69).