### PR TITLE
DPR-311: Apply CDC events to structured zone

### DIFF
--- a/src/it/java/uk/gov/justice/digital/zone/StructuredZoneIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/zone/StructuredZoneIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.zone;
 
-import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
@@ -14,7 +13,6 @@ import uk.gov.justice.digital.client.glue.GlueSchemaClient;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.converter.avro.AvroToSparkSchemaConverter;
-import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DataStorageService;
@@ -22,19 +20,13 @@ import uk.gov.justice.digital.service.SourceReferenceService;
 import uk.gov.justice.digital.test.SparkTestHelpers;
 
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.spark.sql.functions.col;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.zone.Fixtures.*;
-import static uk.gov.justice.digital.zone.Fixtures.TABLE_NAME;
 
 
-public class StructuredZoneIntegrationTest extends BaseSparkTest {
+public class StructuredZoneIntegrationTest extends BaseSparkTest implements Fixtures {
     private SparkTestHelpers helpers = new SparkTestHelpers(spark);
     private final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
 
@@ -87,10 +79,11 @@ public class StructuredZoneIntegrationTest extends BaseSparkTest {
 
         assertTrue(hasNullColumns(offenders));
 
-        Dataset<Row> result = underTest.processLoad(
+        Dataset<Row> result = underTest.process(
                 spark,
                 offenders,
-                new GenericRowWithSchema(new Object[] { "oms_owner", "offenders", "load" }, Fixtures.ROW_SCHEMA)
+                new GenericRowWithSchema(new Object[] { "oms_owner", "offenders", "load" }, Fixtures.ROW_SCHEMA),
+                false
         );
 
         assertTrue(hasNullColumns(result));

--- a/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
+++ b/src/main/java/uk/gov/justice/digital/converter/dms/DMS_3_4_6.java
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.provider.SparkSessionProvider;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.types.DataTypes.StringType;
@@ -78,12 +77,7 @@ public class DMS_3_4_6 implements Converter<JavaRDD<Row>, Dataset<Row>> {
             return Arrays.stream(values()).filter(it -> it.name().equalsIgnoreCase(operation)).findAny();
         }
 
-        private static final DMS_3_4_6.Operation[] cdcOperations = { Insert, Update, Delete };
-
-        public static final Set<String> cdcOperationsSet = Arrays
-                .stream(cdcOperations)
-                .map(DMS_3_4_6.Operation::getName)
-                .collect(Collectors.toSet());
+        public static final Object[] cdcOperations = { Insert.getName(), Update.getName(), Delete.getName() };
     }
 
     // This schema defines the common output format to be created from the incoming data.

--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -91,11 +91,11 @@ public class DataHubJob implements Runnable {
 
                     rawZone.process(spark, dataFrameForTable, table);
 
-                    val structuredLoadDataFrame = structuredZone.processLoad(spark, dataFrameForTable, table);
-                    curatedZone.processLoad(spark, structuredLoadDataFrame, table);
+                    val structuredLoadDataFrame = structuredZone.process(spark, dataFrameForTable, table, false);
+                    curatedZone.process(spark, structuredLoadDataFrame, table, false);
 
-                    val structuredIncrementalDataFrame = structuredZone.processCDC(spark, dataFrameForTable, table);
-                    curatedZone.processCDC(spark, structuredIncrementalDataFrame, table);
+                    val structuredIncrementalDataFrame = structuredZone.process(spark, dataFrameForTable, table, true);
+                    curatedZone.process(spark, structuredIncrementalDataFrame, table, true);
                 } catch (Exception e) {
                     logger.error("Caught unexpected exception", e);
                     throw new RuntimeException("Caught unexpected exception", e);

--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -94,8 +94,8 @@ public class DataHubJob implements Runnable {
                     val structuredLoadDataFrame = structuredZone.processLoad(spark, dataFrameForTable, table);
                     curatedZone.processLoad(spark, structuredLoadDataFrame, table);
 
-                    val structuredCDCDataFrame = structuredZone.processCDC(spark, dataFrameForTable, table);
-                    curatedZone.processCDC(spark, structuredCDCDataFrame, table);
+                    val structuredIncrementalDataFrame = structuredZone.processCDC(spark, dataFrameForTable, table);
+                    curatedZone.processCDC(spark, structuredIncrementalDataFrame, table);
                 } catch (Exception e) {
                     logger.error("Caught unexpected exception", e);
                     throw new RuntimeException("Caught unexpected exception", e);

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -70,14 +70,16 @@ public class DataStorageService {
         }
     }
 
-    public void update(String tablePath, Dataset<Row> dataFrame, String primaryKey) throws DataStorageException {
+    public void updateRecords(
+            String tablePath,
+            Dataset<Row> dataFrame,
+            SourceReference.PrimaryKey primaryKey) throws DataStorageException {
         val dt = getTable(dataFrame.sparkSession(), tablePath);
 
         if (dt != null) {
-            val spk = SOURCE + "." + primaryKey;
-            val tpk = TARGET + "." + primaryKey;
+            final String condition = primaryKey.getSparkCondition(SOURCE, TARGET);
             dt.as(SOURCE)
-                    .merge(dataFrame.as(TARGET), spk + "=" + tpk)
+                    .merge(dataFrame.as(TARGET), condition)
                     .whenMatched()
                     .updateAll()
                     .execute();
@@ -88,11 +90,14 @@ public class DataStorageService {
         }
     }
 
-    public void deleteRecords(String tablePath, Dataset<Row> dataFrame, String primaryKey) throws DataStorageException {
+    public void deleteRecords(
+            String tablePath,
+            Dataset<Row> dataFrame,
+            String primaryKeyFieldName) throws DataStorageException {
         val dt = getTable(dataFrame.sparkSession(), tablePath);
 
         if (dt != null) {
-            dt.delete(functions.col(primaryKey).eqNullSafe(dataFrame.col(primaryKey)));
+            dt.delete(functions.col(primaryKeyFieldName).eqNullSafe(dataFrame.col(primaryKeyFieldName)));
         } else {
             val errorMessage = "Failed to access Delta table for delete";
             logger.error(errorMessage);

--- a/src/main/java/uk/gov/justice/digital/zone/CuratedZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/CuratedZone.java
@@ -37,7 +37,7 @@ public class CuratedZone extends FilteredZone {
     }
 
     @Override
-    public Dataset<Row> processLoad(SparkSession spark, Dataset<Row> dataFrame, Row table) throws DataStorageException {
+    public Dataset<Row> process(SparkSession spark, Dataset<Row> dataFrame, Row table, Boolean isCDC) throws DataStorageException {
 
         val count = dataFrame.count();
 
@@ -76,11 +76,5 @@ public class CuratedZone extends FilteredZone {
 
             return dataFrame;
         } else return createEmptyDataFrame(dataFrame);
-    }
-
-    @Override
-    public Dataset<Row> processCDC(SparkSession spark, Dataset<Row> dataFrame, Row row) throws DataStorageException {
-        // TODO: DPR-314 - Apply CDC to Curated Zone
-        return null;
     }
 }

--- a/src/main/java/uk/gov/justice/digital/zone/FilteredZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/FilteredZone.java
@@ -7,9 +7,12 @@ import uk.gov.justice.digital.exception.DataStorageException;
 
 public abstract class FilteredZone {
 
-    public abstract Dataset<Row> processLoad(SparkSession spark, Dataset<Row> dataFrame, Row row) throws DataStorageException;
-
-    public abstract Dataset<Row> processCDC(SparkSession spark, Dataset<Row> dataFrame, Row row) throws DataStorageException;
+    public abstract Dataset<Row> process(
+            SparkSession spark,
+            Dataset<Row> dataFrame,
+            Row table,
+            Boolean isCDC
+    ) throws DataStorageException;
 
     protected Dataset<Row> createEmptyDataFrame(Dataset<Row> dataFrame) {
         return dataFrame.sparkSession().createDataFrame(

--- a/src/test/java/uk/gov/justice/digital/zone/CuratedZoneTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/CuratedZoneTest.java
@@ -21,10 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.config.JobArguments.CURATED_S3_PATH;
-import static uk.gov.justice.digital.zone.Fixtures.*;
 
 @ExtendWith(MockitoExtension.class)
-class CuratedZoneTest {
+class CuratedZoneTest implements Fixtures {
 
     private static final JobArguments jobArguments =
             new JobArguments(Collections.singletonMap(CURATED_S3_PATH, CURATED_PATH));
@@ -60,6 +59,6 @@ class CuratedZoneTest {
 
         val underTest = new CuratedZone(jobArguments, mockDataStorageService, mockSourceReferenceService);
 
-        assertNotNull(underTest.processLoad(mockSparkSession, mockedDataSet, dataMigrationEventRow));
+        assertNotNull(underTest.process(mockSparkSession, mockedDataSet, dataMigrationEventRow, false));
     }
 }

--- a/src/test/java/uk/gov/justice/digital/zone/Fixtures.java
+++ b/src/test/java/uk/gov/justice/digital/zone/Fixtures.java
@@ -10,40 +10,40 @@ import java.util.Arrays;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 import static uk.gov.justice.digital.zone.RawZone.PRIMARY_KEY_NAME;
 
-public class Fixtures {
+public interface Fixtures {
 
-    public static final String RAW_PATH = "s3://loadjob/raw";
-    public static final String CURATED_PATH = "s3://loadjob/curated";
-    public static final String STRUCTURED_PATH = "s3://loadjob/structured";
-    public static final String VIOLATIONS_PATH = "s3://loadjob/violations";
+    String RAW_PATH = "s3://loadjob/raw";
+    String CURATED_PATH = "s3://loadjob/curated";
+    String STRUCTURED_PATH = "s3://loadjob/structured";
+    String VIOLATIONS_PATH = "s3://loadjob/violations";
 
-    public static final String TABLE_SOURCE = "oms_owner";
-    public static final String TABLE_NAME = "agency_internal_locations";
-    public static final String TABLE_OPERATION = "load";
-    public static final String ROW_CONVERTER = "row_converter";
+    String TABLE_SOURCE = "oms_owner";
+    String TABLE_NAME = "agency_internal_locations";
+    String TABLE_OPERATION = "load";
+    String ROW_CONVERTER = "row_converter";
 
-    public static final String RECORD_KEY_1 = "record-1";
-    public static final String RECORD_KEY_2 = "record-2";
-    public static final String RECORD_KEY_3 = "record-3";
-    public static final String RECORD_KEY_4 = "record-4";
-    public static final String RECORD_KEY_5 = "record-5";
-    public static final String RECORD_KEY_6 = "record-6";
-    public static final String RECORD_KEY_7 = "record-7";
+    String RECORD_KEY_1 = "record-1";
+    String RECORD_KEY_2 = "record-2";
+    String RECORD_KEY_3 = "record-3";
+    String RECORD_KEY_4 = "record-4";
+    String RECORD_KEY_5 = "record-5";
+    String RECORD_KEY_6 = "record-6";
+    String RECORD_KEY_7 = "record-7";
 
-    public static final String PRIMARY_KEY_PLACEHOLDER = "<PRIMARY-KEY>";
+    String PRIMARY_KEY_PLACEHOLDER = "<PRIMARY-KEY>";
 
-    public static String PRIMARY_KEY_FIELD = "primary-key";
+    String PRIMARY_KEY_FIELD = "primary-key";
 
-    public static String STRING_FIELD_KEY = "string-key";
-    public static String STRING_FIELD_VALUE = "stringValue";
+    String STRING_FIELD_KEY = "string-key";
+    String STRING_FIELD_VALUE = "stringValue";
 
-    public static String NULL_FIELD_KEY = "null-key";
-    public static String NUMBER_FIELD_KEY = "number-key";
-    public static Float NUMBER_FIELD_VALUE = 1.0F;
-    public static String ARRAY_FIELD_KEY = "array-key";
-    public static int[] ARRAY_FIELD_VALUE = { 1, 2, 3 };
+    String NULL_FIELD_KEY = "null-key";
+    String NUMBER_FIELD_KEY = "number-key";
+    Float NUMBER_FIELD_VALUE = 1.0F;
+    String ARRAY_FIELD_KEY = "array-key";
+    int[] ARRAY_FIELD_VALUE = { 1, 2, 3 };
 
-    public static final String JSON_DATA =
+    String JSON_DATA =
             "{" +
                     "\"" + PRIMARY_KEY_FIELD + "\": \"" + PRIMARY_KEY_PLACEHOLDER + "\"," +
                     "\"" + STRING_FIELD_KEY + "\": \"" + STRING_FIELD_VALUE + "\"," +
@@ -52,29 +52,29 @@ public class Fixtures {
                     "\"" + ARRAY_FIELD_KEY + "\": " + Arrays.toString(ARRAY_FIELD_VALUE) +
             "}";
 
-    public static final String recordData1 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_1);
-    public static final String recordData2 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_2);
-    public static final String recordData3 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_3);
-    public static final String recordData4 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_4);
-    public static final String recordData5 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_5);
-    public static final String recordData6 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_6);
-    public static final String recordData7 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_7);
+    String recordData1 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_1);
+    String recordData2 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_2);
+    String recordData3 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_3);
+    String recordData4 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_4);
+    String recordData5 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_5);
+    String recordData6 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_6);
+    String recordData7 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_7);
 
-    public static final StructType JSON_DATA_SCHEMA = new StructType()
+    StructType JSON_DATA_SCHEMA = new StructType()
             .add(PRIMARY_KEY_FIELD, DataTypes.StringType, false)
             .add(STRING_FIELD_KEY, DataTypes.StringType, false)
             .add(NULL_FIELD_KEY, DataTypes.StringType, true)
             .add(NUMBER_FIELD_KEY, DataTypes.FloatType, false)
             .add(ARRAY_FIELD_KEY, new ArrayType(DataTypes.IntegerType, false), false);
 
-    public static final StructType STRUCTURED_RECORD_WITH_OPERATION_SCHEMA = JSON_DATA_SCHEMA
+    StructType STRUCTURED_RECORD_WITH_OPERATION_SCHEMA = JSON_DATA_SCHEMA
             .add(OPERATION, DataTypes.StringType, false);
 
-    public static final String GENERIC_METADATA = "{}";
-    public static final String GENERIC_TIMESTAMP = "1";
-    public static final String GENERIC_KEY = "row_key";
+    String GENERIC_METADATA = "{}";
+    String GENERIC_TIMESTAMP = "1";
+    String GENERIC_KEY = "row_key";
 
-    public static final StructType ROW_SCHEMA = new StructType()
+    StructType ROW_SCHEMA = new StructType()
             .add(TIMESTAMP, DataTypes.StringType, false)
             .add(KEY, DataTypes.StringType, false)
             .add(SOURCE, DataTypes.StringType, false)
@@ -85,7 +85,7 @@ public class Fixtures {
             .add(DATA, DataTypes.StringType, true)
             .add(METADATA, DataTypes.StringType, false);
 
-    public static final GenericRowWithSchema dataMigrationEventRow = new GenericRowWithSchema(
+    GenericRowWithSchema dataMigrationEventRow = new GenericRowWithSchema(
             new Object[] {
                     GENERIC_TIMESTAMP,
                     GENERIC_KEY,
@@ -101,7 +101,7 @@ public class Fixtures {
     );
 
 
-    public static final StructType EXPECTED_RAW_SCHEMA = new StructType()
+    StructType EXPECTED_RAW_SCHEMA = new StructType()
             .add(PRIMARY_KEY_NAME, DataTypes.StringType, false)
             .add(TIMESTAMP, DataTypes.StringType, false)
             .add(KEY, DataTypes.StringType, false)
@@ -110,7 +110,5 @@ public class Fixtures {
             .add(OPERATION, DataTypes.StringType, false)
             .add(CONVERTER, DataTypes.StringType, false)
             .add(RAW, DataTypes.StringType, false);
-
-    private Fixtures() { }
 
 }

--- a/src/test/java/uk/gov/justice/digital/zone/Fixtures.java
+++ b/src/test/java/uk/gov/justice/digital/zone/Fixtures.java
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.zone;
 
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 
-import static org.apache.spark.sql.types.DataTypes.StringType;
+import java.util.Arrays;
+
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
 import static uk.gov.justice.digital.zone.RawZone.PRIMARY_KEY_NAME;
 
@@ -19,35 +21,88 @@ public class Fixtures {
     public static final String TABLE_NAME = "agency_internal_locations";
     public static final String TABLE_OPERATION = "load";
     public static final String ROW_CONVERTER = "row_converter";
-    public static final String RAW_DATA = "{}";
+
+    public static final String RECORD_KEY_1 = "record-1";
+    public static final String RECORD_KEY_2 = "record-2";
+    public static final String RECORD_KEY_3 = "record-3";
+    public static final String RECORD_KEY_4 = "record-4";
+    public static final String RECORD_KEY_5 = "record-5";
+    public static final String RECORD_KEY_6 = "record-6";
+    public static final String RECORD_KEY_7 = "record-7";
+
+    public static final String PRIMARY_KEY_PLACEHOLDER = "<PRIMARY-KEY>";
+
+    public static String PRIMARY_KEY_FIELD = "primary-key";
+
+    public static String STRING_FIELD_KEY = "string-key";
+    public static String STRING_FIELD_VALUE = "stringValue";
+
+    public static String NULL_FIELD_KEY = "null-key";
+    public static String NUMBER_FIELD_KEY = "number-key";
+    public static Float NUMBER_FIELD_VALUE = 1.0F;
+    public static String ARRAY_FIELD_KEY = "array-key";
+    public static int[] ARRAY_FIELD_VALUE = { 1, 2, 3 };
+
+    public static final String JSON_DATA =
+            "{" +
+                    "\"" + PRIMARY_KEY_FIELD + "\": \"" + PRIMARY_KEY_PLACEHOLDER + "\"," +
+                    "\"" + STRING_FIELD_KEY + "\": \"" + STRING_FIELD_VALUE + "\"," +
+                    "\"" + NULL_FIELD_KEY + "\": null," +
+                    "\"" + NUMBER_FIELD_KEY + "\": " + NUMBER_FIELD_VALUE + "," +
+                    "\"" + ARRAY_FIELD_KEY + "\": " + Arrays.toString(ARRAY_FIELD_VALUE) +
+            "}";
+
+    public static final String recordData1 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_1);
+    public static final String recordData2 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_2);
+    public static final String recordData3 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_3);
+    public static final String recordData4 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_4);
+    public static final String recordData5 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_5);
+    public static final String recordData6 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_6);
+    public static final String recordData7 = JSON_DATA.replaceAll(PRIMARY_KEY_PLACEHOLDER, RECORD_KEY_7);
+
+    public static final StructType JSON_DATA_SCHEMA = new StructType()
+            .add(PRIMARY_KEY_FIELD, DataTypes.StringType, false)
+            .add(STRING_FIELD_KEY, DataTypes.StringType, false)
+            .add(NULL_FIELD_KEY, DataTypes.StringType, true)
+            .add(NUMBER_FIELD_KEY, DataTypes.FloatType, false)
+            .add(ARRAY_FIELD_KEY, new ArrayType(DataTypes.IntegerType, false), false);
+
+    public static final StructType STRUCTURED_RECORD_WITH_OPERATION_SCHEMA = JSON_DATA_SCHEMA
+            .add(OPERATION, DataTypes.StringType, false);
+
+    public static final String GENERIC_METADATA = "{}";
+    public static final String GENERIC_TIMESTAMP = "1";
+    public static final String GENERIC_KEY = "row_key";
 
     public static final StructType ROW_SCHEMA = new StructType()
-            .add(SOURCE, StringType, false)
-            .add(TABLE, StringType, false)
-            .add(OPERATION, StringType, false);
-
-    public static final GenericRowWithSchema dataMigrationEventRow = new GenericRowWithSchema(
-            new Object[] { TABLE_SOURCE, TABLE_NAME, TABLE_OPERATION },
-            ROW_SCHEMA
-        );
-
-    public static final GenericRowWithSchema dataMigrationEventRowWithInvalidOperation = new GenericRowWithSchema(
-            new Object[] { TABLE_SOURCE, TABLE_NAME, "makeTea" },
-            ROW_SCHEMA
-    );
-
-
-    public static final StructType EXPECTED_RAW_SCHEMA = new StructType()
-            .add(PRIMARY_KEY_NAME, DataTypes.StringType, false)
             .add(TIMESTAMP, DataTypes.StringType, false)
             .add(KEY, DataTypes.StringType, false)
             .add(SOURCE, DataTypes.StringType, false)
             .add(TABLE, DataTypes.StringType, false)
             .add(OPERATION, DataTypes.StringType, false)
             .add(CONVERTER, DataTypes.StringType, false)
-            .add(RAW, DataTypes.StringType, false);
+            .add(RAW, DataTypes.StringType, false)
+            .add(DATA, DataTypes.StringType, true)
+            .add(METADATA, DataTypes.StringType, false);
 
-    public static final StructType RECORD_SCHEMA = new StructType() // TODO: Consolidate this and ROW_SCHEMA as part of DPR-310, DPR-314, DPR-311
+    public static final GenericRowWithSchema dataMigrationEventRow = new GenericRowWithSchema(
+            new Object[] {
+                    GENERIC_TIMESTAMP,
+                    GENERIC_KEY,
+                    TABLE_SOURCE,
+                    TABLE_NAME,
+                    TABLE_OPERATION,
+                    ROW_CONVERTER,
+                    JSON_DATA,
+                    JSON_DATA,
+                    GENERIC_METADATA
+            },
+            ROW_SCHEMA
+    );
+
+
+    public static final StructType EXPECTED_RAW_SCHEMA = new StructType()
+            .add(PRIMARY_KEY_NAME, DataTypes.StringType, false)
             .add(TIMESTAMP, DataTypes.StringType, false)
             .add(KEY, DataTypes.StringType, false)
             .add(SOURCE, DataTypes.StringType, false)

--- a/src/test/java/uk/gov/justice/digital/zone/RawZoneTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/RawZoneTest.java
@@ -74,15 +74,15 @@ class RawZoneTest extends BaseSparkTest {
 
     private Dataset<Row> createTestRecords() {
         val rawData = new ArrayList<Row>();
-        rawData.add(RowFactory.create("3", "load-record-key1", TABLE_SOURCE, TABLE_NAME, Load.getName(), ROW_CONVERTER, RAW_DATA));
-        rawData.add(RowFactory.create("1", "load-record-key2", TABLE_SOURCE, TABLE_NAME, Load.getName(), ROW_CONVERTER, RAW_DATA));
-        rawData.add(RowFactory.create("2", "load-record-key3", TABLE_SOURCE, TABLE_NAME, Load.getName(), ROW_CONVERTER, RAW_DATA));
-        rawData.add(RowFactory.create("0", "insert-record-key1", TABLE_SOURCE, TABLE_NAME, Insert.getName(), ROW_CONVERTER, RAW_DATA));
-        rawData.add(RowFactory.create("4", "insert-record-key2", TABLE_SOURCE, TABLE_NAME, Insert.getName(), ROW_CONVERTER, RAW_DATA));
-        rawData.add(RowFactory.create("6", "update-record-key1", TABLE_SOURCE, TABLE_NAME, Update.getName(), ROW_CONVERTER, RAW_DATA));
-        rawData.add(RowFactory.create("5", "delete-record-key1", TABLE_SOURCE, TABLE_NAME, Delete.getName(), ROW_CONVERTER, RAW_DATA));
+        rawData.add(RowFactory.create("3", "load-record-key1", TABLE_SOURCE, TABLE_NAME, Load.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
+        rawData.add(RowFactory.create("1", "load-record-key2", TABLE_SOURCE, TABLE_NAME, Load.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
+        rawData.add(RowFactory.create("2", "load-record-key3", TABLE_SOURCE, TABLE_NAME, Load.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
+        rawData.add(RowFactory.create("0", "insert-record-key1", TABLE_SOURCE, TABLE_NAME, Insert.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
+        rawData.add(RowFactory.create("4", "insert-record-key2", TABLE_SOURCE, TABLE_NAME, Insert.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
+        rawData.add(RowFactory.create("6", "update-record-key1", TABLE_SOURCE, TABLE_NAME, Update.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
+        rawData.add(RowFactory.create("5", "delete-record-key1", TABLE_SOURCE, TABLE_NAME, Delete.getName(), ROW_CONVERTER, JSON_DATA, "{}", "{}"));
 
-        return spark.createDataFrame(rawData, RECORD_SCHEMA);
+        return spark.createDataFrame(rawData, ROW_SCHEMA);
     }
 
     private Dataset<Row> createExpectedRecords() {
@@ -97,7 +97,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Load.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
 
@@ -110,7 +110,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Load.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
         expectedRawData.add(
@@ -122,7 +122,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Load.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
 
@@ -135,7 +135,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Insert.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
 
@@ -148,7 +148,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Insert.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
 
@@ -161,7 +161,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Update.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
 
@@ -174,7 +174,7 @@ class RawZoneTest extends BaseSparkTest {
                         TABLE_NAME,
                         Delete.getName(),
                         ROW_CONVERTER,
-                        RAW_DATA
+                        JSON_DATA
                 )
         );
 

--- a/src/test/java/uk/gov/justice/digital/zone/RawZoneTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/RawZoneTest.java
@@ -26,10 +26,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation.*;
-import static uk.gov.justice.digital.zone.Fixtures.*;
 
 @ExtendWith(MockitoExtension.class)
-class RawZoneTest extends BaseSparkTest {
+class RawZoneTest extends BaseSparkTest implements Fixtures {
 
     private static final JobArguments jobArguments =
             new JobArguments(Collections.singletonMap(JobArguments.RAW_S3_PATH, RAW_PATH));

--- a/src/test/java/uk/gov/justice/digital/zone/StructuredZoneFixture.java
+++ b/src/test/java/uk/gov/justice/digital/zone/StructuredZoneFixture.java
@@ -1,0 +1,132 @@
+package uk.gov.justice.digital.zone;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation.*;
+
+public interface StructuredZoneFixture extends Fixtures {
+    // input records
+    Row record1Load = RowFactory.create(
+            "3",
+            RECORD_KEY_1,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Load.getName(),
+            ROW_CONVERTER,
+            recordData1,
+            recordData1,
+            GENERIC_METADATA
+    );
+    Row record2Load = RowFactory.create(
+            "1",
+            RECORD_KEY_2,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Load.getName(),
+            ROW_CONVERTER,
+            recordData2,
+            recordData2,
+            GENERIC_METADATA
+    );
+    Row record3Load = RowFactory.create(
+            "2",
+            RECORD_KEY_3,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Load.getName(),
+            ROW_CONVERTER,
+            recordData3,
+            recordData3,
+            GENERIC_METADATA
+    );
+    Row record4Insert = RowFactory.create(
+            "0",
+            RECORD_KEY_4,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Insert.getName(),
+            ROW_CONVERTER,
+            recordData4,
+            recordData4,
+            GENERIC_METADATA
+    );
+    Row record5Insert = RowFactory.create(
+            "4",
+            RECORD_KEY_5,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Insert.getName(),
+            ROW_CONVERTER,
+            recordData5,
+            recordData5,
+            GENERIC_METADATA
+    );
+    Row record6Insert = RowFactory.create(
+            "5",
+            RECORD_KEY_6,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Insert.getName(),
+            ROW_CONVERTER,
+            recordData6,
+            recordData6,
+            GENERIC_METADATA
+    );
+    Row record7Update = RowFactory.create(
+            "6",
+            RECORD_KEY_7,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Update.getName(),
+            ROW_CONVERTER,
+            recordData7,
+            recordData7,
+            GENERIC_METADATA
+    );
+    Row record6Deletion = RowFactory.create(
+            "7",
+            RECORD_KEY_6,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Delete.getName(),
+            ROW_CONVERTER,
+            recordData6,
+            recordData6,
+            GENERIC_METADATA
+    );
+    Row record5Update = RowFactory.create(
+            "8",
+            RECORD_KEY_5,
+            TABLE_SOURCE,
+            TABLE_NAME,
+            Update.getName(),
+            ROW_CONVERTER,
+            recordData5,
+            recordData5,
+            GENERIC_METADATA
+    );
+
+    // structured load records
+    Row structuredRecord2Load = RowFactory
+            .create(RECORD_KEY_2, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Load.getName());
+    Row structuredRecord3Load = RowFactory
+            .create(RECORD_KEY_3, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Load.getName());
+    Row structuredRecord1Load = RowFactory
+            .create(RECORD_KEY_1, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Load.getName());
+
+
+    // structured insert, update, and delete records
+    Row structuredRecord4Insertion = RowFactory
+            .create(RECORD_KEY_4, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Insert.getName());
+    Row structuredRecord5Insertion = RowFactory
+            .create(RECORD_KEY_5, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Insert.getName());
+    Row structuredRecord6Insertion = RowFactory
+            .create(RECORD_KEY_6, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Insert.getName());
+    Row structuredRecord7Update = RowFactory
+            .create(RECORD_KEY_7, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Update.getName());
+    Row structuredRecord6Deletion = RowFactory
+            .create(RECORD_KEY_6, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Delete.getName());
+    Row structuredRecord5Update = RowFactory
+            .create(RECORD_KEY_5, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Update.getName());
+}

--- a/src/test/java/uk/gov/justice/digital/zone/StructuredZoneTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/StructuredZoneTest.java
@@ -4,10 +4,11 @@ package uk.gov.justice.digital.zone;
 import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
@@ -17,18 +18,19 @@ import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.service.SourceReferenceService;
 
-import java.util.ArrayList;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation.*;
-import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation.Delete;
-import static uk.gov.justice.digital.zone.Fixtures.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.KEY;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.zone.RawZone.PRIMARY_KEY_NAME;
 
 @ExtendWith(MockitoExtension.class)
-class StructuredZoneTest extends BaseSparkTest {
+class StructuredZoneTest extends BaseSparkTest implements StructuredZoneFixture {
 
     @Mock
     private JobArguments mockJobArguments;
@@ -42,12 +44,17 @@ class StructuredZoneTest extends BaseSparkTest {
     @Mock
     private SourceReferenceService mockSourceReferenceService;
 
+    @Captor
+    ArgumentCaptor<Dataset<Row>> dataframeCaptor;
+
     private StructuredZone underTest;
 
     private final Dataset<Row> testDataSet = createTestDataset();
 
+
     @BeforeEach
     public void setUp() {
+        reset(mockDataStorage);
         when(mockJobArguments.getViolationsS3Path()).thenReturn(VIOLATIONS_PATH);
         when(mockJobArguments.getStructuredS3Path()).thenReturn(STRUCTURED_PATH);
 
@@ -61,38 +68,148 @@ class StructuredZoneTest extends BaseSparkTest {
     @Test
     public void shouldHandleValidLoadRecords() throws DataStorageException {
         val expectedRecords = createExpectedLoadDataset();
+        val structuredPath = createValidatedPath(STRUCTURED_PATH, TABLE_SOURCE, TABLE_NAME);
+
         givenTheSchemaExists();
         givenTheSourceReferenceIsValid();
+        doNothing()
+                .when(mockDataStorage)
+                .appendDistinct(eq(structuredPath), dataframeCaptor.capture(), any());
 
         assertIterableEquals(
                 expectedRecords.collectAsList(),
-                underTest.processLoad(spark, testDataSet, dataMigrationEventRow).collectAsList()
+                underTest.process(spark, testDataSet, dataMigrationEventRow, false).collectAsList()
         );
+
+        assertIterableEquals(
+                expectedRecords.drop(OPERATION).collectAsList(),
+                dataframeCaptor.getValue().collectAsList()
+            );
     }
 
     @Test
     public void shouldHandleValidIncrementalRecords() throws DataStorageException {
         val expectedRecords = createExpectedIncrementalDataset();
+        val structuredPath = createValidatedPath(STRUCTURED_PATH, TABLE_SOURCE, TABLE_NAME);
+
         givenTheSchemaExists();
         givenTheSourceReferenceIsValid();
+        doNothing().when(mockDataStorage).appendDistinct(eq(structuredPath), dataframeCaptor.capture(), any());
+        doNothing().when(mockDataStorage).updateRecords(eq(structuredPath), dataframeCaptor.capture(), any());
+        doNothing().when(mockDataStorage).deleteRecords(eq(structuredPath), dataframeCaptor.capture(), eq(PRIMARY_KEY_NAME));
 
         assertIterableEquals(
                 expectedRecords.collectAsList(),
-                underTest.processCDC(spark, testDataSet, dataMigrationEventRow).collectAsList()
+                underTest.process(spark, testDataSet, dataMigrationEventRow, true).collectAsList()
+        );
+
+        assertIterableEquals(
+                expectedRecords.drop(OPERATION).collectAsList(),
+                getAllCapturedRecords()
         );
     }
 
     @Test
-    public void shouldHandleInvalidRecords() throws DataStorageException {
+    public void shouldHandleValidInsertRecords() throws DataStorageException {
+        val expectedRecords = createExpectedInsertDataset();
+        val structuredPath = createValidatedPath(STRUCTURED_PATH, TABLE_SOURCE, TABLE_NAME);
+
         givenTheSchemaExists();
         givenTheSourceReferenceIsValid();
-        assertNotNull(underTest.processLoad(spark, testDataSet, dataMigrationEventRow));
+        doNothing().when(mockDataStorage).appendDistinct(eq(structuredPath), dataframeCaptor.capture(), any());
+
+        underTest.process(spark, testDataSet, dataMigrationEventRow, true).collect();
+
+        assertIterableEquals(
+                expectedRecords.drop(OPERATION).collectAsList(),
+                getAllCapturedRecords()
+        );
+    }
+
+    @Test
+    public void shouldHandleValidUpdateRecords() throws DataStorageException {
+        val expectedRecords = createExpectedUpdateDataset();
+        val structuredPath = createValidatedPath(STRUCTURED_PATH, TABLE_SOURCE, TABLE_NAME);
+
+        givenTheSchemaExists();
+        givenTheSourceReferenceIsValid();
+        doNothing().when(mockDataStorage).updateRecords(eq(structuredPath), dataframeCaptor.capture(), any());
+
+        underTest.process(spark, testDataSet, dataMigrationEventRow, true).collect();
+
+        assertIterableEquals(
+                expectedRecords.drop(OPERATION).collectAsList(),
+                getAllCapturedRecords()
+        );
+    }
+
+    @Test
+    public void shouldHandleValidDeleteRecords() throws DataStorageException {
+        val expectedRecords = createExpectedDeleteDataset();
+        val structuredPath = createValidatedPath(STRUCTURED_PATH, TABLE_SOURCE, TABLE_NAME);
+
+        givenTheSchemaExists();
+        givenTheSourceReferenceIsValid();
+        doNothing().when(mockDataStorage).deleteRecords(eq(structuredPath), dataframeCaptor.capture(), eq(PRIMARY_KEY_NAME));
+
+        underTest.process(spark, testDataSet, dataMigrationEventRow, true).collect();
+
+        assertIterableEquals(
+                expectedRecords.drop(OPERATION).collectAsList(),
+                getAllCapturedRecords()
+        );
+    }
+
+    @Test
+    public void shouldContinueWhenInsertFails() throws DataStorageException {
+        givenTheSchemaExists();
+        givenTheSourceReferenceIsValid();
+        doThrow(new DataStorageException("insert failed")).when(mockDataStorage).appendDistinct(any(), any(), any());
+
+        underTest.process(spark, testDataSet, dataMigrationEventRow, true).collect();
+
+        assertTrue(getAllCapturedRecords().isEmpty());
+    }
+
+    @Test
+    public void shouldContinueWhenUpdateFails() throws DataStorageException {
+        givenTheSchemaExists();
+        givenTheSourceReferenceIsValid();
+        doThrow(new DataStorageException("update failed")).when(mockDataStorage).updateRecords(any(), any(), any());
+
+        underTest.process(spark, testDataSet, dataMigrationEventRow, true).collect();
+
+        assertTrue(getAllCapturedRecords().isEmpty());
+    }
+
+    @Test
+    public void shouldContinueWhenDeletionFails() throws DataStorageException {
+        givenTheSchemaExists();
+        givenTheSourceReferenceIsValid();
+        doThrow(new DataStorageException("deletion failed")).when(mockDataStorage).deleteRecords(any(), any(), any());
+
+        underTest.process(spark, testDataSet, dataMigrationEventRow, true).collect();
+
+        assertTrue(getAllCapturedRecords().isEmpty());
+    }
+
+    @Test
+    public void shouldHandleInvalidRecords() throws DataStorageException {
+        for (Boolean isCDC: Arrays.asList(true, false)) {
+            givenTheSchemaExists();
+            givenTheSourceReferenceIsValid();
+
+            assertNotNull(underTest.process(spark, testDataSet, dataMigrationEventRow, isCDC));
+        }
     }
 
     @Test
     public void shouldHandleNoSchemaFound() throws DataStorageException {
-        givenTheSchemaDoesNotExist();
-        assertNotNull(underTest.processLoad(spark, testDataSet, dataMigrationEventRow));
+        for (Boolean isCDC: Arrays.asList(true, false)) {
+            givenTheSchemaDoesNotExist();
+
+            assertTrue(underTest.process(spark, testDataSet, dataMigrationEventRow, isCDC).isEmpty());
+        }
     }
 
     private void givenTheSchemaExists() {
@@ -108,234 +225,79 @@ class StructuredZoneTest extends BaseSparkTest {
         when(mockSourceReference.getSource()).thenReturn(TABLE_SOURCE);
         when(mockSourceReference.getTable()).thenReturn(TABLE_NAME);
         when(mockSourceReference.getSchema()).thenReturn(JSON_DATA_SCHEMA);
+        when(mockSourceReference.getPrimaryKey()).thenReturn(new SourceReference.PrimaryKey(KEY));
     }
 
     private Dataset<Row> createTestDataset() {
-        val rawData = new ArrayList<Row>();
-
-        rawData.add(
-                RowFactory.create(
-                        "3",
-                        RECORD_KEY_1,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Load.getName(),
-                        ROW_CONVERTER,
-                        recordData1,
-                        recordData1,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "1",
-                        RECORD_KEY_2,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Load.getName(),
-                        ROW_CONVERTER,
-                        recordData2,
-                        recordData2,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "2",
-                        RECORD_KEY_3,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Load.getName(),
-                        ROW_CONVERTER,
-                        recordData3,
-                        recordData3,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "0",
-                        RECORD_KEY_4,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Insert.getName(),
-                        ROW_CONVERTER,
-                        recordData4,
-                        recordData4,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "4",
-                        RECORD_KEY_5,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Insert.getName(),
-                        ROW_CONVERTER,
-                        recordData5,
-                        recordData5,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "5",
-                        RECORD_KEY_6,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Insert.getName(),
-                        ROW_CONVERTER,
-                        recordData6,
-                        recordData6,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "6",
-                        RECORD_KEY_7,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Update.getName(),
-                        ROW_CONVERTER,
-                        recordData7,
-                        recordData7,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "7",
-                        RECORD_KEY_6,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Delete.getName(),
-                        ROW_CONVERTER,
-                        recordData6,
-                        recordData6,
-                        GENERIC_METADATA
-                )
-        );
-        rawData.add(
-                RowFactory.create(
-                        "8",
-                        RECORD_KEY_5,
-                        TABLE_SOURCE,
-                        TABLE_NAME,
-                        Update.getName(),
-                        ROW_CONVERTER,
-                        recordData5,
-                        recordData5,
-                        GENERIC_METADATA
-                )
-        );
+        val rawData = new ArrayList<>(Arrays.asList(
+                record1Load,
+                record2Load,
+                record3Load,
+                record4Insert,
+                record5Insert,
+                record6Insert,
+                record7Update,
+                record6Deletion,
+                record5Update
+        ));
 
         return spark.createDataFrame(rawData, ROW_SCHEMA);
     }
 
     private Dataset<Row> createExpectedLoadDataset() {
-        val expectedLoadData = new ArrayList<Row>();
-
-        expectedLoadData.add(
-                RowFactory.create(
-                        RECORD_KEY_2,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Load.getName()
-                )
-        );
-        expectedLoadData.add(
-                RowFactory.create(
-                        RECORD_KEY_3,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Load.getName()
-                )
-        );
-        expectedLoadData.add(
-                RowFactory.create(
-                        RECORD_KEY_1,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Load.getName()
-                )
-        );
+        val expectedLoadData = new ArrayList<>(Arrays.asList(
+                structuredRecord2Load,
+                structuredRecord3Load,
+                structuredRecord1Load
+        ));
 
         return spark.createDataFrame(expectedLoadData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
     }
 
     private Dataset<Row> createExpectedIncrementalDataset() {
-        val expectedIncrementalData = new ArrayList<Row>();
-
-        expectedIncrementalData.add(
-                RowFactory.create(
-                        RECORD_KEY_4,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Insert.getName()
-                )
-        );
-        expectedIncrementalData.add(
-                RowFactory.create(
-                        RECORD_KEY_5,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Insert.getName()
-                )
-        );
-        expectedIncrementalData.add(
-                RowFactory.create(
-                        RECORD_KEY_6,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Insert.getName()
-                )
-        );
-        expectedIncrementalData.add(
-                RowFactory.create(
-                        RECORD_KEY_7,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Update.getName()
-                )
-        );
-        expectedIncrementalData.add(
-                RowFactory.create(
-                        RECORD_KEY_6,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Delete.getName()
-                )
-        );
-        expectedIncrementalData.add(
-                RowFactory.create(
-                        RECORD_KEY_5,
-                        STRING_FIELD_VALUE,
-                        null,
-                        NUMBER_FIELD_VALUE,
-                        ARRAY_FIELD_VALUE,
-                        Update.getName()
-                )
-        );
+        val expectedIncrementalData = new ArrayList<>(Arrays.asList(
+                structuredRecord4Insertion,
+                structuredRecord5Insertion,
+                structuredRecord6Insertion,
+                structuredRecord7Update,
+                structuredRecord6Deletion,
+                structuredRecord5Update
+        ));
 
         return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
+    }
+
+    private Dataset<Row> createExpectedInsertDataset() {
+        val expectedIncrementalData = new ArrayList<>(Arrays.asList(
+                structuredRecord4Insertion,
+                structuredRecord5Insertion,
+                structuredRecord6Insertion
+        ));
+
+        return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
+    }
+
+    private Dataset<Row> createExpectedUpdateDataset() {
+        val expectedIncrementalData = new ArrayList<>(Arrays.asList(
+                structuredRecord7Update,
+                structuredRecord5Update
+        ));
+
+        return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
+    }
+
+    private Dataset<Row> createExpectedDeleteDataset() {
+        val expectedIncrementalData = new ArrayList<>(Collections.singletonList(structuredRecord6Deletion));
+
+        return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
+    }
+
+    private List<Row> getAllCapturedRecords() {
+        return dataframeCaptor
+                .getAllValues()
+                .stream()
+                .flatMap(x -> x.collectAsList().stream())
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
This PR:
- Applies the incremental/CDC events to the structured zone
- The CDC events are applied (inserted/updated/deleted) on a row-by-row basis
- In case a row operation fails, the row data and destination table are logged without failing the spark job