### PR TITLE
NOJIRA owasp run during main build should use separate cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
           context:
             - hmpps-reporting-common
             - hmpps-reporting-orb
-          cache_key: "v4"
+          cache_key: "owasp-build-cache"
       - reporting/gradle_build_publish:
           tag: "8.0"
           app: digital-prison-reporting-jobs
@@ -51,4 +51,4 @@ workflows:
           context:
             - hmpps-reporting-common
             - hmpps-reporting-orb
-          cache_key: "v4"
+          cache_key: "owasp-build-cache"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ workflows:
             - hmpps-reporting-orb
           filters:
             branches:
-              only: main           
+              only: main
+          cache_key: "v4"
       - reporting/gradle_build_publish:
           tag: "8.0"
           app: digital-prison-reporting-jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ workflows:
           context:
             - hmpps-reporting-common
             - hmpps-reporting-orb
+          cache_key: "dpr-jobs-build-cache"
 
   owasp-security:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ workflows:
           context:
             - hmpps-reporting-common
             - hmpps-reporting-orb
-          filters:
-            branches:
-              only: main
           cache_key: "v4"
       - reporting/gradle_build_publish:
           tag: "8.0"


### PR DESCRIPTION
Summary of changes
* use separate cache keys for owasp and build tasks with descriptive key names
* enable owasp task on PR builds 