### PR TITLE
DPR-585 update manifest only if we have a delta table

### DIFF
--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -183,9 +183,9 @@ public class DataStorageService {
         if (DeltaTable.isDeltaTable(spark, tablePath))
             return DeltaTable.forPath(spark, tablePath);
         else {
-            logger.warn("Cannot update manifest for table: {} - Not a delta table", tablePath);
+            logger.warn("No valid table found for path: {} - Not a delta table", tablePath);
+            return null;
         }
-        return null;
     }
 
     public void endTableUpdates(SparkSession spark, TableIdentifier tableId) throws DataStorageException {
@@ -197,8 +197,12 @@ public class DataStorageService {
     }
 
     public void updateDeltaManifestForTable(SparkSession spark, String tablePath) {
-        DeltaTable deltaTable = getTable(spark, tablePath);
-        updateManifest(deltaTable);
+        logger.info("Updating manifest for table: {}", tablePath);
+
+        val  deltaTable = getTable(spark, tablePath);
+
+        if (deltaTable != null) updateManifest(deltaTable);
+        else logger.warn("Unable to update manifest for table: {} Not a delta table", tablePath);
     }
 
 }


### PR DESCRIPTION
Summary of changes
* prevent NPE on update manifest call if the current table is not a delta table
* also revised logging on `getTable` so that it makes more sense - manifest update happens elsewhere

Note - we may need to revisit this if this is a state that should cause the job to abort. For now it will just warn.