### PR TITLE
DPR-615: Glue job failure exit code

### DIFF
--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -123,9 +123,13 @@ public class DataHubJob implements Runnable {
         try {
             kinesisReader.setBatchProcessor(this::batchProcessor);
             kinesisReader.startAndAwaitTermination();
-        } catch (InterruptedException e) {
-            logger.error("Kinesis job interrupted");
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                logger.error("Kinesis job interrupted", e);
+            } else {
+                logger.error("Exception occurred during streaming job", e);
+                System.exit(1);
+            }
         }
     }
 

--- a/src/main/java/uk/gov/justice/digital/job/DomainRefreshJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DomainRefreshJob.java
@@ -39,6 +39,7 @@ public class DomainRefreshJob implements Runnable {
             domainService.run();
         } catch (Exception e) {
             logger.error("Caught exception during job run", e);
+            System.exit(1);
         }
 
     }


### PR DESCRIPTION
This PR logs the error and exits with a non-zero code when an irrecoverable error is encountered by the Spark job.
This was tested in sandbox on both the reporting and refresh jobs as shown in the screenshots below:

<img width="1422" alt="Screenshot 2023-07-14 at 12 29 57" src="https://github.com/ministryofjustice/digital-prison-reporting-jobs/assets/136330532/86f9c5f9-b125-41fb-954c-1ac575968c7e">

<img width="1419" alt="Screenshot 2023-07-14 at 12 29 36" src="https://github.com/ministryofjustice/digital-prison-reporting-jobs/assets/136330532/9fde0a45-0303-4938-92ec-c0612806194f">
