### PR TITLE
DPR-674: Fix bug in JsonValidator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ext {
     deltaVersion = '2.2.0'
     jacksonVersion = '2.14.2'
     junitVersion = '5.8.1'
+    hamcrestVersion = '2.2'
     log4jVersion = '2.20.0'
     micronautVersion = '3.8.7'
     mockitoVersion = '4.11.0'
@@ -86,6 +87,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.mockito/mockito-inline
     testImplementation 'org.mockito:mockito-inline:4.11.0'
     testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
+    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
     testImplementation "com.networknt:json-schema-validator:1.0.81"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZone.java
@@ -59,11 +59,9 @@ public abstract class StructuredZone implements Zone {
 
         val sourceReference = sourceReferenceService.getSourceReference(sourceName, tableName);
 
-        val structuredDataFrame = sourceReference.isPresent()
+        return sourceReference.isPresent()
                 ? handleSchemaFound(spark, sortedRecords, sourceReference.get())
                 : handleNoSchemaFound(spark, sortedRecords, sourceName, tableName);
-
-        return structuredDataFrame;
     }
 
     private Dataset<Row> handleSchemaFound(


### PR DESCRIPTION
This fixes the bug in the JsonValidator where nullable columns missing in the raw data were treated as mandatory.

After the fix, 
```
{
    "mandatoryField": "foo"
}
```
is now treated as valid and equal to
```
{
    "mandatoryField": "foo",
    "nullableField": null 
}
```