### PR TITLE
DPR-677: Set stopGracefullyOnShutdown to true

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisReader.java
+++ b/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisReader.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Bean;
 import jakarta.inject.Inject;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
@@ -13,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.reflect.ClassTag$;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.config.JobProperties;
 
 @Bean
 public class KinesisReader {
@@ -26,13 +26,11 @@ public class KinesisReader {
     @Inject
     public KinesisReader(
             JobArguments jobArguments,
-            JobProperties jobProperties,
+            String jobName,
             SparkContext sparkContext
     ) {
-        String jobName = jobProperties.getSparkJobName();
-
         streamingContext = new JavaStreamingContext(
-                sparkContext.getConf(),
+                JavaSparkContext.fromSparkContext(sparkContext),
                 jobArguments.getKinesisReaderBatchDuration()
         );
 

--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -2,15 +2,18 @@ package uk.gov.justice.digital.job;
 
 import io.micronaut.configuration.picocli.PicocliRunner;
 import lombok.val;
+import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import uk.gov.justice.digital.client.kinesis.KinesisReader;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.converter.Converter;
 import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
@@ -44,8 +47,7 @@ public class DataHubJob implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(DataHubJob.class);
 
 
-    private final JobArguments arguments;
-    private final KinesisReader kinesisReader;
+    public final KinesisReader kinesisReader;
     private final RawZone rawZone;
     private final StructuredZoneLoad structuredZoneLoad;
     private final StructuredZoneCDC structuredZoneCDC;
@@ -53,12 +55,12 @@ public class DataHubJob implements Runnable {
     private final CuratedZoneCDC curatedZoneCDC;
     private final DomainService domainService;
     private final Converter<JavaRDD<Row>, Dataset<Row>> converter;
-    private final SparkSessionProvider sparkSessionProvider;
+    private final SparkSession spark;
 
     @Inject
     public DataHubJob(
         JobArguments arguments,
-        KinesisReader kinesisReader,
+        JobProperties properties,
         RawZone rawZone,
         StructuredZoneLoad structuredZoneLoad,
         StructuredZoneCDC structuredZoneCDC,
@@ -69,8 +71,11 @@ public class DataHubJob implements Runnable {
         SparkSessionProvider sparkSessionProvider
     ) {
         logger.info("Initializing DataHubJob");
-        this.arguments = arguments;
-        this.kinesisReader = kinesisReader;
+        String jobName = properties.getSparkJobName();
+        SparkConf sparkConf = new SparkConf().setAppName(jobName);
+
+        this.spark = sparkSessionProvider.getConfiguredSparkSession(sparkConf, arguments.getLogLevel());
+        this.kinesisReader = new KinesisReader(arguments, properties, spark.sparkContext());
         this.rawZone = rawZone;
         this.structuredZoneLoad = structuredZoneLoad;
         this.structuredZoneCDC = structuredZoneCDC;
@@ -78,7 +83,6 @@ public class DataHubJob implements Runnable {
         this.curatedZoneCDC = curatedZoneCDC;
         this.domainService = domainService;
         this.converter = converter;
-        this.sparkSessionProvider = sparkSessionProvider;
         logger.info("DataHubJob initialization complete");
     }
 
@@ -87,7 +91,7 @@ public class DataHubJob implements Runnable {
         PicocliRunner.run(DataHubJob.class, MicronautContext.withArgs(args));
     }
 
-    private void batchProcessor(JavaRDD<byte[]> batch) {
+    public void batchProcessor(JavaRDD<byte[]> batch) {
         if (batch.isEmpty()) {
             logger.warn("Batch: {} - Skipping empty batch", batch.id());
         }
@@ -98,8 +102,6 @@ public class DataHubJob implements Runnable {
 
             val startTime = System.currentTimeMillis();
 
-            val logLevel = arguments.getLogLevel();
-            val spark = sparkSessionProvider.getConfiguredSparkSession(batch.context().getConf(), logLevel);
             val rowRdd = batch.map(d -> RowFactory.create(new String(d, StandardCharsets.UTF_8)));
             val dataFrame = converter.convert(rowRdd);
 

--- a/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubJob.java
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.client.kinesis.KinesisReader;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.converter.Converter;
+import uk.gov.justice.digital.converter.dms.DMS_3_4_6;
 import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DomainService;
@@ -75,7 +76,7 @@ public class DataHubJob implements Runnable {
         SparkConf sparkConf = new SparkConf().setAppName(jobName);
 
         this.spark = sparkSessionProvider.getConfiguredSparkSession(sparkConf, arguments.getLogLevel());
-        this.kinesisReader = new KinesisReader(arguments, properties, spark.sparkContext());
+        this.kinesisReader = new KinesisReader(arguments, jobName, spark.sparkContext());
         this.rawZone = rawZone;
         this.structuredZoneLoad = structuredZoneLoad;
         this.structuredZoneCDC = structuredZoneCDC;

--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -19,6 +19,7 @@ public class SparkSessionProvider {
                 .set("spark.databricks.delta.autoCompact.enabled", "true")
                 .set("spark.databricks.delta.optimizeWrite.enabled", "true")
                 .set("spark.databricks.delta.schema.autoMerge.enabled", "true")
+                .set("spark.streaming.stopGracefullyOnShutdown", "true")
                 .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
                 .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
                 .set("spark.sql.legacy.charVarcharAsString", "true")


### PR DESCRIPTION
This PR allows a graceful shutdown of the spark streaming context when a Glue job termination is invoked.
This will prevent data loss and the Kinesis DynamoDB checkpoint from getting corrupted due to an abrupt shutdown.