### PR TITLE
DPR-674: Use map transformation for validation

### DIFF
--- a/src/main/java/uk/gov/justice/digital/job/validator/JsonValidator.java
+++ b/src/main/java/uk/gov/justice/digital/job/validator/JsonValidator.java
@@ -1,0 +1,139 @@
+package uk.gov.justice.digital.job.validator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import lombok.val;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.job.filter.NomisDataFilter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * JSON validator that is intended to be invoked *after* from_json is used to parse a field containing a JSON string.
+ * <p>>
+ * Data is filtered prior to validation to ensure that the raw data matches the expected spark representation so that
+ * validation passes.
+ * <p>
+ * By design, from_json will forcibly enable nullable on all fields declared in the schema. This resolves potential
+ * downstream issues with parquet but makes it harder for us to validate JSON principally because from_json
+ *   o silently allows fields declared notNull to be null
+ *   o silently converts fields with incompatible values to null
+ * <p>
+ * For this reason this validator *must* be used *after* first parsing a JSON string with from_json.
+ * <p>
+ * This validator performs the following checks
+ *   o original and parsed json *must* be equal - if there is a difference this indicates a bad value in the source data
+ *     e.g. a String value when a Numeric value was expected
+ *   o all fields declared notNull *must* have a value
+ *   o handling of dates represented in the incoming raw data as an ISO 8601 datetime string with the time values all
+ *     set to zero
+ * <p>
+ * and can be used as follows within Spark SQL
+ * <p>
+ * StructType schema = .... // Some schema defining the format of the JSON being processed
+ * <p>
+ * UserDefinedFunction jsonValidator = JsonValidator.createAndRegister(
+ *      schema,
+ *      someDataFrame.sparkSession(),
+ *      sourceName,
+ *      tableName
+ * );
+ * <p>
+ * // dataframe with a single string column 'rawJson' containing JSON to parse and validate against a schema
+ * someDataFrame
+ *  .withColumn("parsedJson", from_json(col("rawJson"), schema))
+ *  .withColumn("valid", jsonValidator.apply(col("rawData"), to_json("parsedJson")))
+ * <p>
+ * The dataframe can then be filtered on the value of the boolean valid column where
+ *  o true -> the JSON has passed validation
+ *  o false -> the JSON has not passed validation
+ */
+public class JsonValidator {
+
+    public static class JsonValidatorStatic {
+        private static final ObjectMapper objectMapper = new ObjectMapper();
+
+        private static final Logger logger = LoggerFactory.getLogger(JsonValidator.class);
+
+        public static String validate(
+                String originalJson,
+                String parsedJson,
+                StructType schema
+        ) {
+
+            // null content is still valid
+            if (originalJson == null || parsedJson == null) return "Json data was parsed as null";
+
+            TypeReference<Map<String,Object>> mapTypeReference = new TypeReference<Map<String,Object>>() {};
+
+            try {
+                val originalData = objectMapper.readValue(originalJson, mapTypeReference);
+                val parsedDataWithNullColumnsDropped = removeNullValues(objectMapper.readValue(parsedJson, mapTypeReference));
+
+                val nomisFilter = new NomisDataFilter(schema);
+
+                // Apply data filters. See NomisDataFilter.
+                val filteredDataWithNullColumnsDropped = removeNullValues(nomisFilter.apply(originalData));
+
+                // Check that
+                //  o the original and parsed data match using a simple equality check
+                //  o any fields declared not-nullable have a value
+                val result = filteredDataWithNullColumnsDropped.equals(parsedDataWithNullColumnsDropped) &&
+                        allNotNullFieldsHaveValues(schema, objectMapper.readTree(originalJson));
+
+                logger.debug("JSON validation result - json valid: {}", result);
+
+                if (!result) {
+                    // We treat null fields the same as missing fields
+                    val difference = Maps.difference(filteredDataWithNullColumnsDropped, parsedDataWithNullColumnsDropped);
+
+                    val errorMessage = String.format("JSON validation failed. Parsed and Raw JSON have the following differences: %s", difference);
+                    logger.error(errorMessage);
+                    return errorMessage;
+                } else return "";
+            } catch (JsonProcessingException e) {
+                String errorMessage = "Failed to process record as json" + e.getMessage();
+                logger.error(errorMessage, e);
+                return errorMessage;
+            }
+
+        }
+
+        private static boolean allNotNullFieldsHaveValues(StructType schema, JsonNode json) {
+            for (StructField structField : schema.fields()) {
+                // Skip fields that are declared nullable in the table schema.
+                if (structField.nullable()) continue;
+
+                val jsonField = Optional.ofNullable(json.get(structField.name()));
+
+                val jsonFieldIsNull = jsonField
+                        .map(JsonNode::isNull)  // Field present in JSON but with no value
+                        .orElse(true);          // If no field found then it's null by default.
+
+                // We fail immediately if the field is null since it's declared as not-nullable.
+                if (jsonFieldIsNull) {
+                    logger.error("JSON validation failed. Not null field {} is null", structField);
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static Map<String, Object> removeNullValues(Map<String, Object> map) {
+            return map
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue() != null)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZone.java
@@ -1,16 +1,19 @@
 package uk.gov.justice.digital.zone.structured;
 
 import lombok.val;
+import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
-import uk.gov.justice.digital.job.udf.JsonValidator;
 import uk.gov.justice.digital.service.SourceReferenceService;
 import uk.gov.justice.digital.writer.Writer;
 import uk.gov.justice.digital.zone.Zone;
@@ -22,11 +25,13 @@ import java.util.Map;
 import static org.apache.spark.sql.functions.*;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.ParsedDataFields.*;
+import static uk.gov.justice.digital.job.validator.JsonValidator.*;
 
 public abstract class StructuredZone implements Zone {
 
     public static final String ERROR = "error";
     public static final String PARSED_DATA = "parsedData";
+    public static final String PARSED_DATA_STRING = "parsedDataString";
     public static final String VALID = "valid";
 
     private static final Logger logger = LoggerFactory.getLogger(StructuredZone.class);
@@ -75,7 +80,7 @@ public abstract class StructuredZone implements Zone {
         val tablePath = createValidatedPath(structuredPath, source, table);
         val validationFailedViolationPath = createValidatedPath(violationsPath, source, table);
 
-        val validatedDataFrame = validateJsonData(spark, dataFrame, sourceReference.getSchema(), source, table);
+        val validatedDataFrame = validateJsonData(dataFrame, sourceReference.getSchema(), source, table);
 
         handleInvalidRecords(spark, validatedDataFrame, source, table, validationFailedViolationPath);
 
@@ -150,19 +155,37 @@ public abstract class StructuredZone implements Zone {
     }
 
     private Dataset<Row> validateJsonData(
-            SparkSession spark,
             Dataset<Row> dataFrame,
             StructType schema,
             String source,
             String table
     ) {
-        logger.info("Validating data against schema: {}/{}", source, table);
-        val jsonValidator = JsonValidator.createAndRegister(schema, spark, source, table);
+        logger.debug("Validating data against schema: {}/{}", source, table);
+
+        val schemaWithErrorColumn = new StructType()
+                .add(OPERATION, DataTypes.StringType)
+                .add(DATA, DataTypes.StringType)
+                .add(ERROR, DataTypes.StringType)
+                .add(METADATA, DataTypes.StringType)
+                .add(PARSED_DATA, schema);
+
+        val encoder = RowEncoder.apply(schemaWithErrorColumn);
 
         return dataFrame
                 .select(col(DATA), col(METADATA), col(OPERATION))
                 .withColumn(PARSED_DATA, from_json(col(DATA), schema, jsonOptions))
-                .withColumn(ERROR, jsonValidator.apply(col(DATA), to_json(col(PARSED_DATA), jsonOptions)))
+                .withColumn(PARSED_DATA_STRING, to_json(col(PARSED_DATA), jsonOptions))
+                .map((MapFunction<Row, Row>) row -> {
+                    val originalData = row.<String>getAs(DATA);
+                    val parsedData = row.<String>getAs(PARSED_DATA_STRING);
+                    val operation = row.<String>getAs(OPERATION);
+                    val metadata = row.<String>getAs(METADATA);
+
+                    val validationResult = JsonValidatorStatic.validate(originalData, parsedData, schema);
+                    val validatedRow = new Object[] { operation, originalData, validationResult, metadata, row.getAs(PARSED_DATA) };
+
+                    return new GenericRow(validatedRow);
+                }, encoder)
                 .withColumn(VALID, col(ERROR).equalTo(lit("")));
     }
 


### PR DESCRIPTION
This uses a map function instead of a UDF for the Json validation.

To avoid serialization errors, a static class JsonValidatorStatic is used.