### PR TITLE
DPR2-123: Support viewText with three way join

### DIFF
--- a/src/main/java/uk/gov/justice/digital/common/ColumnMapping.java
+++ b/src/main/java/uk/gov/justice/digital/common/ColumnMapping.java
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.common;
+
+import java.util.Objects;
+
+public class ColumnMapping {
+
+    private final String tableName;
+    private final String columnName;
+
+    private ColumnMapping(String tableName, String columnName) {
+        this.tableName = tableName;
+        this.columnName = columnName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public static ColumnMapping create(String tableName, String columnName) {
+        return new ColumnMapping(tableName, columnName);
+    }
+
+    public ColumnMapping upperCaseColumnName() {
+        return new ColumnMapping(tableName, columnName.toUpperCase());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof ColumnMapping))
+            return false;
+        ColumnMapping other = (ColumnMapping) o;
+        return Objects.equals(this.tableName, other.tableName) && Objects.equals(this.columnName, other.columnName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableName, columnName);
+    }
+
+    @Override
+    public String toString() {
+        return "ColumnMapping{" +
+                "tableName='" + tableName + '\'' +
+                ", columnName='" + columnName + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/common/SourceMapping.java
+++ b/src/main/java/uk/gov/justice/digital/common/SourceMapping.java
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.common;
+
+import lombok.val;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class SourceMapping {
+
+    private final String sourceTable;
+    private final String destinationTable;
+    private final Map<String, String> tableAliases;
+    private final Map<ColumnMapping, ColumnMapping> columnMap;
+
+    private SourceMapping(
+            String sourceTable,
+            String destinationTable,
+            Map<String, String> tableAliases,
+            Map<ColumnMapping, ColumnMapping> columnMap
+    ) {
+        this.sourceTable = sourceTable;
+        this.destinationTable = destinationTable;
+        this.tableAliases = tableAliases;
+        this.columnMap = columnMap;
+    }
+
+    public String getSourceTable() {
+        return sourceTable;
+    }
+
+    public String getDestinationTable() {
+        return destinationTable;
+    }
+
+    public Map<String, String> getTableAliases() {
+        return tableAliases;
+    }
+
+    public Map<ColumnMapping, ColumnMapping> getColumnMap() {
+        return columnMap;
+    }
+
+    public SourceMapping withSourceColumnsUpperCased() {
+        val upperCasedSourceColumnMap = new HashMap<ColumnMapping, ColumnMapping>();
+        for (Map.Entry<ColumnMapping, ColumnMapping> entry : columnMap.entrySet()) {
+            upperCasedSourceColumnMap.put(entry.getKey().upperCaseColumnName(), entry.getValue());
+        }
+        return new SourceMapping(sourceTable, destinationTable, tableAliases, upperCasedSourceColumnMap);
+    }
+
+    public static SourceMapping create(
+            String sourceTable,
+            String destinationTable,
+            Map<String, String> tableAliases,
+            Map<ColumnMapping, ColumnMapping> columnMap
+    ) {
+        return new SourceMapping(sourceTable, destinationTable, tableAliases, columnMap);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SourceMapping that = (SourceMapping) o;
+        return Objects.equals(sourceTable, that.sourceTable) &&
+                Objects.equals(destinationTable, that.destinationTable) &&
+                Objects.equals(tableAliases, that.tableAliases) &&
+                Objects.equals(columnMap, that.columnMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceTable, destinationTable, tableAliases, columnMap);
+    }
+
+    @Override
+    public String toString() {
+        return "SourceMapping{" +
+                "sourceTable='" + sourceTable + '\'' +
+                ", destinationTable='" + destinationTable + '\'' +
+                ", tableAliases=" + tableAliases +
+                ", columnMap=" + columnMap +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/domain/ViewTextProcessor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/ViewTextProcessor.java
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.domain;
+
+import lombok.val;
+import org.apache.hadoop.shaded.com.google.re2j.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+import uk.gov.justice.digital.common.ColumnMapping;
+import uk.gov.justice.digital.common.SourceMapping;
+import uk.gov.justice.digital.exception.DomainServiceException;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ViewTextProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(ViewTextProcessor.class);
+
+    private static final Pattern aliasRegexPattern = Pattern.compile(" (\\S+)(\\s+as\\s+)(\\S+) ");
+    private static final Pattern joinExprRegexPattern = Pattern
+            .compile("((join)|((left)(\\s+)(join))|((right)(\\s+)(join))|((full)(\\s+)(join)))");
+
+    public static Set<SourceMapping> buildAllSourceMappings(List<String> sources, String viewText) {
+        val sourceMappings = new HashSet<SourceMapping>();
+
+        sources.stream()
+                .flatMap(source1 -> sources.stream().map(source2 -> Tuple2.apply(source1, source2)))
+                .filter(combination -> !combination._1.equalsIgnoreCase(combination._2))
+                .forEach(sourcesCombination -> {
+                    try {
+                        val sourceMapping = ViewTextProcessor.buildSourceMapping(sourcesCombination._1, sourcesCombination._2, viewText);
+                        if (!sourceMapping.getColumnMap().isEmpty()) sourceMappings.add(sourceMapping);
+                    } catch (DomainServiceException e) {
+                        logger.warn("Failed to build source mappings", e);
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        return sourceMappings;
+    }
+
+    public static SourceMapping buildSourceMapping(
+            String referenceTableName,
+            String adjoiningTableName,
+            String viewText
+    ) throws DomainServiceException {
+        val columnMappings = new HashMap<ColumnMapping, ColumnMapping>();
+
+        val fromExpression = viewText.toLowerCase().split(" from ", 2)[1];
+        val tableAliases = resolveTableAliases(fromExpression, referenceTableName, adjoiningTableName);
+        val joinExpressions = fromExpression.split(joinExprRegexPattern.pattern());
+
+        for (String joinExpression : joinExpressions) {
+            val onExpressions = joinExpression.split(" on ");
+
+            if (onExpressions.length == 2) {
+                // ViewText has a join expression
+                val joinClause = onExpressions[1];
+                val andExpressions = Arrays
+                        .stream(joinClause.split(" and "))
+                        .map(String::trim)
+                        .filter(andExpression -> containsTableOrItsAlias(referenceTableName, tableAliases, andExpression) &&
+                                containsTableOrItsAlias(adjoiningTableName, tableAliases, andExpression)
+                        ).collect(Collectors.toList());
+
+                val joinColumns = andExpressions
+                        .stream()
+                        .flatMap(str -> Arrays.stream(str.trim().split("=")).map(String::trim))
+                        .collect(Collectors.toList());
+
+                val currentTableJoinColumns = joinColumns
+                        .stream()
+                        .filter(column -> containsTableOrItsAlias(referenceTableName, tableAliases, column))
+                        .map(ViewTextProcessor::toColumnMapping)
+                        .collect(Collectors.toList());
+
+                val otherTableJoinColumns = joinColumns
+                        .stream()
+                        .filter(column -> !containsTableOrItsAlias(referenceTableName, tableAliases, column))
+                        .map(ViewTextProcessor::toColumnMapping)
+                        .collect(Collectors.toList());
+
+                if (currentTableJoinColumns.size() == otherTableJoinColumns.size()) {
+                    val intermediateMap = IntStream.range(0, currentTableJoinColumns.size())
+                            .boxed()
+                            .map(i -> Collections.singletonMap(currentTableJoinColumns.get(i), otherTableJoinColumns.get(i)))
+                            .flatMap(map -> map.entrySet().stream())
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                    columnMappings.putAll(intermediateMap);
+                } else {
+                    throw new DomainServiceException("Join expression length mismatch in viewText " + viewText);
+                }
+            }
+        }
+
+        return SourceMapping.create(referenceTableName, adjoiningTableName, tableAliases, columnMappings);
+    }
+
+    private static HashMap<String, String> resolveTableAliases(String sqlText, String referenceTableName, String adjoiningTableName) {
+        val tableAliases = new HashMap<String, String>();
+        val matcher = aliasRegexPattern.matcher(sqlText);
+
+        while (matcher.find()) {
+            val originalName = matcher.group(1).toLowerCase();
+            val alias = matcher.group(3);
+            if (originalName.equalsIgnoreCase(referenceTableName) || originalName.equalsIgnoreCase(adjoiningTableName)) {
+                tableAliases.put(alias, originalName);
+            }
+        }
+
+        return tableAliases;
+    }
+
+    private static boolean containsTableOrItsAlias(String tableName, HashMap<String, String> tableAliases, String str) {
+        if (tableAliases.containsValue(tableName)) {
+            val aliases = tableAliases.entrySet().stream()
+                    .filter(entrySet -> entrySet.getValue().equalsIgnoreCase(tableName))
+                    .map(Map.Entry::getKey).collect(Collectors.toSet());
+            return aliases.stream().anyMatch(alias -> str.contains(alias.toLowerCase()));
+        } else {
+            return str.contains(tableName.toLowerCase());
+        }
+    }
+
+    private static ColumnMapping toColumnMapping(String column) {
+        val tableName = column.substring(0, column.lastIndexOf("."));
+        val columnName = column.substring(column.lastIndexOf(".") + 1);
+        return ColumnMapping.create(tableName, columnName);
+    }
+
+    // Private constructor to prevent instantiation.
+    private ViewTextProcessor() {}
+}

--- a/src/main/java/uk/gov/justice/digital/service/DomainService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DomainService.java
@@ -3,18 +3,19 @@ package uk.gov.justice.digital.service;
 import com.google.common.collect.ImmutableList;
 import jakarta.inject.Inject;
 import lombok.val;
-import org.apache.hadoop.shaded.com.google.re2j.Pattern;
 import org.apache.spark.sql.functions;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.constructor.DuplicateKeyException;
 import uk.gov.justice.digital.client.dynamodb.DomainDefinitionClient;
+import uk.gov.justice.digital.common.SourceMapping;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.DomainExecutor;
+import uk.gov.justice.digital.domain.ViewTextProcessor;
 import uk.gov.justice.digital.domain.model.DomainDefinition;
 import uk.gov.justice.digital.domain.model.TableDefinition;
 import uk.gov.justice.digital.exception.DatabaseClientException;
@@ -25,7 +26,6 @@ import javax.inject.Singleton;
 import java.util.*;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation.Load;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_6.Operation.getOperation;
@@ -39,9 +39,6 @@ public class DomainService {
     private final DomainDefinitionClient domainClient;
     private final DomainExecutor executor;
     private final JobArguments arguments;
-    private static final Pattern aliasRegexPattern = Pattern.compile(" (\\S+)(\\s+as\\s+)(\\S+) ");
-    private static final Pattern joinExprRegexPattern = Pattern
-            .compile("((join)|((left)(\\s+)(join))|((right)(\\s+)(join))|((full)(\\s+)(join)))");
 
     @Inject
     public DomainService(
@@ -65,19 +62,19 @@ public class DomainService {
         );
     }
 
-    public void refreshDomainUsingDataFrame(SparkSession spark, Dataset<Row> dataFrame, Row tableInfo) {
-        String tableName = tableInfo.getAs(TABLE);
+    public void refreshDomainUsingDataFrame(SparkSession spark, Dataset<Row> dataFrame, String sourceName, String tableName) {
+        val sourceTable = sourceName + "." + tableName;
         val domainDefinitions = getDomainDefinitions();
-        val domainDefinitionsForSource = filterDomainDefinitionsForSource(domainDefinitions, tableName);
-        logger.debug("Found {} domains with source table {}", domainDefinitionsForSource.size(), tableName);
+        val domainDefinitionsForSource = filterDomainDefinitionsForSource(domainDefinitions, sourceTable);
+        logger.debug("Found {} domains with source table {}", domainDefinitionsForSource.size(), sourceTable);
 
         if (domainDefinitionsForSource.isEmpty()) {
             // log and proceed when no domain is found for the table
-            logger.warn("No domain definition found for table: " + tableName);
+            logger.warn("No domain definition found for table: " + sourceTable);
         } else {
             domainDefinitionsForSource.forEach(domainDefinition ->
                     dataFrame.collectAsList()
-                            .forEach(row -> refreshDomainUsingCDCRecord(spark, domainDefinition, row, tableName))
+                            .forEach(row -> refreshDomainUsingCDCRecord(spark, domainDefinition, row, sourceTable))
             );
         }
     }
@@ -191,7 +188,7 @@ public class DomainService {
                                         table.getTransform()
                                                 .getSources()
                                                 .stream()
-                                                .anyMatch(source -> source.toLowerCase().endsWith("." + sourceName.toLowerCase())))
+                                                .anyMatch(source -> source.equalsIgnoreCase(sourceName)))
                 ).collect(Collectors.toList());
     }
 
@@ -202,101 +199,77 @@ public class DomainService {
             String referenceTableName
     ) {
         val sourceToRecordMap = new HashMap<String, Dataset<Row>>();
+        val sourcesWithoutRecords = new HashSet<String>();
+
         val viewText = tableDefinition.getTransform().getViewText().replaceAll("\\n", " ");
-        tableDefinition
-                .getTransform()
-                .getSources()
-                .forEach(adjoiningTableName -> {
-                    if (adjoiningTableName.toLowerCase().endsWith(referenceTableName.toLowerCase())) {
-                        sourceToRecordMap.put(adjoiningTableName, referenceDataFrame);
+        val sourceMappings = ViewTextProcessor.buildAllSourceMappings(tableDefinition.getTransform().getSources(), viewText);
+
+        tableDefinition.getTransform().getSources().forEach(source -> {
+                    if (source.equalsIgnoreCase(referenceTableName)) {
+                        sourceToRecordMap.put(source, referenceDataFrame);
                     } else {
-                        try {
-                            val columnMappings = buildColumnMapBetweenReferenceAndAdjoiningTables(referenceTableName, adjoiningTableName, viewText);
-                            val adjoiningDataFrame = executor
-                                    .getAdjoiningDataFrameForReferenceDataFrame(spark, adjoiningTableName, columnMappings, referenceDataFrame);
+                        val optionalSourceMapping = findRelatedSourceMapping(referenceTableName, sourceMappings, source);
+                        if (optionalSourceMapping.isPresent()) {
+                            val adjoiningDataFrame = executor.getAdjoiningDataFrame(spark, optionalSourceMapping.get(), referenceDataFrame);
                             if (adjoiningDataFrame.isEmpty()) {
-                                logger.warn("Adjoining dataFrame is empty for source {} and viewText {}", adjoiningTableName, viewText);
+                                logger.warn("Adjoining dataFrame is empty for source {} given {}", source, referenceTableName);
                             } else {
-                                sourceToRecordMap.put(adjoiningTableName, adjoiningDataFrame);
+                                logger.debug("Adding dataframe for source {} and ref: {}", source, referenceTableName);
+                                sourceToRecordMap.put(source, adjoiningDataFrame);
                             }
-                        } catch (DomainServiceException | DuplicateKeyException e) {
-                            logger.warn("Failed to to get dataFrame for other table source {} ", adjoiningTableName, e);
+                        } else {
+                            sourcesWithoutRecords.add(source);
                         }
                     }
-                });
+                }
+        );
+
+        val missingSourceRecords = getMissingSourceRecords(spark, sourcesWithoutRecords, sourceMappings, sourceToRecordMap);
+        sourceToRecordMap.putAll(missingSourceRecords);
+
         return sourceToRecordMap;
     }
 
-    protected Map<String, String> buildColumnMapBetweenReferenceAndAdjoiningTables(
-            String referenceTableName,
-            String adjoiningTableName,
-            String viewText
-    ) throws DomainServiceException {
-        val columnMappings = new HashMap<String, String>();
+    private Map<String, Dataset<Row>> getMissingSourceRecords(
+            SparkSession spark,
+            Set<String> sourcesWithoutDataframes,
+            Set<SourceMapping> sourceMappings,
+            Map<String, Dataset<Row>> sourceToRecordMap
+    ) {
+        val missingSourceRecords = new HashMap<String, Dataset<Row>>();
 
-        val fromExpression = viewText.toLowerCase().split(" from ", 2)[1];
-        val aliasesResolved = resolveAliases(fromExpression);
-        val joinExpressions = aliasesResolved.split(joinExprRegexPattern.pattern());
-
-        for (String joinExpression : joinExpressions) {
-            val onExpressions = joinExpression.split(" on ");
-
-            if (onExpressions.length == 2) {
-                // ViewText has a join expression
-                val joinClause = onExpressions[1];
-                val andExpressions = Arrays
-                        .stream(joinClause.split(" and "))
-                        .map(String::trim)
-                        .filter(x ->
-                                x.toLowerCase().contains(referenceTableName.toLowerCase()) &&
-                                        x.toLowerCase().contains(adjoiningTableName.toLowerCase())
-                        )
-                        .collect(Collectors.toList());
-
-                val joinColumns = andExpressions
+        sourcesWithoutDataframes.forEach(source ->
+                sourceMappings
                         .stream()
-                        .flatMap(str -> Arrays.stream(str.trim().split("=")).map(String::trim))
-                        .collect(Collectors.toList());
+                        .filter(sourceMapping -> sourceMapping.getDestinationTable().equalsIgnoreCase(source) &&
+                                sourceToRecordMap.containsKey(sourceMapping.getSourceTable()))
+                        .findFirst()
+                        .ifPresent(sourceMapping -> {
+                            val reverseMapping = sourceMapping.withSourceColumnsUpperCased();
+                            val referenceDataFrame = sourceToRecordMap.get(sourceMapping.getSourceTable());
+                            val adjoiningDataFrame = executor.getAdjoiningDataFrame(spark, reverseMapping, referenceDataFrame);
+                            if (adjoiningDataFrame.isEmpty()) {
+                                logger.warn("Failed to retrieve dataFrame for {} using already retrieved source {}", source, sourceMapping.getSourceTable());
+                            } else {
+                                logger.debug("Missing record retrieved for source: {}", source);
+                                missingSourceRecords.put(source, adjoiningDataFrame);
+                            }
+                        }));
 
-                val currentTableJoinColumns = joinColumns
-                        .stream()
-                        .filter(column -> column.trim().contains(referenceTableName.toLowerCase()))
-                        .map(x -> x.substring(x.lastIndexOf(".") + 1))
-                        .collect(Collectors.toList());
-
-                val otherTableJoinColumns = joinColumns
-                        .stream()
-                        .filter(column -> column.trim().contains(adjoiningTableName.toLowerCase()))
-                        .map(x -> x.substring(x.lastIndexOf(".") + 1))
-                        .collect(Collectors.toList());
-
-                if (currentTableJoinColumns.size() == otherTableJoinColumns.size()) {
-                    val intermediateMap = IntStream.range(0, currentTableJoinColumns.size())
-                            .boxed()
-                            .collect(Collectors.toMap(currentTableJoinColumns::get, otherTableJoinColumns::get));
-                    columnMappings.putAll(intermediateMap);
-                } else {
-                    throw new DomainServiceException("Join expression length mismatch in viewText " + viewText);
-                }
-            }
-        }
-
-        return columnMappings;
+        return missingSourceRecords;
     }
 
-    private String resolveAliases(String sqlText) {
-        String aliasReplacedText = sqlText;
-        val matcher = aliasRegexPattern.matcher(sqlText);
-
-        while (matcher.find()) {
-            val originalName = matcher.group(1);
-            val alias = matcher.group(3);
-            aliasReplacedText = aliasReplacedText
-                    .replaceAll(" as " + alias, " ")
-                    .replaceAll(alias, originalName);
-        }
-
-        return aliasReplacedText;
+    @NotNull
+    private static Optional<SourceMapping> findRelatedSourceMapping(
+            String source,
+            Set<SourceMapping> sourceMappings,
+            String destination
+    ) {
+        return sourceMappings
+                .stream()
+                .filter(sourceMapping -> sourceMapping.getSourceTable().equalsIgnoreCase(source) &&
+                        sourceMapping.getDestinationTable().equalsIgnoreCase(destination))
+                .findFirst();
     }
 
     private static Dataset<Row> lowerCaseColumnNames(SparkSession spark, Row row) {

--- a/src/test/java/uk/gov/justice/digital/domain/ViewTextProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/domain/ViewTextProcessorTest.java
@@ -1,0 +1,449 @@
+package uk.gov.justice.digital.domain;
+
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.digital.common.ColumnMapping;
+import uk.gov.justice.digital.common.SourceMapping;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsIn.in;
+import static org.hamcrest.core.Every.everyItem;
+
+class ViewTextProcessorTest {
+
+    private static final String externalMovements = "nomis.offender_external_movements";
+    private static final String movementReasons = "nomis.movement_reasons";
+    private static final String agencyLocations = "nomis.agency_locations";
+    private static final String originLocation = "origin_location";
+    private static final String destinationLocation = "destination_location";
+
+    @Test
+    public void shouldCreateColumnMappingForViewTextWithSingleJoinColumn() throws Exception {
+        val table1 = "nomis.table_1";
+        val table2 = "nomis.table_2";
+
+        val table1Column1 = "table_1_column_1";
+        val table2Column1 = "table_2_column_1";
+
+        val expectedTable1To2Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(table1, table1Column1),
+                ColumnMapping.create(table2, table2Column1)
+        );
+
+        val expectedTable2To1Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(table2, table2Column1),
+                ColumnMapping.create(table1, table1Column1)
+        );
+
+        val viewText = "select " +
+                table1 + ".offender_book_id as id, " +
+                table2 + ".birth_date as birth_date, " +
+                table1 + ".living_unit_id as living_unit_id, " +
+                table2 + ".first_name as first_name, " +
+                table2 + ".last_name as last_name, " +
+                table2 + ".offender_id_display as offender_no " +
+                "from " + table1 + " " +
+                "join " + table2 + " " +
+                "on " + table1 + "." + table1Column1 + " = " + table2 + "." + table2Column1;
+
+        SourceMapping table1To2mappings = ViewTextProcessor.buildSourceMapping(table1, table2, viewText);
+        SourceMapping table2To1Mappings = ViewTextProcessor.buildSourceMapping(table2, table1, viewText);
+
+        assertThat(
+                table1To2mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To2Mappings.entrySet())))
+        );
+
+        assertThat(
+                table2To1Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable2To1Mappings.entrySet())))
+        );
+    }
+
+    @Test
+    public void shouldCreateColumnMappingForViewTextWithMultipleJoinColumns() throws Exception {
+        val table1 = "nomis.table_1";
+        val table2 = "nomis.table_2";
+
+        val table1Column1 = "table_1_column_1";
+        val table2Column1 = "table_2_column_1";
+
+        val table1Column2 = "table_1_column_2";
+        val table2Column2 = "table_2_column_2";
+
+        val expectedTable1To2Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(table1, table1Column1),
+                ColumnMapping.create(table2, table2Column1)
+        );
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(table1, table1Column2),
+                ColumnMapping.create(table2, table2Column2)
+        );
+
+        val expectedTable2To1Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(table2, table2Column1),
+                ColumnMapping.create(table1, table1Column1)
+        );
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(table2, table2Column2),
+                ColumnMapping.create(table1, table1Column2)
+        );
+
+        val viewText = "select " +
+                table1 + ".offender_book_id as id, " +
+                table2 + ".birth_date as birth_date, " +
+                table1 + ".living_unit_id as living_unit_id, " +
+                table2 + ".first_name as first_name, " +
+                table2 + ".last_name as last_name, " +
+                table2 + ".offender_id_display as offender_no " +
+                "from " + table1 + " " +
+                "join " + table2 + " " +
+                "on " + table1 + "." + table1Column1 + " = " + table2 + "." + table2Column1 + " " +
+                "and " + table2 + "." + table2Column2 + " = " + table1 + "." + table1Column2;
+
+        SourceMapping table1To2Mappings = ViewTextProcessor.buildSourceMapping(table1, table2, viewText);
+        SourceMapping table2To1Mappings = ViewTextProcessor.buildSourceMapping(table2, table1, viewText);
+
+        assertThat(
+                table1To2Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To2Mappings.entrySet())))
+        );
+
+        assertThat(
+                table2To1Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable2To1Mappings.entrySet())))
+        );
+    }
+
+    @Test
+    public void shouldCreateColumnMappingForViewTextWithMultipleJoinExpressions() throws Exception {
+        val table1 = "nomis.table_1";
+        val table2 = "nomis.table_2";
+        val table3 = "nomis.table_3";
+        val table4 = "nomis.table_4";
+        val table5 = "nomis.table_5";
+
+        val table1Column1 = "table_1_column_1";
+        val table2Column1 = "table_2_column_1";
+
+        val table1Column2 = "table_1_column_2";
+        val table2Column2 = "table_2_column_2";
+
+        val table1Column3 = "table_1_column_3";
+        val table3Column3 = "table_3_column_3";
+
+        val table1Column4 = "table_1_column_4";
+        val table4Column4 = "table_4_column_4";
+
+        val table1Column5 = "table_1_column_5";
+        val table5Column5 = "table_5_column_5";
+
+        val expectedTable1To2Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(table1, table1Column1),
+                ColumnMapping.create(table2, table2Column1)
+        );
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(table1, table1Column2),
+                ColumnMapping.create(table2, table2Column2)
+        );
+
+        val expectedTable1To3Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To3Mappings.put(
+                ColumnMapping.create(table1, table1Column3),
+                ColumnMapping.create(table3, table3Column3)
+        );
+
+        val expectedTable1To4Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To4Mappings.put(
+                ColumnMapping.create(table1, table1Column4),
+                ColumnMapping.create(table4, table4Column4)
+        );
+
+        val expectedTable1To5Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To5Mappings.put(
+                ColumnMapping.create(table1, table1Column5),
+                ColumnMapping.create(table5, table5Column5)
+        );
+
+        val viewText = "select " +
+                table1 + ".offender_book_id as id, " +
+                table2 + ".birth_date as birth_date, " +
+                table1 + ".living_unit_id as living_unit_id, " +
+                table2 + ".first_name as first_name, " +
+                table2 + ".last_name as last_name, " +
+                table2 + ".offender_id_display as offender_no " +
+                "from " + table1 + " " +
+                "join " + table2 + " " +
+                "on " + table1 + "." + table1Column1 + " = " + table2 + "." + table2Column1 + " " +
+                "and " + table2 + "." + table2Column2 + " = " + table1 + "." + table1Column2 + " " +
+                "LEFT JOIN " + table3 + " " +
+                "on " + table1 + "." + table1Column3 + " = " + table3 + "." + table3Column3 + " " +
+                "RIGHT  JOIN " + table4 + " " +
+                "on " + table1 + "." + table1Column4 + " = " + table4 + "." + table4Column4 + " " +
+                "full join " + table5 + " " +
+                "on " + table1 + "." + table1Column5 + " = " + table5 + "." + table5Column5;
+
+        SourceMapping table1To2Mappings = ViewTextProcessor.buildSourceMapping(table1, table2, viewText);
+        SourceMapping table1To3Mappings = ViewTextProcessor.buildSourceMapping(table1, table3, viewText);
+        SourceMapping table1To4Mappings = ViewTextProcessor.buildSourceMapping(table1, table4, viewText);
+        SourceMapping table1To5Mappings = ViewTextProcessor.buildSourceMapping(table1, table5, viewText);
+
+        assertThat(
+                table1To2Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To2Mappings.entrySet())))
+        );
+
+        assertThat(
+                table1To3Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To3Mappings.entrySet())))
+        );
+
+        assertThat(
+                table1To4Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To4Mappings.entrySet())))
+        );
+
+        assertThat(
+                table1To5Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To5Mappings.entrySet())))
+        );
+    }
+
+    @Test
+    public void shouldResolveAliasesWhenBuildingColumnMappings() throws Exception {
+        val table1 = "nomis.table_1";
+        val table2 = "nomis.table_2";
+        val table3 = "nomis.table_3";
+
+        val table2Alias = "table2_alias";
+
+        val table1Column1 = "table_1_column_1";
+        val table2Column1 = "table_2_column_1";
+        val table3Column1 = "table_3_column_1";
+
+        val expectedMappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedMappings.put(
+                ColumnMapping.create(table1, table1Column1),
+                ColumnMapping.create(table2Alias, table2Column1)
+        );
+
+        val viewText = "select " +
+                table1 + ".offender_book_id as id, " +
+                table2 + ".birth_date as birth_date, " +
+                table1 + ".living_unit_id as living_unit_id, " +
+                table2 + ".first_name as first_name, " +
+                table2 + ".last_name as last_name, " +
+                table2 + ".offender_id_display as offender_no " +
+                "from " + table1 + " " +
+                "join " + table2 + " as  " + table2Alias + " " +
+                "on " + table1 + "." + table1Column1 + " = table2_alias." + table2Column1 + " " +
+                "left join " + table3 + "  as table3_alias " +
+                "on " + table1 + "." + table1Column1 + " = table3_alias." + table3Column1;
+
+        val mappings = ViewTextProcessor.buildSourceMapping(table1, table2, viewText);
+
+        assertThat(
+                mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedMappings.entrySet())))
+        );
+    }
+
+    @Test
+    public void shouldReturnEmptyMapForViewTextWithNoJoinCondition() throws Exception {
+        val table1 = "nomis.table_1";
+        val expectedMappings = new HashMap<ColumnMapping, ColumnMapping>();
+
+        val viewText = "select " +
+                table1 + ".offender_book_id as id, " +
+                table1 + ".living_unit_id as living_unit_id, " +
+                "from " + table1;
+
+        val mappings = ViewTextProcessor.buildSourceMapping(table1, table1, viewText);
+
+        assertThat(
+                mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedMappings.entrySet())))
+        );
+    }
+
+    @Test
+    public void shouldResolveAliasesAndBuildColumnMappingsForComplexQuery() throws Exception {
+
+        val expectedTable1To2Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(externalMovements, "movement_type"),
+                ColumnMapping.create(movementReasons, "movement_type")
+        );
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(externalMovements, "movement_reason_code"),
+                ColumnMapping.create(movementReasons, "movement_reason_code")
+        );
+
+        val expectedTable1To3Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To3Mappings.put(
+                ColumnMapping.create(externalMovements, "from_agy_loc_id"),
+                ColumnMapping.create(originLocation, "agy_loc_id")
+        );
+        expectedTable1To3Mappings.put(
+                ColumnMapping.create(externalMovements, "to_agy_loc_id"),
+                ColumnMapping.create(destinationLocation, "agy_loc_id")
+        );
+
+        val expectedTable2To1Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(movementReasons, "movement_type"),
+                ColumnMapping.create(externalMovements, "movement_type")
+        );
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(movementReasons, "movement_reason_code"),
+                ColumnMapping.create(externalMovements, "movement_reason_code")
+        );
+
+        val expectedTable2To3Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+
+        val expectedTable3To1Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable3To1Mappings.put(
+                ColumnMapping.create(originLocation, "agy_loc_id"),
+                ColumnMapping.create(externalMovements, "from_agy_loc_id")
+        );
+        expectedTable3To1Mappings.put(
+                ColumnMapping.create(destinationLocation, "agy_loc_id"),
+                ColumnMapping.create(externalMovements, "to_agy_loc_id")
+        );
+
+        val expectedTable3To2Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+
+        val viewText = complexViewTextWithAliases();
+
+        SourceMapping table1To2Mappings = ViewTextProcessor.buildSourceMapping(externalMovements, movementReasons, viewText);
+        SourceMapping table1To3Mappings = ViewTextProcessor.buildSourceMapping(externalMovements, agencyLocations, viewText);
+        SourceMapping table2To1Mappings = ViewTextProcessor.buildSourceMapping(movementReasons, externalMovements, viewText);
+        SourceMapping table2To3Mappings = ViewTextProcessor.buildSourceMapping(movementReasons, agencyLocations, viewText);
+        SourceMapping table3To1Mappings = ViewTextProcessor.buildSourceMapping(agencyLocations, externalMovements, viewText);
+        SourceMapping table3To2Mappings = ViewTextProcessor.buildSourceMapping(agencyLocations, movementReasons, viewText);
+
+        assertThat(
+                table1To2Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To2Mappings.entrySet())))
+        );
+
+        assertThat(
+                table1To3Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable1To3Mappings.entrySet())))
+        );
+
+        assertThat(
+                table2To1Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable2To1Mappings.entrySet())))
+        );
+
+        assertThat(
+                table2To3Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable2To3Mappings.entrySet())))
+        );
+
+        assertThat(
+                table3To1Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable3To1Mappings.entrySet())))
+        );
+
+        assertThat(
+                table3To2Mappings.getColumnMap().entrySet(),
+                everyItem(is(in(expectedTable3To2Mappings.entrySet())))
+        );
+    }
+
+    @Test
+    public void shouldBuildAllSourceMappingsInViewText() {
+        val tableAliases = new HashMap<String, String>();
+        tableAliases.put(originLocation, agencyLocations);
+        tableAliases.put(destinationLocation, agencyLocations);
+
+        val sources = Arrays.asList(externalMovements, movementReasons, agencyLocations);
+
+        val expectedTable1To2Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(externalMovements, "movement_type"),
+                ColumnMapping.create(movementReasons, "movement_type")
+        );
+        expectedTable1To2Mappings.put(
+                ColumnMapping.create(externalMovements, "movement_reason_code"),
+                ColumnMapping.create(movementReasons, "movement_reason_code")
+        );
+
+        val expectedTable1To3Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable1To3Mappings.put(
+                ColumnMapping.create(externalMovements, "from_agy_loc_id"),
+                ColumnMapping.create(originLocation, "agy_loc_id")
+        );
+        expectedTable1To3Mappings.put(
+                ColumnMapping.create(externalMovements, "to_agy_loc_id"),
+                ColumnMapping.create(destinationLocation, "agy_loc_id")
+        );
+
+        val expectedTable2To1Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(movementReasons, "movement_type"),
+                ColumnMapping.create(externalMovements, "movement_type")
+        );
+        expectedTable2To1Mappings.put(
+                ColumnMapping.create(movementReasons, "movement_reason_code"),
+                ColumnMapping.create(externalMovements, "movement_reason_code")
+        );
+
+        val expectedTable3To1Mappings = new HashMap<ColumnMapping, ColumnMapping>();
+        expectedTable3To1Mappings.put(
+                ColumnMapping.create(originLocation, "agy_loc_id"),
+                ColumnMapping.create(externalMovements, "from_agy_loc_id")
+        );
+        expectedTable3To1Mappings.put(
+                ColumnMapping.create(destinationLocation, "agy_loc_id"),
+                ColumnMapping.create(externalMovements, "to_agy_loc_id")
+        );
+
+        val expectedSourceMapping = new HashSet<SourceMapping>();
+        expectedSourceMapping.add(SourceMapping.create(externalMovements, movementReasons, Collections.emptyMap(), expectedTable1To2Mappings));
+        expectedSourceMapping.add(SourceMapping.create(externalMovements, agencyLocations, tableAliases, expectedTable1To3Mappings));
+        expectedSourceMapping.add(SourceMapping.create(movementReasons, externalMovements, Collections.emptyMap(), expectedTable2To1Mappings));
+        expectedSourceMapping.add(SourceMapping.create(agencyLocations, externalMovements, tableAliases, expectedTable3To1Mappings));
+
+        val viewText = complexViewTextWithAliases();
+
+        val sourceMappings = ViewTextProcessor.buildAllSourceMappings(sources, viewText);
+
+        assertThat(sourceMappings, everyItem(is(in(expectedSourceMapping))));
+    }
+
+    @NotNull
+    private static String complexViewTextWithAliases() {
+        return "select concat(cast(" + externalMovements + ".offender_book_id as string), '.', cast(" + externalMovements + ".movement_seq as string)) as id, " +
+                externalMovements + ".offender_book_id as prisoner, " +
+                externalMovements + ".movement_date as date, " +
+                externalMovements + ".movement_time as time, " +
+                externalMovements + ".direction_code as direction, " +
+                externalMovements + ".movement_type as type, " +
+                "origin_location.description as origin, " +
+                "destination_location.description as destination, " +
+                movementReasons + ".description as reason " +
+                "from " + externalMovements + " " +
+                "join " + movementReasons + " " +
+                "on " + movementReasons + ".movement_type=" + externalMovements + ".movement_type " +
+                "and " + movementReasons + ".movement_reason_code=" + externalMovements + ".movement_reason_code " +
+                "left join " + agencyLocations + " as origin_location " +
+                "on " + externalMovements + ".from_agy_loc_id = origin_location.agy_loc_id " +
+                "left join " + agencyLocations + " as destination_location " +
+                "on " + externalMovements + ".to_agy_loc_id = destination_location.agy_loc_id";
+    }
+}


### PR DESCRIPTION
This PR adds support for domains with joins on multiple tables.
For example, a domain containing three tables `tableA`, `tableB` and `tableC`
Where:
1.  `tableA` has a join with `tableB` but not with `tableC`
2. `tableC` has a join with `tableB` but not with `tableA`

Since there is no direct relationship between `tableA` and `tableC` we have to go through `tableB`.

The processing steps will be:
- When a CDC record for `tableA` arrives
- Then the dataframe record for `tableB` is loaded using the CDC record for `tableA`
- And the dataframe record for `tableC` is loaded using previously loaded record for `tableB`
- And the domain is refreshed