### PR TITLE
DPR2-130: Exclude irrelevant domain tables

### DIFF
--- a/src/main/java/uk/gov/justice/digital/service/DomainService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DomainService.java
@@ -88,7 +88,9 @@ public class DomainService {
         cdcOperations.ifPresent(operation -> {
             val referenceDataframe = lowerCaseColumnNames(spark, row);
 
-            domainDefinition.getTables().forEach(tableDefinition -> {
+            domainDefinition.getTables().stream().filter(table ->
+                    table.getTransform().getSources().stream().anyMatch(source -> source.equalsIgnoreCase(referenceTableName))
+            ).forEach(tableDefinition -> {
                         val tableTransform = tableDefinition.getTransform();
                         val violations = tableDefinition.getViolations();
 


### PR DESCRIPTION
This PR excludes domains tables which are not relevant to the received CDC event.