### PR TITLE
DPR2-52: Allow maintenance jobs to recurse in to S3 "directories"

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -35,6 +35,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.KINESIS_STARTING_POSITION, "trim_horizon" },
             { JobArguments.BATCH_MAX_RETRIES, "5" },
             { JobArguments.LOG_LEVEL, "debug" },
+            { JobArguments.MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH, "1" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -61,6 +62,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.KINESIS_STARTING_POSITION, validArguments.getKinesisStartingPosition() },
                 { JobArguments.BATCH_MAX_RETRIES, Integer.toString(validArguments.getBatchMaxRetries()) },
                 { JobArguments.LOG_LEVEL, validArguments.getLogLevel().toString().toLowerCase() },
+                { JobArguments.MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH, Integer.toString(validArguments.getMaintenanceListTableRecurseMaxDepth()) },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);

--- a/src/it/java/uk/gov/justice/digital/service/DataStorageServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/DataStorageServiceIntegrationTest.java
@@ -18,7 +18,7 @@ public class DataStorageServiceIntegrationTest extends DeltaTablesTestBase {
         setupNonDeltaFilesAndDirs();
     }
     @Test
-    public void shouldListOnlyDeltaTablePathsInRoot() throws Exception {
+    public void shouldListDeltaTablePathsInRootIgnoringNonDeltaDirsAndFiles() throws Exception {
         int depthLimitToRecurseDeltaTables = 1;
         List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
         // Should ignore non-delta table directories and files in the rootPath

--- a/src/it/java/uk/gov/justice/digital/service/DataStorageServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/DataStorageServiceIntegrationTest.java
@@ -18,7 +18,7 @@ public class DataStorageServiceIntegrationTest extends DeltaTablesTestBase {
         setupNonDeltaFilesAndDirs();
     }
     @Test
-    public void shouldListOnlyDeltaTablePaths() throws Exception {
+    public void shouldListOnlyDeltaTablePathsInRoot() throws Exception {
         int depthLimitToRecurseDeltaTables = 1;
         List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
         // Should ignore non-delta table directories and files in the rootPath
@@ -26,18 +26,18 @@ public class DataStorageServiceIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldRecurseToListOnlyDeltaTablePaths() throws Exception {
+    public void shouldListDeltaTablePathsWhenRecursingDepth2() throws Exception {
         int depthLimitToRecurseDeltaTables = 2;
         List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
-        // Should ignore non-delta table directories and files in the rootPath
+        // Should find an extra table 1 level deeper
         assertEquals(3, deltaTables.size());
     }
 
     @Test
-    public void shouldRecurseFurtherToListOnlyDeltaTablePaths() throws Exception {
+    public void shouldListDeltaTablePathsWhenRecursingDepth3() throws Exception {
         int depthLimitToRecurseDeltaTables = 3;
         List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
-        // Should ignore non-delta table directories and files in the rootPath
+        // Should find an extra table 1 level deeper and another extra table 2 levels deeper
         assertEquals(4, deltaTables.size());
     }
 

--- a/src/it/java/uk/gov/justice/digital/service/DataStorageServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/DataStorageServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.service;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.test.DeltaTablesTestBase;
 
@@ -12,16 +12,33 @@ import static uk.gov.justice.digital.test.SparkTestHelpers.countParquetFiles;
 public class DataStorageServiceIntegrationTest extends DeltaTablesTestBase {
     private static final DataStorageService underTest = new DataStorageService();
 
-    @BeforeAll
-    public static void setupTest() throws Exception {
+    @BeforeEach
+    public void setupTest() throws Exception {
         setupDeltaTablesFixture();
         setupNonDeltaFilesAndDirs();
     }
     @Test
     public void shouldListOnlyDeltaTablePaths() throws Exception {
-        List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString());
+        int depthLimitToRecurseDeltaTables = 1;
+        List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
         // Should ignore non-delta table directories and files in the rootPath
         assertEquals(2, deltaTables.size());
+    }
+
+    @Test
+    public void shouldRecurseToListOnlyDeltaTablePaths() throws Exception {
+        int depthLimitToRecurseDeltaTables = 2;
+        List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
+        // Should ignore non-delta table directories and files in the rootPath
+        assertEquals(3, deltaTables.size());
+    }
+
+    @Test
+    public void shouldRecurseFurtherToListOnlyDeltaTablePaths() throws Exception {
+        int depthLimitToRecurseDeltaTables = 3;
+        List<String> deltaTables = underTest.listDeltaTablePaths(spark, rootPath.toString(), depthLimitToRecurseDeltaTables);
+        // Should ignore non-delta table directories and files in the rootPath
+        assertEquals(4, deltaTables.size());
     }
 
     @Test

--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
@@ -24,26 +24,31 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
         int depthLimit = 1;
         assertMultipleParquetFilesPrecondition(offendersTablePath);
         assertMultipleParquetFilesPrecondition(offenderBookingsTablePath);
+        assertMultipleParquetFilesPrecondition(agencyLocationsTablePathDepth2);
+        assertMultipleParquetFilesPrecondition(internalLocationsTablePathDepth3);
         // Compaction should add a single new parquet file containing all the data from the original files.
         // It won't remove the old parquet files until a vacuum occurs and the data has passed its retention period.
-        long originalNumberOfParquetFilesOffenders = countParquetFiles(offendersTablePath);
-        long originalNumberOfParquetFilesOffenderBookings = countParquetFiles(offenderBookingsTablePath);
-
-
-        long expectedNumberOfParquetFilesAfterCompactionOffenders = originalNumberOfParquetFilesOffenders + 1;
-        long expectedNumberOfParquetFilesAfterCompactionOffenderBookings = originalNumberOfParquetFilesOffenderBookings + 1;
+        long originalNumFilesOffenders = countParquetFiles(offendersTablePath);
+        long originalNumFilesOffenderBookings = countParquetFiles(offenderBookingsTablePath);
+        long originalNumFilesAgencyLocations = countParquetFiles(agencyLocationsTablePathDepth2);
+        long originalNumFilesInternalLocations = countParquetFiles(internalLocationsTablePathDepth3);
 
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
 
         // In this test we verify compaction using both the effect on number of files and the reported delta operations.
         // In other tests we just check the delta operations in metadata.
-        assertEquals(expectedNumberOfParquetFilesAfterCompactionOffenders, countParquetFiles(offendersTablePath));
-        assertEquals(expectedNumberOfParquetFilesAfterCompactionOffenderBookings, countParquetFiles(offenderBookingsTablePath));
+        long expectedNumFilesAfterOffenders = originalNumFilesOffenders + 1;
+        long expectedNumbFilesAfterOffenderBookings = originalNumFilesOffenderBookings + 1;
+
+        assertEquals(expectedNumFilesAfterOffenders, countParquetFiles(offendersTablePath));
+        assertEquals(expectedNumbFilesAfterOffenderBookings, countParquetFiles(offenderBookingsTablePath));
+        assertEquals(originalNumFilesAgencyLocations, countParquetFiles(agencyLocationsTablePathDepth2));
+        assertEquals(originalNumFilesInternalLocations, countParquetFiles(internalLocationsTablePathDepth3));
 
         assertEquals(1, numberOfCompactions(offendersTablePath.toString()));
         assertEquals(1, numberOfCompactions(offenderBookingsTablePath.toString()));
-        assertEquals(0, numberOfCompactions(agencyLocationsTablePath.toString()));
-        assertEquals(0, numberOfCompactions(internalLocationsTablePath.toString()));
+        assertEquals(0, numberOfCompactions(agencyLocationsTablePathDepth2.toString()));
+        assertEquals(0, numberOfCompactions(internalLocationsTablePathDepth3.toString()));
     }
 
     @Test
@@ -54,8 +59,8 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
 
         assertEquals(1, numberOfCompactions(offendersTablePath.toString()));
         assertEquals(1, numberOfCompactions(offenderBookingsTablePath.toString()));
-        assertEquals(1, numberOfCompactions(agencyLocationsTablePath.toString()));
-        assertEquals(0, numberOfCompactions(internalLocationsTablePath.toString()));
+        assertEquals(1, numberOfCompactions(agencyLocationsTablePathDepth2.toString()));
+        assertEquals(0, numberOfCompactions(internalLocationsTablePathDepth3.toString()));
     }
 
     @Test
@@ -66,7 +71,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
 
         assertEquals(1, numberOfCompactions(offendersTablePath.toString()));
         assertEquals(1, numberOfCompactions(offenderBookingsTablePath.toString()));
-        assertEquals(1, numberOfCompactions(agencyLocationsTablePath.toString()));
-        assertEquals(1, numberOfCompactions(internalLocationsTablePath.toString()));
+        assertEquals(1, numberOfCompactions(agencyLocationsTablePathDepth2.toString()));
+        assertEquals(1, numberOfCompactions(internalLocationsTablePathDepth3.toString()));
     }
 }

--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
@@ -35,6 +35,8 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
 
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
 
+        // In this test we verify compaction using both the effect on number of files and the reported delta operations.
+        // In other tests we just check the delta operations in metadata.
         assertEquals(expectedNumberOfParquetFilesAfterCompactionOffenders, countParquetFiles(offendersTablePath));
         assertEquals(expectedNumberOfParquetFilesAfterCompactionOffenderBookings, countParquetFiles(offenderBookingsTablePath));
 
@@ -66,10 +68,5 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
         assertEquals(1, numberOfCompactions(offenderBookingsTablePath.toString()));
         assertEquals(1, numberOfCompactions(agencyLocationsTablePath.toString()));
         assertEquals(1, numberOfCompactions(internalLocationsTablePath.toString()));
-    }
-
-    private static long numberOfCompactions(String tablePath) {
-        return spark.sql(format("DESCRIBE HISTORY delta.`%s`", tablePath))
-                .where("operation = 'OPTIMIZE'").count();
     }
 }

--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
@@ -20,13 +20,13 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
 
         assertMultipleParquetFilesPrecondition(offendersTablePath);
         assertMultipleParquetFilesPrecondition(offenderBookingsTablePath);
-        assertMultipleParquetFilesPrecondition(agencyLocationsTablePath);
-        assertMultipleParquetFilesPrecondition(internalLocationsTablePath);
+        assertMultipleParquetFilesPrecondition(agencyLocationsTablePathDepth2);
+        assertMultipleParquetFilesPrecondition(internalLocationsTablePathDepth3);
 
         setDeltaTableRetentionToZero(offendersTablePath.toString());
         setDeltaTableRetentionToZero(offenderBookingsTablePath.toString());
-        setDeltaTableRetentionToZero(agencyLocationsTablePath.toString());
-        setDeltaTableRetentionToZero(internalLocationsTablePath.toString());
+        setDeltaTableRetentionToZero(agencyLocationsTablePathDepth2.toString());
+        setDeltaTableRetentionToZero(internalLocationsTablePathDepth3.toString());
     }
 
     @Test
@@ -40,8 +40,8 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
         assertEquals(1, countParquetFiles(offendersTablePath));
         assertEquals(1, countParquetFiles(offenderBookingsTablePath));
         // The tables in subdirectories have not been compacted
-        assertTrue(countParquetFiles(agencyLocationsTablePath) > 1);
-        assertTrue(countParquetFiles(internalLocationsTablePath) > 1);
+        assertTrue(countParquetFiles(agencyLocationsTablePathDepth2) > 1);
+        assertTrue(countParquetFiles(internalLocationsTablePathDepth3) > 1);
     }
 
     @Test
@@ -54,9 +54,9 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
         // The tables in the root and 2nd level have been compacted
         assertEquals(1, countParquetFiles(offendersTablePath));
         assertEquals(1, countParquetFiles(offenderBookingsTablePath));
-        assertEquals(1, countParquetFiles(agencyLocationsTablePath));
+        assertEquals(1, countParquetFiles(agencyLocationsTablePathDepth2));
         // The tables in subdirectories below depth 2 have not been compacted
-        assertTrue(countParquetFiles(internalLocationsTablePath) > 1);
+        assertTrue(countParquetFiles(internalLocationsTablePathDepth3) > 1);
     }
 
     @Test
@@ -69,8 +69,8 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
         // The tables have all been compacted down to level 3 subdirectories
         assertEquals(1, countParquetFiles(offendersTablePath));
         assertEquals(1, countParquetFiles(offenderBookingsTablePath));
-        assertEquals(1, countParquetFiles(agencyLocationsTablePath));
-        assertEquals(1, countParquetFiles(internalLocationsTablePath));
+        assertEquals(1, countParquetFiles(agencyLocationsTablePathDepth2));
+        assertEquals(1, countParquetFiles(internalLocationsTablePathDepth3));
     }
 
 }

--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
@@ -1,35 +1,76 @@
 package uk.gov.justice.digital.service;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.test.DeltaTablesTestBase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.justice.digital.test.SparkTestHelpers.countParquetFiles;
 
 class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
 
-    private static MaintenanceService underTest;
+    private MaintenanceService underTest;
 
-    @BeforeAll
-    public static void setupTest() throws Exception {
+    @BeforeEach
+    public void setupTest() throws Exception {
         setupDeltaTablesFixture();
         setupNonDeltaFilesAndDirs();
         underTest = new MaintenanceService(new DataStorageService());
+
+        assertMultipleParquetFilesPrecondition(offendersTablePath);
+        assertMultipleParquetFilesPrecondition(offenderBookingsTablePath);
+        assertMultipleParquetFilesPrecondition(agencyLocationsTablePath);
+        assertMultipleParquetFilesPrecondition(internalLocationsTablePath);
+
+        setDeltaTableRetentionToZero(offendersTablePath.toString());
+        setDeltaTableRetentionToZero(offenderBookingsTablePath.toString());
+        setDeltaTableRetentionToZero(agencyLocationsTablePath.toString());
+        setDeltaTableRetentionToZero(internalLocationsTablePath.toString());
     }
 
     @Test
-    public void shouldVacuumAllDeltaTables() throws Exception {
-        assertMultipleParquetFilesPrecondition(offendersTablePath);
-        assertMultipleParquetFilesPrecondition(offenderBookingsTablePath);
+    public void shouldVacuumDeltaTablesWhenRecursingDepth1() throws Exception {
+        int depthLimit = 1;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
-        underTest.compactDeltaTables(spark, rootPath.toString());
-        setDeltaTableRetentionToZero(offendersTablePath.toString());
-        setDeltaTableRetentionToZero(offenderBookingsTablePath.toString());
-        underTest.vacuumDeltaTables(spark, rootPath.toString());
+        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.vacuumDeltaTables(spark, rootPath.toString(), depthLimit);
 
+        // The tables in the root have been compacted
         assertEquals(1, countParquetFiles(offendersTablePath));
         assertEquals(1, countParquetFiles(offenderBookingsTablePath));
+        // The tables in subdirectories have not been compacted
+        assertTrue(countParquetFiles(agencyLocationsTablePath) > 1);
+        assertTrue(countParquetFiles(internalLocationsTablePath) > 1);
+    }
+
+    @Test
+    public void shouldVacuumDeltaTablesWhenRecursingDepth2() throws Exception {
+        int depthLimit = 2;
+        // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
+        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.vacuumDeltaTables(spark, rootPath.toString(), depthLimit);
+
+        // The tables in the root and 2nd level have been compacted
+        assertEquals(1, countParquetFiles(offendersTablePath));
+        assertEquals(1, countParquetFiles(offenderBookingsTablePath));
+        assertEquals(1, countParquetFiles(agencyLocationsTablePath));
+        // The tables in subdirectories below depth 2 have not been compacted
+        assertTrue(countParquetFiles(internalLocationsTablePath) > 1);
+    }
+
+    @Test
+    public void shouldVacuumDeltaTablesWhenRecursingDepth3() throws Exception {
+        int depthLimit = 3;
+        // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
+        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.vacuumDeltaTables(spark, rootPath.toString(), depthLimit);
+
+        // The tables have all been compacted down to level 3 subdirectories
+        assertEquals(1, countParquetFiles(offendersTablePath));
+        assertEquals(1, countParquetFiles(offenderBookingsTablePath));
+        assertEquals(1, countParquetFiles(agencyLocationsTablePath));
+        assertEquals(1, countParquetFiles(internalLocationsTablePath));
     }
 
 }

--- a/src/it/java/uk/gov/justice/digital/test/DeltaTablesTestBase.java
+++ b/src/it/java/uk/gov/justice/digital/test/DeltaTablesTestBase.java
@@ -17,27 +17,36 @@ import static uk.gov.justice.digital.test.SparkTestHelpers.*;
  */
 public class DeltaTablesTestBase extends BaseSparkTest {
     @TempDir
-    protected static Path rootPath;
-    protected static Path offendersTablePath;
-    protected static Path offenderBookingsTablePath;
+    protected Path rootPath;
+    protected Path offendersTablePath;
+    protected Path offenderBookingsTablePath;
+    protected Path agencyLocationsTablePath;
+    protected Path internalLocationsTablePath;
 
 
-    protected static void setupDeltaTablesFixture() {
+    protected void setupDeltaTablesFixture() {
         SparkTestHelpers helpers = new SparkTestHelpers(spark);
         offendersTablePath = rootPath.resolve("offenders").toAbsolutePath();
         offenderBookingsTablePath = rootPath.resolve("offender-bookings").toAbsolutePath();
+        agencyLocationsTablePath = rootPath.resolve("another-dir").resolve("agency-locations").toAbsolutePath();
+        internalLocationsTablePath = rootPath.resolve("another-dir").resolve("yet-another-dir").resolve("internal-locations").toAbsolutePath();
         // repartition to force the data in the delta table to have multiple small files at the start of tests
         int largeNumPartitions = 5;
         Dataset<Row> offenders = helpers.readSampleParquet(OFFENDERS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
         helpers.overwriteDeltaTable(offendersTablePath.toString(), offenders);
         Dataset<Row> offenderBookings = helpers.readSampleParquet(OFFENDER_BOOKINGS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
         helpers.overwriteDeltaTable(offenderBookingsTablePath.toString(), offenderBookings);
+
+        Dataset<Row> agencyLocations = helpers.readSampleParquet(AGENCY_LOCATIONS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
+        helpers.overwriteDeltaTable(agencyLocationsTablePath.toString(), agencyLocations);
+        Dataset<Row> internalLocations = helpers.readSampleParquet(INTERNAL_LOCATIONS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
+        helpers.overwriteDeltaTable(internalLocationsTablePath.toString(), internalLocations);
     }
 
     /**
      * Adds some extraneous non-delta table files and directories in to the root path
      */
-    protected static void setupNonDeltaFilesAndDirs() throws IOException {
+    protected void setupNonDeltaFilesAndDirs() throws IOException {
         assertTrue(rootPath.resolve("file-to-be-ignored.parquet").toFile().createNewFile());
         assertTrue(rootPath.resolve("dir-to-be-ignored").toFile().mkdirs());
         assertTrue(rootPath.resolve("dir-to-be-ignored").resolve("file-to-be-ignored2.parquet").toFile().createNewFile());

--- a/src/it/java/uk/gov/justice/digital/test/DeltaTablesTestBase.java
+++ b/src/it/java/uk/gov/justice/digital/test/DeltaTablesTestBase.java
@@ -20,16 +20,16 @@ public class DeltaTablesTestBase extends BaseSparkTest {
     protected Path rootPath;
     protected Path offendersTablePath;
     protected Path offenderBookingsTablePath;
-    protected Path agencyLocationsTablePath;
-    protected Path internalLocationsTablePath;
+    protected Path agencyLocationsTablePathDepth2;
+    protected Path internalLocationsTablePathDepth3;
 
 
     protected void setupDeltaTablesFixture() {
         SparkTestHelpers helpers = new SparkTestHelpers(spark);
         offendersTablePath = rootPath.resolve("offenders").toAbsolutePath();
         offenderBookingsTablePath = rootPath.resolve("offender-bookings").toAbsolutePath();
-        agencyLocationsTablePath = rootPath.resolve("another-dir-depth-1").resolve("agency-locations").toAbsolutePath();
-        internalLocationsTablePath = rootPath.resolve("another-dir-depth-1").resolve("yet-another-dir-depth-2").resolve("internal-locations").toAbsolutePath();
+        agencyLocationsTablePathDepth2 = rootPath.resolve("another-dir-depth-1").resolve("agency-locations").toAbsolutePath();
+        internalLocationsTablePathDepth3 = rootPath.resolve("another-dir-depth-1").resolve("yet-another-dir-depth-2").resolve("internal-locations").toAbsolutePath();
         // repartition to force the data in the delta table to have multiple small files at the start of tests
         int largeNumPartitions = 5;
         Dataset<Row> offenders = helpers.readSampleParquet(OFFENDERS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
@@ -38,9 +38,9 @@ public class DeltaTablesTestBase extends BaseSparkTest {
         helpers.overwriteDeltaTable(offenderBookingsTablePath.toString(), offenderBookings);
 
         Dataset<Row> agencyLocations = helpers.readSampleParquet(AGENCY_LOCATIONS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
-        helpers.overwriteDeltaTable(agencyLocationsTablePath.toString(), agencyLocations);
+        helpers.overwriteDeltaTable(agencyLocationsTablePathDepth2.toString(), agencyLocations);
         Dataset<Row> internalLocations = helpers.readSampleParquet(INTERNAL_LOCATIONS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
-        helpers.overwriteDeltaTable(internalLocationsTablePath.toString(), internalLocations);
+        helpers.overwriteDeltaTable(internalLocationsTablePathDepth3.toString(), internalLocations);
     }
 
     /**

--- a/src/it/java/uk/gov/justice/digital/test/DeltaTablesTestBase.java
+++ b/src/it/java/uk/gov/justice/digital/test/DeltaTablesTestBase.java
@@ -28,8 +28,8 @@ public class DeltaTablesTestBase extends BaseSparkTest {
         SparkTestHelpers helpers = new SparkTestHelpers(spark);
         offendersTablePath = rootPath.resolve("offenders").toAbsolutePath();
         offenderBookingsTablePath = rootPath.resolve("offender-bookings").toAbsolutePath();
-        agencyLocationsTablePath = rootPath.resolve("another-dir").resolve("agency-locations").toAbsolutePath();
-        internalLocationsTablePath = rootPath.resolve("another-dir").resolve("yet-another-dir").resolve("internal-locations").toAbsolutePath();
+        agencyLocationsTablePath = rootPath.resolve("another-dir-depth-1").resolve("agency-locations").toAbsolutePath();
+        internalLocationsTablePath = rootPath.resolve("another-dir-depth-1").resolve("yet-another-dir-depth-2").resolve("internal-locations").toAbsolutePath();
         // repartition to force the data in the delta table to have multiple small files at the start of tests
         int largeNumPartitions = 5;
         Dataset<Row> offenders = helpers.readSampleParquet(OFFENDERS_SAMPLE_PARQUET_PATH).repartition(largeNumPartitions);
@@ -66,6 +66,11 @@ public class DeltaTablesTestBase extends BaseSparkTest {
                 countParquetFiles(path) > 1,
                 "Test pre-condition failed - we want to start with multiple parquet files in this test"
         );
+    }
+
+    protected static long numberOfCompactions(String tablePath) {
+        return spark.sql(format("DESCRIBE HISTORY delta.`%s`", tablePath))
+                .where("operation = 'OPTIMIZE'").count();
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -46,6 +46,7 @@ public class JobArguments {
     public static final String REDSHIFT_SECRETS_NAME = "dpr.redshift.secrets.name";
     public static final String DATA_MART_DB_NAME = "dpr.datamart.db.name";
     public static final String MAINTENANCE_TABLES_ROOT_PATH = "dpr.maintenance.root.path";
+    public static final String MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH = "dpr.maintenance.listtable.recurseMaxDepth";
     public static final String CHECKPOINT_LOCATION = "checkpoint.location";
     public static final String BATCH_MAX_RETRIES = "dpr.batch.max.retries";
 
@@ -163,6 +164,16 @@ public class JobArguments {
 
     public String getMaintenanceTablesRootPath() {
         return getArgument(MAINTENANCE_TABLES_ROOT_PATH);
+    }
+
+    public int getMaintenanceListTableRecurseMaxDepth() {
+        // The Domain layer only has a depth of 2, with tables nested under domains
+        // e.g. s3://dpr-domain-preproduction/establishment/living_unit/
+        int defaultRecurseDepth = 2;
+        return Optional
+                .ofNullable(config.get(MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH))
+                .map(Integer::parseInt)
+                .orElse(defaultRecurseDepth);
     }
 
     public String getCheckpointLocation() {

--- a/src/main/java/uk/gov/justice/digital/job/CompactionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/CompactionJob.java
@@ -48,7 +48,11 @@ public class CompactionJob implements Runnable {
         try {
             logger.info("Compaction running");
             SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(jobArguments.getLogLevel());
-            maintenanceService.compactDeltaTables(spark, jobArguments.getMaintenanceTablesRootPath());
+
+            String rootPath = jobArguments.getMaintenanceTablesRootPath();
+            int maxDepth = jobArguments.getMaintenanceListTableRecurseMaxDepth();
+
+            maintenanceService.compactDeltaTables(spark, rootPath, maxDepth);
             logger.info("Compaction finished");
         } catch (Exception e) {
             logger.error("Caught exception during job run", e);

--- a/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
@@ -48,7 +48,11 @@ public class VacuumJob implements Runnable {
         try {
             logger.info("Vacuum running");
             SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(jobArguments.getLogLevel());
-            maintenanceService.vacuumDeltaTables(spark, jobArguments.getMaintenanceTablesRootPath());
+
+            String rootPath = jobArguments.getMaintenanceTablesRootPath();
+            int maxDepth = jobArguments.getMaintenanceListTableRecurseMaxDepth();
+
+            maintenanceService.vacuumDeltaTables(spark, rootPath, maxDepth);
             logger.info("Vacuum finished");
         } catch (Exception e) {
             logger.error("Caught exception during job run", e);

--- a/src/main/java/uk/gov/justice/digital/service/MaintenanceService.java
+++ b/src/main/java/uk/gov/justice/digital/service/MaintenanceService.java
@@ -25,11 +25,11 @@ public class MaintenanceService {
     }
 
     /**
-     * Runs a delta lake compaction on all delta lake tables immediately below rootPath
+     * Runs a delta lake compaction on all delta lake tables recursively below rootPath with the given depth limit
      */
-    public void compactDeltaTables(SparkSession spark, String rootPath) throws DataStorageException, MaintenanceOperationFailedException {
+    public void compactDeltaTables(SparkSession spark, String rootPath, int recurseForTablesDepthLimit) throws DataStorageException, MaintenanceOperationFailedException {
         logger.info("Beginning delta table compaction for tables under root path: {}", rootPath);
-        List<String> deltaTablePaths = storageService.listDeltaTablePaths(spark, rootPath);
+        List<String> deltaTablePaths = storageService.listDeltaTablePaths(spark, rootPath, recurseForTablesDepthLimit);
         logger.info("Found {} delta tables", deltaTablePaths.size());
         logger.debug("Found delta tables at the following paths: {}", String.join(", ", (deltaTablePaths)));
         attemptAll(deltaTablePaths, path -> storageService.compactDeltaTable(spark, path));
@@ -37,11 +37,11 @@ public class MaintenanceService {
     }
 
     /**
-     * Runs a delta lake vacuum on all delta lake tables immediately below rootPath
+     * Runs a delta lake vacuum on all delta lake tables recursively below rootPath with the given depth limit
      */
-    public void vacuumDeltaTables(SparkSession spark, String rootPath) throws DataStorageException, MaintenanceOperationFailedException {
+    public void vacuumDeltaTables(SparkSession spark, String rootPath, int recurseForTablesDepthLimit) throws DataStorageException, MaintenanceOperationFailedException {
         logger.info("Beginning delta table vacuum for tables under root path {}", rootPath);
-        List<String> deltaTablePaths = storageService.listDeltaTablePaths(spark, rootPath);
+        List<String> deltaTablePaths = storageService.listDeltaTablePaths(spark, rootPath, recurseForTablesDepthLimit);
         logger.info("Found {} delta tables", deltaTablePaths.size());
         logger.debug("Found delta tables at the following paths: {}", String.join(", ", (deltaTablePaths)));
         attemptAll(deltaTablePaths, path -> storageService.vacuum(spark, path));

--- a/src/test/java/uk/gov/justice/digital/service/DataStorageServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DataStorageServiceTest.java
@@ -26,7 +26,10 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class DataStorageServiceTest extends BaseSparkTest {
 
+    private static final int DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES = 1;
+
     private static final DataStorageService underTest = new DataStorageService();
+
 
     private MockedStatic<DeltaTable> mockDeltaTableStatic;
 
@@ -198,14 +201,14 @@ class DataStorageServiceTest extends BaseSparkTest {
     @Test
     public void shouldThrowForBadlyFormattedDeltaTablePath() {
         assertThrows(DataStorageException.class, () ->
-                underTest.listDeltaTablePaths(spark, "://some-path")
+                underTest.listDeltaTablePaths(spark, "://some-path", DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)
         );
     }
 
     @Test
     public void shouldThrowWhenDeltaTablePathDoesNotExist() {
         assertThrows(DataStorageException.class, () ->
-            underTest.listDeltaTablePaths(spark, "/doesnotexist")
+            underTest.listDeltaTablePaths(spark, "/doesnotexist", DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)
         );
     }
 

--- a/src/test/java/uk/gov/justice/digital/service/MaintenanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/MaintenanceServiceTest.java
@@ -52,6 +52,14 @@ class MaintenanceServiceTest {
     }
 
     @Test
+    public void compactShouldListTablePaths() throws Exception {
+        underTest.compactDeltaTables(mockSparkSession, rootPath, 1);
+        verify(mockDataStorageService).listDeltaTablePaths(mockSparkSession, rootPath, 1);
+        underTest.compactDeltaTables(mockSparkSession, "s3://anotherpath", 2);
+        verify(mockDataStorageService).listDeltaTablePaths(mockSparkSession, "s3://anotherpath", 2);
+    }
+
+    @Test
     public void shouldTryToCompactAllTablesWhenCompactionFailsWithConcurrentDeleteReadException() throws Exception {
         when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)).thenReturn(deltaTablePaths);
 
@@ -90,6 +98,14 @@ class MaintenanceServiceTest {
         verify(mockDataStorageService).vacuum(mockSparkSession, table1);
         verify(mockDataStorageService).vacuum(mockSparkSession, table2);
         verify(mockDataStorageService).vacuum(mockSparkSession, table3);
+    }
+
+    @Test
+    public void vacuumShouldListTablePaths() throws Exception {
+        underTest.vacuumDeltaTables(mockSparkSession, rootPath, 1);
+        verify(mockDataStorageService).listDeltaTablePaths(mockSparkSession, rootPath, 1);
+        underTest.vacuumDeltaTables(mockSparkSession, "s3://anotherpath", 2);
+        verify(mockDataStorageService).listDeltaTablePaths(mockSparkSession, "s3://anotherpath", 2);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/MaintenanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/MaintenanceServiceTest.java
@@ -29,6 +29,8 @@ class MaintenanceServiceTest {
     private static final String table3 = rootPath + "/table3";
     private static final List<String> deltaTablePaths = Arrays.asList(table1, table2, table3);
 
+    private static final int DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES = 1;
+
     private MaintenanceService underTest;
     @Mock
     private DataStorageService mockDataStorageService;
@@ -42,8 +44,8 @@ class MaintenanceServiceTest {
 
     @Test
     public void shouldCompactEachTable() throws Exception {
-        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath)).thenReturn(deltaTablePaths);
-        underTest.compactDeltaTables(mockSparkSession, rootPath);
+        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)).thenReturn(deltaTablePaths);
+        underTest.compactDeltaTables(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table1);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table2);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table3);
@@ -51,13 +53,13 @@ class MaintenanceServiceTest {
 
     @Test
     public void shouldTryToCompactAllTablesWhenCompactionFailsWithConcurrentDeleteReadException() throws Exception {
-        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath)).thenReturn(deltaTablePaths);
+        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)).thenReturn(deltaTablePaths);
 
         // This is a specific Exception we have seen and want to handle
         doThrow(new ConcurrentDeleteReadException("Failed compaction"))
                 .when(mockDataStorageService).compactDeltaTable(eq(mockSparkSession), anyString());
 
-        assertThrows(MaintenanceOperationFailedException.class, () -> underTest.compactDeltaTables(mockSparkSession, rootPath));
+        assertThrows(MaintenanceOperationFailedException.class, () -> underTest.compactDeltaTables(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES));
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table1);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table2);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table3);
@@ -65,7 +67,7 @@ class MaintenanceServiceTest {
 
     @Test
     public void shouldTryToCompactAllTablesWhenCompactionFailsWithException() throws Exception {
-        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath)).thenReturn(deltaTablePaths);
+        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)).thenReturn(deltaTablePaths);
 
         // make sure we handle checked and unchecked exceptions in general
         doThrow(new DataStorageException("Failed compaction"))
@@ -75,7 +77,7 @@ class MaintenanceServiceTest {
                 "Failed compaction"))
                 .when(mockDataStorageService).compactDeltaTable(eq(mockSparkSession), eq(table2));
 
-        assertThrows(MaintenanceOperationFailedException.class, () -> underTest.compactDeltaTables(mockSparkSession, rootPath));
+        assertThrows(MaintenanceOperationFailedException.class, () -> underTest.compactDeltaTables(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES));
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table1);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table2);
         verify(mockDataStorageService).compactDeltaTable(mockSparkSession, table3);
@@ -83,8 +85,8 @@ class MaintenanceServiceTest {
 
     @Test
     public void shouldVacuumEachTable() throws Exception {
-        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath)).thenReturn(deltaTablePaths);
-        underTest.vacuumDeltaTables(mockSparkSession, rootPath);
+        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)).thenReturn(deltaTablePaths);
+        underTest.vacuumDeltaTables(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES);
         verify(mockDataStorageService).vacuum(mockSparkSession, table1);
         verify(mockDataStorageService).vacuum(mockSparkSession, table2);
         verify(mockDataStorageService).vacuum(mockSparkSession, table3);
@@ -92,7 +94,7 @@ class MaintenanceServiceTest {
 
     @Test
     public void shouldTryToVacuumAllTablesWhenVacuumFailsWithException() throws Exception {
-        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath)).thenReturn(deltaTablePaths);
+        when(mockDataStorageService.listDeltaTablePaths(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES)).thenReturn(deltaTablePaths);
 
         doThrow(new DataStorageException("Failed vacuum"))
                 .when(mockDataStorageService).vacuum(eq(mockSparkSession), eq(table1));
@@ -101,7 +103,7 @@ class MaintenanceServiceTest {
                 "Failed vacuum"))
                 .when(mockDataStorageService).vacuum(eq(mockSparkSession), eq(table2));
 
-        assertThrows(MaintenanceOperationFailedException.class, () -> underTest.vacuumDeltaTables(mockSparkSession, rootPath));
+        assertThrows(MaintenanceOperationFailedException.class, () -> underTest.vacuumDeltaTables(mockSparkSession, rootPath, DEPTH_LIMIT_TO_RECURSE_DELTA_TABLES));
         verify(mockDataStorageService).vacuum(mockSparkSession, table1);
         verify(mockDataStorageService).vacuum(mockSparkSession, table2);
         verify(mockDataStorageService).vacuum(mockSparkSession, table3);


### PR DESCRIPTION
- Maintenance jobs can now recurse into S3 "directories" below the root to look for nested delta lake tables
- Recursing 2 levels deep works for domain (2 levels of nesting with a table in a domain, e.g. the establishment table in the establishment domain is s3://dpr-domain-development/establishment/establishment/ where s3://dpr-domain-development/ is the root)
- Still works for raw, structured, curated