### PR TITLE
DPR2-147: Fix streaming job not ingesting events after running idle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '7.1.1' // originally 7.1.2 but downgraded since circle CI build was failing
     id 'io.freefair.lombok' version '6.5.1'
     id 'org.sonarqube'  version '3.5.0.2730'
     id 'org.owasp.dependencycheck'  version '8.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     micronautVersion = '3.8.7'
     mockitoVersion = '4.11.0'
     sparkVersion = '3.3.0'
-    hadoopVersion = '3.3.1' // was hadoopVersion = '3.3.3' downgraded for Glue 4.0
+    hadoopVersion = '3.3.1' // was hadoopVersion = '3.3.1' downgraded for Glue 4.0
     awsKinesisVersion = '1.9.3' // was awsKinesisVersion = '1.14.10' downgraded for Glue 4.0
     awsSdkVersion = '1.12.425'
     glueApiVersion = '4.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     micronautVersion = '3.8.7'
     mockitoVersion = '4.11.0'
     sparkVersion = '3.3.0'
-    hadoopVersion = '3.3.1' // was hadoopVersion = '3.3.1' downgraded for Glue 4.0
+    hadoopVersion = '3.3.1' // was hadoopVersion = '3.3.3' downgraded for Glue 4.0
     awsKinesisVersion = '1.9.3' // was awsKinesisVersion = '1.14.10' downgraded for Glue 4.0
     awsSdkVersion = '1.12.425'
     glueApiVersion = '4.0.0'

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -142,6 +142,23 @@ class JobArgumentsIntegrationTest {
     }
 
     @Test
+    public void shouldThrowErrorWhenGivenInvalidIdleTimeBetweenReadsInMillis() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.IDLE_TIME_BETWEEN_READS_IN_MILLIS, "not a number");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertThrows(NumberFormatException.class, jobArguments::getIdleTimeBetweenReadsInMillis);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "1, 1", "0, 0", "12345, 12345", "0123, 123" })
+    public void shouldSetIdleTimeBetweenReadsInMillis(String input, Integer expected) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.IDLE_TIME_BETWEEN_READS_IN_MILLIS, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(expected.toString(), jobArguments.getIdleTimeBetweenReadsInMillis());
+    }
+
+    @Test
     public void shouldReturnCorrectValuesInGetConfig() {
         Map<String, String> actualArguments = validArguments.getConfig();
         assertEquals(testArguments, actualArguments);

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -5,6 +5,9 @@ import io.micronaut.context.env.CommandLinePropertySource;
 import io.micronaut.context.env.Environment;
 import lombok.val;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -33,6 +36,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.CHECKPOINT_LOCATION, "s3://somepath/checkpoint/app-name" },
             { JobArguments.KINESIS_STREAM_ARN, "arn:aws:kinesis:eu-west-2:123456:stream/dpr-kinesis-ingestor-env" },
             { JobArguments.KINESIS_STARTING_POSITION, "trim_horizon" },
+            { JobArguments.ADD_IDLE_TIME_BETWEEN_READS, "true" },
             { JobArguments.BATCH_MAX_RETRIES, "5" },
             { JobArguments.LOG_LEVEL, "debug" },
             { JobArguments.MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH, "1" },
@@ -60,6 +64,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.CHECKPOINT_LOCATION, validArguments.getCheckpointLocation() },
                 { JobArguments.KINESIS_STREAM_ARN, validArguments.getKinesisStreamArn() },
                 { JobArguments.KINESIS_STARTING_POSITION, validArguments.getKinesisStartingPosition() },
+                { JobArguments.ADD_IDLE_TIME_BETWEEN_READS, validArguments.addIdleTimeBetweenReads() },
                 { JobArguments.BATCH_MAX_RETRIES, Integer.toString(validArguments.getBatchMaxRetries()) },
                 { JobArguments.LOG_LEVEL, validArguments.getLogLevel().toString().toLowerCase() },
                 { JobArguments.MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH, Integer.toString(validArguments.getMaintenanceListTableRecurseMaxDepth()) },
@@ -116,6 +121,24 @@ class JobArgumentsIntegrationTest {
         args.put(JobArguments.LOG_LEVEL, "some level");
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals("WARN", jobArguments.getLogLevel().toString().toUpperCase());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "not a boolean", "1", "0", "" })
+    public void shouldDefaultToFalseForNonBooleanValueForAddIdleTimeBetweenReads(String input) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.ADD_IDLE_TIME_BETWEEN_READS, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals("false", jobArguments.addIdleTimeBetweenReads());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true, true", "false, false", "True, true", "False, false" })
+    public void shouldConvertValidValueForAddIdleTimeBetweenReadsToBoolean(String input, Boolean expected) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.ADD_IDLE_TIME_BETWEEN_READS, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(expected.toString(), jobArguments.addIdleTimeBetweenReads());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisDataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisDataProvider.java
@@ -30,6 +30,7 @@ public class KinesisDataProvider {
         Map<String, String> kinesisConnectionOptions = new HashMap<>();
         kinesisConnectionOptions.put("streamARN", arguments.getKinesisStreamArn());
         kinesisConnectionOptions.put("startingPosition", arguments.getKinesisStartingPosition());
+        kinesisConnectionOptions.put("addIdleTimeBetweenReads", arguments.addIdleTimeBetweenReads());
         // https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-format-json-home.html
         kinesisConnectionOptions.put("classification", "json");
         kinesisConnectionOptions.put("inferSchema", "false");

--- a/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisDataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/kinesis/KinesisDataProvider.java
@@ -30,7 +30,14 @@ public class KinesisDataProvider {
         Map<String, String> kinesisConnectionOptions = new HashMap<>();
         kinesisConnectionOptions.put("streamARN", arguments.getKinesisStreamArn());
         kinesisConnectionOptions.put("startingPosition", arguments.getKinesisStartingPosition());
-        kinesisConnectionOptions.put("addIdleTimeBetweenReads", arguments.addIdleTimeBetweenReads());
+
+        String addIdleTimeBetweenReads = arguments.addIdleTimeBetweenReads();
+        kinesisConnectionOptions.put("addIdleTimeBetweenReads", addIdleTimeBetweenReads);
+
+        if (Boolean.parseBoolean(addIdleTimeBetweenReads)) {
+            kinesisConnectionOptions.put("idleTimeBetweenReadsInMs", arguments.getIdleTimeBetweenReadsInMillis());
+        }
+
         // https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-format-json-home.html
         kinesisConnectionOptions.put("classification", "json");
         kinesisConnectionOptions.put("inferSchema", "false");

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -46,6 +46,7 @@ public class JobArguments {
     // (where Z represents a UTC timezone offset with a +/-. For example "2023-04-04T08:00:00-04:00").
     // We default to trim_horizon to avoid data loss
     public static final String KINESIS_STARTING_POSITION_DEFAULT = "trim_horizon";
+    public static final String ADD_IDLE_TIME_BETWEEN_READS = "dpr.add.idle.time.between.reads";
     public static final String RAW_S3_PATH = "dpr.raw.s3.path";
     public static final String STRUCTURED_S3_PATH = "dpr.structured.s3.path";
     public static final String VIOLATIONS_S3_PATH = "dpr.violations.s3.path";
@@ -122,6 +123,13 @@ public class JobArguments {
 
     public String getKinesisStartingPosition() {
         return getArgument(KINESIS_STARTING_POSITION, KINESIS_STARTING_POSITION_DEFAULT);
+    }
+
+    public String addIdleTimeBetweenReads() {
+        return String.valueOf(
+                Optional.of(config.get(ADD_IDLE_TIME_BETWEEN_READS).toLowerCase())
+                .map(Boolean::parseBoolean)
+                .orElse(false));
     }
 
     public String getKinesisStreamArn() {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -46,7 +46,11 @@ public class JobArguments {
     // (where Z represents a UTC timezone offset with a +/-. For example "2023-04-04T08:00:00-04:00").
     // We default to trim_horizon to avoid data loss
     public static final String KINESIS_STARTING_POSITION_DEFAULT = "trim_horizon";
+    // See https://docs.aws.amazon.com/glue/latest/webapi/API_KinesisStreamingSourceOptions.html
+    // dpr.add.idle.time.between.reads defaults to false thereby causing IdleTimeBetweenReadsInMs to default to 0 ms
     public static final String ADD_IDLE_TIME_BETWEEN_READS = "dpr.add.idle.time.between.reads";
+    // The provided value for dpr.idle.time.between.reads.millis is only applied when dpr.add.idle.time.between.reads is true
+    public static final String IDLE_TIME_BETWEEN_READS_IN_MILLIS = "dpr.idle.time.between.reads.millis";
     public static final String RAW_S3_PATH = "dpr.raw.s3.path";
     public static final String STRUCTURED_S3_PATH = "dpr.structured.s3.path";
     public static final String VIOLATIONS_S3_PATH = "dpr.violations.s3.path";
@@ -128,8 +132,20 @@ public class JobArguments {
     public String addIdleTimeBetweenReads() {
         return String.valueOf(
                 Optional.of(config.get(ADD_IDLE_TIME_BETWEEN_READS).toLowerCase())
-                .map(Boolean::parseBoolean)
-                .orElse(false));
+                        .map(Boolean::parseBoolean)
+                        .orElse(false));
+    }
+
+    public String getIdleTimeBetweenReadsInMillis() {
+        if (!Boolean.parseBoolean(addIdleTimeBetweenReads())) {
+            logger.warn(
+                    "Argument {} will not be applied when {} is omitted or set to false",
+                    IDLE_TIME_BETWEEN_READS_IN_MILLIS,
+                    ADD_IDLE_TIME_BETWEEN_READS
+            );
+        }
+
+        return String.valueOf(Integer.parseInt(getArgument(IDLE_TIME_BETWEEN_READS_IN_MILLIS)));
     }
 
     public String getKinesisStreamArn() {

--- a/src/main/java/uk/gov/justice/digital/zone/raw/RawZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/raw/RawZone.java
@@ -23,6 +23,7 @@ import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.*;
 public class RawZone implements Zone {
 
     public static final String PRIMARY_KEY_NAME = "id";
+    public static final SourceReference.PrimaryKey primaryKey = new SourceReference.PrimaryKey(PRIMARY_KEY_NAME);
     private static final Logger logger = LoggerFactory.getLogger(RawZone.class);
 
     private final String rawS3Path;
@@ -51,7 +52,7 @@ public class RawZone implements Zone {
 
         logger.debug("Applying batch to deltalake table: {}", tablePath);
         val rawDataFrame = createRawDataFrame(records);
-        storage.appendDistinct(tablePath, rawDataFrame, new SourceReference.PrimaryKey(PRIMARY_KEY_NAME));
+        storage.appendDistinct(tablePath, rawDataFrame, primaryKey);
 
         logger.debug("Append completed successfully");
 


### PR DESCRIPTION
This fixes the streaming job not ingesting events in dev after running idle for an extended period.
This provides configurable arguments to add an idle time between reads.