### PR TITLE
DPR2-151 write violations on retry failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ run the tests.
     TBD
 ```
 
+
 ## Contributing
 
 Please adhere to the following guidelines when making contributions to the
@@ -106,6 +107,123 @@ project.
 ### Releases
 
 - v1.0.0
+
+## DataStorageService Backoff Retry
+- `dpr.datastorage.retry.maxAttempts` - The maximum number of attempts to make, i.e. 1 means no retries, 10 means make the 1st attempt + 9 retries.
+- `dpr.datastorage.retry.minWaitMillis` - The minimum time to wait after an attempt before retrying in milliseconds, prior to jitter being applied.
+- `dpr.datastorage.retry.maxWaitMillis` - The maximum time to wait after an attempt before retrying in milliseconds, prior to jitter being applied.
+- `dpr.datastorage.retry.jitterFactor` - If greater than zero it applies some random jitter to the calculated wait time, e.g. 0.25 jitter factor will add or subtract up to 250ms from a 1 second wait time.
+
+Note that jitter can result in the wait for one iteration exceeding maxWaitMillis. The actual maximum wait is `maxWaitMillis + (maxWaitMillis * jitterFactor)`.
+
+Here are some examples settings and log outputs showing time taken (where the retried example operation takes zero time).
+
+- maxAttempts: 10
+- minWaitMillis: 100
+- maxWaitMillis: 500
+- jitterFactor: 0.25
+
+```
+Retrying after attempt 1. Elapsed time total: 200ms.
+Retrying after attempt 2. Elapsed time total: 445ms.
+Retrying after attempt 3. Elapsed time total: 874ms.
+Retrying after attempt 4. Elapsed time total: 1,374ms.
+Retrying after attempt 5. Elapsed time total: 1,925ms.
+Retrying after attempt 6. Elapsed time total: 2,374ms.
+Retrying after attempt 7. Elapsed time total: 3,045ms.
+Retrying after attempt 8. Elapsed time total: 3,575ms.
+Retrying after attempt 9. Elapsed time total: 4,205ms.
+Retries exceeded on attempt 10. Elapsed time total: 4,207ms.
+```
+
+- maxAttempts: 10
+- minWaitMillis: 100
+- maxWaitMillis: 5000
+- jitterFactor: 0.25
+
+```
+Retrying after attempt 1. Elapsed time total: 200ms.
+Retrying after attempt 2. Elapsed time total: 454ms.
+Retrying after attempt 3. Elapsed time total: 835ms.
+Retrying after attempt 4. Elapsed time total: 1,879ms.
+Retrying after attempt 5. Elapsed time total: 3,932ms.
+Retrying after attempt 6. Elapsed time total: 7,753ms.
+Retrying after attempt 7. Elapsed time total: 13,629ms.
+Retrying after attempt 8. Elapsed time total: 19,280ms.
+Retrying after attempt 9. Elapsed time total: 23,788ms.
+Retries exceeded on attempt 10. Elapsed time total: 23,790ms.
+```
+
+- maxAttempts: 10
+- minWaitMillis: 100
+- maxWaitMillis: 10000
+- jitterFactor: 0.25
+
+```
+Retrying after attempt 1. Elapsed time total: 204ms.
+Retrying after attempt 2. Elapsed time total: 442ms.
+Retrying after attempt 3. Elapsed time total: 1,013ms.
+Retrying after attempt 4. Elapsed time total: 2,060ms.
+Retrying after attempt 5. Elapsed time total: 3,948ms.
+Retrying after attempt 6. Elapsed time total: 6,641ms.
+Retrying after attempt 7. Elapsed time total: 13,488ms.
+Retrying after attempt 8. Elapsed time total: 23,605ms.
+Retrying after attempt 9. Elapsed time total: 31,772ms.
+Retries exceeded on attempt 10. Elapsed time total: 31,774ms.
+```
+
+- maxAttempts: 10
+- minWaitMillis: 500
+- maxWaitMillis: 5000
+- jitterFactor: 0.25
+
+```
+Retrying after attempt 1. Elapsed time total: 705ms.
+Retrying after attempt 2. Elapsed time total: 1,829ms.
+Retrying after attempt 3. Elapsed time total: 4,383ms.
+Retrying after attempt 4. Elapsed time total: 9,286ms.
+Retrying after attempt 5. Elapsed time total: 14,087ms.
+Retrying after attempt 6. Elapsed time total: 18,729ms.
+Retrying after attempt 7. Elapsed time total: 24,264ms.
+Retrying after attempt 8. Elapsed time total: 29,515ms.
+Retrying after attempt 9. Elapsed time total: 34,571ms.
+Retries exceeded on attempt 10. Elapsed time total: 34,573ms.
+```
+
+- maxAttempts: 10
+- minWaitMillis: 500
+- maxWaitMillis: 10000
+- jitterFactor: 0.25
+
+```
+Retrying after attempt 1. Elapsed time total: 469ms.
+Retrying after attempt 2. Elapsed time total: 1,405ms.
+Retrying after attempt 3. Elapsed time total: 3,665ms.
+Retrying after attempt 4. Elapsed time total: 8,505ms.
+Retrying after attempt 5. Elapsed time total: 18,406ms.
+Retrying after attempt 6. Elapsed time total: 28,948ms.
+Retrying after attempt 7. Elapsed time total: 41,448ms.
+Retrying after attempt 8. Elapsed time total: 50,899ms.
+Retrying after attempt 9. Elapsed time total: 60,200ms.
+Retries exceeded on attempt 10. Elapsed time total: 60,202ms.
+```
+
+- maxAttempts: 10
+- minWaitMillis: 1000
+- maxWaitMillis: 20000
+- jitterFactor: 0.25
+```
+Retrying after attempt 1. Elapsed time total: 1,121ms.
+Retrying after attempt 2. Elapsed time total: 3,296ms.
+Retrying after attempt 3. Elapsed time total: 6,489ms.
+Retrying after attempt 4. Elapsed time total: 14,194ms.
+Retrying after attempt 5. Elapsed time total: 32,057ms.
+Retrying after attempt 6. Elapsed time total: 57,081ms.
+Retrying after attempt 7. Elapsed time total: 75,936ms.
+Retrying after attempt 8. Elapsed time total: 92,927ms.
+Retrying after attempt 9. Elapsed time total: 111,546ms.
+Retries exceeded on attempt 10. Elapsed time total: 111,548ms.
+```
 
 ## TODO
 

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIntegrationTest.java
@@ -13,13 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
-import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.converter.dms.DMS_3_4_7;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
-import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.service.DomainService;
 import uk.gov.justice.digital.service.SourceReferenceService;
+import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.zone.curated.CuratedZoneCDC;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
 import uk.gov.justice.digital.zone.raw.RawZone;
@@ -53,9 +52,7 @@ public class BatchProcessorIntegrationTest extends BaseSparkTest {
     @Mock
     private SourceReferenceService sourceReferenceService;
     @Mock
-    private DataStorageService storageService;
-    @Mock
-    private JobArguments arguments;
+    private ViolationService violationService;
 
     private DMS_3_4_7 converter;
 
@@ -76,7 +73,6 @@ public class BatchProcessorIntegrationTest extends BaseSparkTest {
     void setUp() {
         converter = new DMS_3_4_7(spark);
         undertest = new BatchProcessor(
-                arguments,
                 rawZone,
                 structuredZoneLoad,
                 structuredZoneCDC,
@@ -84,7 +80,7 @@ public class BatchProcessorIntegrationTest extends BaseSparkTest {
                 curatedZoneCDC,
                 domainService,
                 sourceReferenceService,
-                storageService
+                violationService
         );
     }
 
@@ -184,7 +180,6 @@ public class BatchProcessorIntegrationTest extends BaseSparkTest {
     }
 
     private void shouldAppendViolations(int numTimes) throws DataStorageException {
-        verify(storageService, times(numTimes)).append(anyString(), any());
-        verify(storageService, times(numTimes)).updateDeltaManifestForTable(eq(spark), anyString());
+        verify(violationService, times(numTimes)).handleNoSchemaFound(eq(spark), any(), anyString(), any());
     }
 }

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -63,7 +63,7 @@ public class JobArguments {
     public static final int MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH_DEFAULT = 2;
     public static final String CHECKPOINT_LOCATION = "checkpoint.location";
     public static final String BATCH_MAX_RETRIES = "dpr.batch.max.retries";
-    public static final int BATCH_MAX_RETRIES_DEFAULT =3;
+    public static final int BATCH_MAX_RETRIES_DEFAULT = 3;
     public static final String DATA_STORAGE_RETRY_MAX_ATTEMPTS = "dpr.datastorage.retry.maxAttempts";
     // You can turn off retries by setting max attempts to 1
     public static final int DATA_STORAGE_RETRY_MAX_ATTEMPTS_DEFAULT = 1;

--- a/src/main/java/uk/gov/justice/digital/exception/DataStorageException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/DataStorageException.java
@@ -8,6 +8,10 @@ public class DataStorageException extends Exception {
         super(errorMessage);
     }
 
+    public DataStorageException(Throwable cause) {
+        super(cause);
+    }
+
     public DataStorageException(String errorMessage, Throwable cause) {
         super(errorMessage, cause);
     }

--- a/src/main/java/uk/gov/justice/digital/exception/DataStorageRetriesExhaustedException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/DataStorageRetriesExhaustedException.java
@@ -6,6 +6,7 @@ package uk.gov.justice.digital.exception;
 public class DataStorageRetriesExhaustedException extends DataStorageException {
 
     private static final long serialVersionUID = -2122315875377665022L;
+
     public DataStorageRetriesExhaustedException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/uk/gov/justice/digital/exception/DataStorageRetriesExhaustedException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/DataStorageRetriesExhaustedException.java
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.exception;
+
+/**
+ * Thrown when the DataStorageService exceeds the configured number of retries/attempts.
+ */
+public class DataStorageRetriesExhaustedException extends DataStorageException {
+    public DataStorageRetriesExhaustedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/exception/DataStorageRetriesExhaustedException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/DataStorageRetriesExhaustedException.java
@@ -4,6 +4,8 @@ package uk.gov.justice.digital.exception;
  * Thrown when the DataStorageService exceeds the configured number of retries/attempts.
  */
 public class DataStorageRetriesExhaustedException extends DataStorageException {
+
+    private static final long serialVersionUID = -2122315875377665022L;
     public DataStorageRetriesExhaustedException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -395,18 +395,20 @@ public class DataStorageService {
                 .onFailedAttempt(e -> {
                     Throwable lastException = e.getLastException();
                     int thisAttempt = e.getAttemptCount();
-                    Duration elapsedTimeTotal = e.getElapsedTime();
-                    Duration elapsedTimeSinceAttemptStarted = e.getElapsedAttemptTime();
-                    String msg = format("Failed attempt %d. Elapsed time total: %s. Elapsed time since attempt started: %s.", thisAttempt, elapsedTimeTotal, elapsedTimeSinceAttemptStarted);
+                    String msg = format("Failed attempt %,d.", thisAttempt);
                     logger.debug(msg, lastException);
                 })
-                .onRetry(e -> logger.debug("Retrying..."))
+                .onRetry(e -> {
+                    int lastAttempt = e.getAttemptCount();
+                    long elapsedTimeTotal = e.getElapsedTime().toMillis();
+                    String msg = format("Retrying after attempt %,d. Elapsed time total: %,dms.", lastAttempt, elapsedTimeTotal);
+                    logger.debug(msg);
+                })
                 .onRetriesExceeded(e -> {
                     Throwable lastException = e.getException();
                     int thisAttempt = e.getAttemptCount();
-                    Duration elapsedTimeTotal = e.getElapsedTime();
-                    Duration elapsedTimeSinceAttemptStarted = e.getElapsedAttemptTime();
-                    String msg = format("Retries exceeded on attempt %d. Elapsed time total: %s. Elapsed time since attempt started: %s.", thisAttempt, elapsedTimeTotal, elapsedTimeSinceAttemptStarted);
+                    long elapsedTimeTotal = e.getElapsedTime().toMillis();
+                    String msg = format("Retries exceeded on attempt %,d. Elapsed time total: %,dms.", thisAttempt, elapsedTimeTotal);
                     logger.error(msg, lastException);
                 });
         return builder.build();

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -6,6 +6,7 @@ import dev.failsafe.RetryPolicyBuilder;
 import dev.failsafe.function.CheckedRunnable;
 import io.delta.tables.DeltaTable;
 import jakarta.inject.Inject;
+import lombok.Getter;
 import lombok.val;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,6 +48,16 @@ public class DataStorageService {
 
     // Retry policy used on operations that are at risk of concurrent modification exceptions
     private final RetryPolicy<Void> retryPolicy;
+
+    @Getter
+    public static class DataStorageContext {
+        private final String zone;
+
+        public DataStorageContext(String zone) {
+            this.zone = zone;
+        }
+
+    }
 
     @Inject
     public DataStorageService(JobArguments jobArguments) {

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.domain.model.TableIdentifier;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -108,7 +109,7 @@ public class DataStorageService {
             SparkSession spark,
             String tablePath,
             Dataset<Row> dataFrame,
-            SourceReference.PrimaryKey primaryKey) {
+            SourceReference.PrimaryKey primaryKey) throws DataStorageRetriesExhaustedException {
         val dt = getTable(spark, tablePath);
 
         try {
@@ -127,6 +128,9 @@ public class DataStorageService {
             } else {
                 logger.error("Failed to upsert table {}. Delta table is not present", tablePath);
             }
+        } catch (DataStorageRetriesExhaustedException e) {
+            // We don't want to catch this particular Exception so rethrow before the next catch block
+            throw e;
         } catch (Exception e) {
             val errorMessage = String.format("Failed to upsert table %s", tablePath);
             logger.error(errorMessage, e);
@@ -137,7 +141,7 @@ public class DataStorageService {
             SparkSession spark,
             String tablePath,
             Dataset<Row> dataFrame,
-            SourceReference.PrimaryKey primaryKey) {
+            SourceReference.PrimaryKey primaryKey) throws DataStorageRetriesExhaustedException {
         val dt = getTable(spark, tablePath);
 
         try {
@@ -154,6 +158,9 @@ public class DataStorageService {
             } else {
                 logger.error("Failed to update table {}. Delta table is not present", tablePath);
             }
+        } catch (DataStorageRetriesExhaustedException e) {
+            // We don't want to catch this particular Exception so rethrow before the next catch block
+            throw e;
         } catch (Exception e) {
             val errorMessage = String.format("Failed to update table %s", tablePath);
             logger.error(errorMessage, e);
@@ -164,7 +171,7 @@ public class DataStorageService {
             SparkSession spark,
             String tablePath,
             Dataset<Row> dataFrame,
-            SourceReference.PrimaryKey primaryKey) {
+            SourceReference.PrimaryKey primaryKey) throws DataStorageRetriesExhaustedException {
         val dt = getTable(spark, tablePath);
 
         try {
@@ -181,6 +188,9 @@ public class DataStorageService {
             } else {
                 logger.error("Failed to delete table {}. Delta table is not present", tablePath);
             }
+        } catch (DataStorageRetriesExhaustedException e) {
+            // We don't want to catch this particular Exception so rethrow before the next catch block
+            throw e;
         } catch (Exception e) {
             val errorMessage = String.format("Failed to delete table %s", tablePath);
             logger.error(errorMessage, e);
@@ -288,7 +298,7 @@ public class DataStorageService {
     public void updateDeltaManifestForTable(SparkSession spark, String tablePath) {
         logger.info("Updating manifest for table: {}", tablePath);
 
-        val  deltaTable = getTable(spark, tablePath);
+        val deltaTable = getTable(spark, tablePath);
 
         if (deltaTable.isPresent()) updateManifest(deltaTable.get());
         else logger.warn("Unable to update manifest for table: {} Not a delta table", tablePath);
@@ -361,8 +371,12 @@ public class DataStorageService {
 
     }
 
-    private void doWithRetryOnConcurrentModification(CheckedRunnable runnable) {
-        Failsafe.with(retryPolicy).run(runnable);
+    private void doWithRetryOnConcurrentModification(CheckedRunnable runnable) throws DataStorageRetriesExhaustedException {
+        try {
+            Failsafe.with(retryPolicy).run(runnable);
+        } catch (DeltaConcurrentModificationException e) {
+            throw new DataStorageRetriesExhaustedException(e);
+        }
     }
 
     private static RetryPolicy<Void> buildRetryPolicy(JobArguments jobArguments) {

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -6,7 +6,6 @@ import dev.failsafe.RetryPolicyBuilder;
 import dev.failsafe.function.CheckedRunnable;
 import io.delta.tables.DeltaTable;
 import jakarta.inject.Inject;
-import lombok.Getter;
 import lombok.val;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -48,16 +47,6 @@ public class DataStorageService {
 
     // Retry policy used on operations that are at risk of concurrent modification exceptions
     private final RetryPolicy<Void> retryPolicy;
-
-    @Getter
-    public static class DataStorageContext {
-        private final String zone;
-
-        public DataStorageContext(String zone) {
-            this.zone = zone;
-        }
-
-    }
 
     @Inject
     public DataStorageService(JobArguments jobArguments) {

--- a/src/main/java/uk/gov/justice/digital/service/ViolationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ViolationService.java
@@ -30,6 +30,9 @@ public class ViolationService {
     private final String violationsPath;
     private final DataStorageService storageService;
 
+    /**
+     * Allows us to record where a violation occurred.
+     */
     public enum ZoneName {
         RAW("Raw"),
         STRUCTURED_LOAD("Structured Load"),

--- a/src/main/java/uk/gov/justice/digital/service/ViolationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ViolationService.java
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.service;
+
+import jakarta.inject.Inject;
+import lombok.val;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
+
+import javax.inject.Singleton;
+
+import static java.lang.String.format;
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.lit;
+import static uk.gov.justice.digital.common.CommonDataFields.ERROR;
+import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.DATA;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.METADATA;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+
+@Singleton
+public class ViolationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ViolationService.class);
+
+    private final String violationsPath;
+    private final DataStorageService storageService;
+
+    public enum ZoneName {
+        RAW("Raw"),
+        STRUCTURED_LOAD("Structured Load"),
+        STRUCTURED_CDC("Structured CDC"),
+        CURATED_LOAD("Curated Load"),
+        CURATED_CDC("Curated CDC");
+
+        private final String name;
+
+        ZoneName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    @Inject
+    public ViolationService(
+            JobArguments arguments,
+            DataStorageService storageService
+    ) {
+        this.violationsPath = arguments.getViolationsS3Path();
+        this.storageService = storageService;
+    }
+
+    public void handleRetriesExhausted(
+            SparkSession spark,
+            Dataset<Row> dataFrame,
+            String source,
+            String table,
+            DataStorageRetriesExhaustedException cause,
+            ZoneName zoneName
+    ) {
+        String violationMessage = format("Violation - Data storage service retries exceeded for %s/%s for %s", source, table, zoneName);
+        logger.warn(violationMessage, cause);
+        val destinationPath = createValidatedPath(violationsPath, source, table);
+        val violationDf = dataFrame
+                .select(col(DATA), col(METADATA))
+                .withColumn(ERROR, lit(violationMessage));
+        try {
+            storageService.append(destinationPath, violationDf);
+            storageService.updateDeltaManifestForTable(spark, destinationPath);
+        } catch (DataStorageException e) {
+            String msg = "Could not write violation data";
+            logger.error(msg, e);
+            // This is a serious problem because we could lose data if we don't stop here
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    public void handleNoSchemaFound(
+            SparkSession spark,
+            Dataset<Row> dataFrame,
+            String source,
+            String table
+    ) throws DataStorageException {
+        logger.warn("Violation - No schema found for {}/{}", source, table);
+        val destinationPath = createValidatedPath(violationsPath, source, table);
+
+        val missingSchemaRecords = dataFrame
+                .select(col(DATA), col(METADATA))
+                .withColumn(ERROR, lit(format("Schema does not exist for %s/%s", source, table)))
+                .drop(OPERATION);
+
+        storageService.append(destinationPath, missingSchemaRecords);
+        storageService.updateDeltaManifestForTable(spark, destinationPath);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/writer/Writer.java
+++ b/src/main/java/uk/gov/justice/digital/writer/Writer.java
@@ -10,11 +10,11 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.converter.dms.DMS_3_4_7;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.function.Consumer;
 
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.Operation.getOperation;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
@@ -58,22 +58,25 @@ public abstract class Writer {
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
-    ) {
+    ) throws DataStorageRetriesExhaustedException {
         logger.info("Applying {} CDC records to deltalake table: {}", validRecords.count(), destinationPath);
-        validRecords.collectAsList().forEach(processRow(spark, storage, destinationPath, primaryKey));
+
+        for (Row row: validRecords.collectAsList()) {
+            processRow(spark, storage, destinationPath, primaryKey, row);
+        }
 
         logger.info("CDC records successfully applied to table: {}", destinationPath);
         storage.updateDeltaManifestForTable(spark, destinationPath);
     }
 
     @NotNull
-    protected static Consumer<Row> processRow(
+    protected static void processRow(
             SparkSession spark,
             DataStorageService storage,
             String destinationPath,
-            SourceReference.PrimaryKey primaryKey
-    ) {
-        return row -> {
+            SourceReference.PrimaryKey primaryKey,
+            Row row
+    ) throws DataStorageRetriesExhaustedException {
             String unvalidatedOperation = row.getAs(OPERATION);
             val optionalOperation = getOperation(unvalidatedOperation);
 
@@ -81,13 +84,15 @@ public abstract class Writer {
                 val operation = optionalOperation.get();
                 try {
                     writeRow(spark, storage, destinationPath, primaryKey, operation, row);
+                } catch (DataStorageRetriesExhaustedException ex) {
+                    // We rethrow because we do not want to catch this specific DataStorageException here
+                    throw ex;
                 } catch (DataStorageException ex) {
                     logger.error("Failed to {}", String.format("%s: %s to %s", operation.getName(), row.json(), destinationPath), ex);
                 }
             } else {
                 logger.error("Operation {} is invalid for {} to {}", unvalidatedOperation, row.json(), destinationPath);
             }
-        };
     }
 
     private static void writeRow(

--- a/src/main/java/uk/gov/justice/digital/writer/curated/CuratedZoneCdcWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/curated/CuratedZoneCdcWriter.java
@@ -4,6 +4,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import uk.gov.justice.digital.domain.model.SourceReference;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.writer.Writer;
 
@@ -23,7 +24,7 @@ public class CuratedZoneCdcWriter extends Writer {
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
-    ) {
+    ) throws DataStorageRetriesExhaustedException {
         writeCdcRecords(spark, storage, destinationPath, primaryKey, validRecords);
     }
 

--- a/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneCdcWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneCdcWriter.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.writer.Writer;
 
@@ -31,7 +32,7 @@ public class StructuredZoneCdcWriter extends Writer {
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
-    ) {
+    ) throws DataStorageRetriesExhaustedException {
         writeCdcRecords(spark, storage, destinationPath, primaryKey, validRecords);
     }
 

--- a/src/main/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoad.java
+++ b/src/main/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoad.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
+import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.writer.Writer;
 import uk.gov.justice.digital.writer.curated.CuratedZoneLoadWriter;
 
@@ -21,20 +23,25 @@ public class CuratedZoneLoad extends CuratedZone {
 
     private static final Logger logger = LoggerFactory.getLogger(CuratedZoneLoad.class);
 
+    private final ViolationService violationService;
+
     @Inject
     public CuratedZoneLoad(
             JobArguments jobArguments,
-            DataStorageService storage
+            DataStorageService storage,
+            ViolationService violationService
     ) {
-        this(jobArguments, createWriter(storage));
+        this(jobArguments, createWriter(storage), violationService);
     }
 
     @SuppressWarnings("unused")
     private CuratedZoneLoad(
             JobArguments jobArguments,
-            Writer writer
+            Writer writer,
+            ViolationService violationService
     ) {
         super(jobArguments, writer);
+        this.violationService = violationService;
     }
 
     private static Writer createWriter(DataStorageService storage) {
@@ -43,20 +50,25 @@ public class CuratedZoneLoad extends CuratedZone {
 
     @Override
     public Dataset<Row> process(SparkSession spark, Dataset<Row> dataFrame, SourceReference sourceReference) throws DataStorageException {
-        if (dataFrame.isEmpty()) {
-            return spark.emptyDataFrame();
-        } else {
-            String sourceName = sourceReference.getSource();
-            String tableName = sourceReference.getTable();
+        Dataset<Row> result;
+        try {
+            if (dataFrame.isEmpty()) {
+                result = spark.emptyDataFrame();
+            } else {
+                String sourceName = sourceReference.getSource();
+                String tableName = sourceReference.getTable();
 
-            val startTime = System.currentTimeMillis();
+                val startTime = System.currentTimeMillis();
 
-            logger.debug("Processing records for {}/{}", sourceName, tableName);
-            val result = super.process(spark, dataFrame, sourceReference);
-            logger.debug("Processed batch in {}ms", System.currentTimeMillis() - startTime);
-
-            return result;
+                logger.debug("Processing records for {}/{}", sourceName, tableName);
+                result = super.process(spark, dataFrame, sourceReference);
+                logger.debug("Processed batch in {}ms", System.currentTimeMillis() - startTime);
+            }
+        } catch (DataStorageRetriesExhaustedException e) {
+            violationService.handleRetriesExhausted(spark, dataFrame, sourceReference.getSource(), sourceReference.getTable(), e, ViolationService.ZoneName.CURATED_LOAD);
+            result = spark.emptyDataFrame();
         }
+        return result;
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/zone/raw/RawZone.java
+++ b/src/main/java/uk/gov/justice/digital/zone/raw/RawZone.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
+import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.zone.Zone;
 
 import javax.inject.Inject;
@@ -28,11 +30,13 @@ public class RawZone implements Zone {
 
     private final String rawS3Path;
     private final DataStorageService storage;
+    private final ViolationService violationService;
 
     @Inject
-    public RawZone(JobArguments jobArguments, DataStorageService storage) {
+    public RawZone(JobArguments jobArguments, DataStorageService storage, ViolationService violationService) {
         this.rawS3Path = jobArguments.getRawS3Path();
         this.storage = storage;
+        this.violationService = violationService;
     }
 
     @Override
@@ -45,22 +49,28 @@ public class RawZone implements Zone {
 
         String rowSource = sourceReference.getSource();
         String rowTable = sourceReference.getTable();
+        Dataset<Row> result;
+        try {
 
-        logger.debug("Processing batch for source: {} table: {}", rowSource, rowTable);
+            logger.debug("Processing batch for source: {} table: {}", rowSource, rowTable);
 
-        val tablePath = getTablePath(sourceReference);
+            val tablePath = getTablePath(sourceReference);
 
-        logger.debug("Applying batch to deltalake table: {}", tablePath);
-        val rawDataFrame = createRawDataFrame(records);
-        storage.appendDistinct(tablePath, rawDataFrame, primaryKey);
+            logger.debug("Applying batch to deltalake table: {}", tablePath);
+            val rawDataFrame = createRawDataFrame(records);
+            storage.appendDistinct(tablePath, rawDataFrame, primaryKey);
 
-        logger.debug("Append completed successfully");
+            logger.debug("Append completed successfully");
 
-        storage.updateDeltaManifestForTable(spark, tablePath);
+            storage.updateDeltaManifestForTable(spark, tablePath);
 
+            result = rawDataFrame;
+        } catch (DataStorageRetriesExhaustedException e) {
+            violationService.handleRetriesExhausted(spark, records, rowSource, rowTable, e, ViolationService.ZoneName.RAW);
+            result = spark.emptyDataFrame();
+        }
         logger.debug("Processed batch for {}/{} in {}ms", rowSource, rowTable, System.currentTimeMillis() - startTime);
-
-        return rawDataFrame;
+        return result;
     }
 
     private static Dataset<Row> createRawDataFrame(Dataset<Row> dataset) {

--- a/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZoneCDC.java
+++ b/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZoneCDC.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
+import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.writer.Writer;
 import uk.gov.justice.digital.writer.structured.StructuredZoneCdcWriter;
 
@@ -18,26 +20,32 @@ import javax.inject.Inject;
 import static org.apache.spark.sql.functions.col;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.Operation.cdcOperations;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.*;
+import static uk.gov.justice.digital.service.ViolationService.ZoneName.STRUCTURED_CDC;
 
 public class StructuredZoneCDC extends StructuredZone {
 
     private static final Logger logger = LoggerFactory.getLogger(StructuredZoneCDC.class);
 
+    private final ViolationService violationService;
+
 
     @Inject
     public StructuredZoneCDC(
             JobArguments jobArguments,
-            DataStorageService storage
+            DataStorageService storage,
+            ViolationService violationService
     ) {
-        this(jobArguments, createWriter(storage));
+        this(jobArguments, createWriter(storage), violationService);
     }
 
     @SuppressWarnings("unused")
     private StructuredZoneCDC(
             JobArguments jobArguments,
-            Writer writer
+            Writer writer,
+            ViolationService violationService
     ) {
         super(jobArguments, writer);
+        this.violationService = violationService;
     }
 
     private static Writer createWriter(DataStorageService storage) {
@@ -46,22 +54,26 @@ public class StructuredZoneCDC extends StructuredZone {
 
     @Override
     public Dataset<Row> process(SparkSession spark, Dataset<Row> dataFrame, SourceReference sourceReference) throws DataStorageException {
+        Dataset<Row> result;
         val filteredRecords = dataFrame.filter(col(OPERATION).isin(cdcOperations));
+        try {
+            if (filteredRecords.isEmpty()) {
+                result = spark.emptyDataFrame();
+            } else {
+                String sourceName = sourceReference.getSource();
+                String tableName = sourceReference.getTable();
 
-        if (filteredRecords.isEmpty()) {
-            return spark.emptyDataFrame();
-        } else {
-            String sourceName = sourceReference.getSource();
-            String tableName = sourceReference.getTable();
+                val startTime = System.currentTimeMillis();
 
-            val startTime = System.currentTimeMillis();
-
-            logger.debug("Processing records for {}/{}", sourceName, tableName);
-            val result = super.process(spark, filteredRecords, sourceReference);
-            logger.debug("Processed batch in {}ms", System.currentTimeMillis() - startTime);
-
-            return result;
+                logger.debug("Processing records for {}/{}", sourceName, tableName);
+                result = super.process(spark, filteredRecords, sourceReference);
+                logger.debug("Processed batch in {}ms", System.currentTimeMillis() - startTime);
+            }
+        } catch (DataStorageRetriesExhaustedException e) {
+            violationService.handleRetriesExhausted(spark, filteredRecords, sourceReference.getSource(), sourceReference.getTable(), e, STRUCTURED_CDC);
+            result = spark.emptyDataFrame();
         }
+        return result;
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/service/ViolationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ViolationServiceTest.java
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.service;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static uk.gov.justice.digital.service.ViolationService.ZoneName.RAW;
+
+@ExtendWith(MockitoExtension.class)
+class ViolationServiceTest extends BaseSparkTest {
+
+    @Mock
+    private JobArguments mockJobArguments;
+    @Mock
+    private DataStorageService mockDataStorage;
+    @Mock
+    private Dataset<Row> mockDataFrame;
+    @Mock
+    private DataStorageRetriesExhaustedException mockCause;
+
+    private ViolationService underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new ViolationService(mockJobArguments, mockDataStorage);
+    }
+
+    @Test
+    public void handleRetriesExhaustedShouldWriteViolations() throws DataStorageException {
+        underTest.handleRetriesExhausted(spark, testInputDataframe(), "source", "table", mockCause, RAW);
+        verify(mockDataStorage).append(any(), any());
+        verify(mockDataStorage).updateDeltaManifestForTable(any(), any());
+    }
+
+    @Test
+    public void handleRetriesExhaustedShouldThrowIfWriteFails() throws DataStorageException {
+        doThrow(DataStorageException.class).when(mockDataStorage).append(any(), any());
+        assertThrows(RuntimeException.class, () -> underTest.handleRetriesExhausted(spark, testInputDataframe(), "source", "table", mockCause, RAW));
+    }
+
+    @Test
+    public void handleNoSchemaFoundShouldWriteViolations() throws DataStorageException {
+        underTest.handleNoSchemaFound(spark, testInputDataframe(), "source", "table");
+        verify(mockDataStorage).append(any(), any());
+        verify(mockDataStorage).updateDeltaManifestForTable(any(), any());
+    }
+
+    @Test
+    public void handleNoSchemaFoundShouldThrowIfWriteFails() throws DataStorageException {
+        doThrow(DataStorageException.class).when(mockDataStorage).append(any(), any());
+        assertThrows(DataStorageException.class, () -> underTest.handleNoSchemaFound(spark, testInputDataframe(), "source", "table"));
+    }
+
+    private Dataset<Row> testInputDataframe() {
+        List<String> input = new ArrayList<>();
+        input.add("data1,metadata1,other1");
+        input.add("data2,metadata2,other2");
+        return spark.createDataset(input, Encoders.STRING())
+                .toDF()
+                .selectExpr(
+                        "split(value, ',')[0] as data",
+                        "split(value, ',')[1] as metadata",
+                        "split(value, ',')[2] as someothercolumn"
+                );
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoadTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoadTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.zone.curated;
 
 
+import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,14 +15,26 @@ import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
+import uk.gov.justice.digital.service.ViolationService;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
-import static uk.gov.justice.digital.test.Fixtures.*;
+import static uk.gov.justice.digital.service.ViolationService.ZoneName.CURATED_LOAD;
+import static uk.gov.justice.digital.test.Fixtures.CURATED_PATH;
+import static uk.gov.justice.digital.test.Fixtures.PRIMARY_KEY_FIELD;
+import static uk.gov.justice.digital.test.Fixtures.TABLE_NAME;
+import static uk.gov.justice.digital.test.Fixtures.TABLE_SOURCE;
 import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredLoadDataset;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +48,8 @@ class CuratedZoneLoadTest extends BaseSparkTest {
 
     @Mock
     private DataStorageService mockDataStorage;
+    @Mock
+    private ViolationService mockViolationService;
 
     @Captor
     ArgumentCaptor<Dataset<Row>> dataframeCaptor;
@@ -55,7 +70,8 @@ class CuratedZoneLoadTest extends BaseSparkTest {
 
         underTest = new CuratedZoneLoad(
                 mockJobArguments,
-                mockDataStorage
+                mockDataStorage,
+                mockViolationService
         );
     }
 
@@ -75,6 +91,30 @@ class CuratedZoneLoadTest extends BaseSparkTest {
                 testDataSet.drop(OPERATION).collectAsList(),
                 dataframeCaptor.getValue().collectAsList()
         );
+    }
+
+    @Test
+    public void shouldWriteViolationsWhenDataStorageRetriesExhausted() throws DataStorageException {
+        when(mockSourceReference.getSource()).thenReturn(TABLE_SOURCE);
+        when(mockSourceReference.getTable()).thenReturn(TABLE_NAME);
+
+        DataStorageRetriesExhaustedException thrown = new DataStorageRetriesExhaustedException(new Exception("Some problem"));
+        doThrow(thrown).when(mockDataStorage).appendDistinct(any(), any(), any());
+
+        underTest.process(spark, testDataSet, mockSourceReference).collect();
+        verify(mockViolationService).handleRetriesExhausted(any(), eq(testDataSet), eq(TABLE_SOURCE), eq(TABLE_NAME), eq(thrown), eq(CURATED_LOAD));
+    }
+
+    @Test
+    public void shouldReturnEmptyDataFrameWhenDataStorageRetriesExhausted() throws DataStorageException {
+        when(mockSourceReference.getSource()).thenReturn(TABLE_SOURCE);
+        when(mockSourceReference.getTable()).thenReturn(TABLE_NAME);
+
+        DataStorageRetriesExhaustedException thrown = new DataStorageRetriesExhaustedException(new Exception("Some problem"));
+        doThrow(thrown).when(mockDataStorage).appendDistinct(any(), any(), any());
+
+        val resultDf = underTest.process(spark, testDataSet, mockSourceReference);
+        assertTrue(resultDf.isEmpty());
     }
 
     private void givenTheSourceReferenceIsValid() {

--- a/src/test/java/uk/gov/justice/digital/zone/raw/RawZoneTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/raw/RawZoneTest.java
@@ -4,6 +4,7 @@ package uk.gov.justice.digital.zone.raw;
 import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -12,17 +13,28 @@ import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
+import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
+import uk.gov.justice.digital.service.ViolationService;
 
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
-import static uk.gov.justice.digital.test.Fixtures.*;
-import static uk.gov.justice.digital.test.ZoneFixtures.*;
+import static uk.gov.justice.digital.service.ViolationService.ZoneName.RAW;
+import static uk.gov.justice.digital.test.Fixtures.RAW_PATH;
+import static uk.gov.justice.digital.test.Fixtures.TABLE_NAME;
+import static uk.gov.justice.digital.test.Fixtures.TABLE_SOURCE;
+import static uk.gov.justice.digital.test.ZoneFixtures.createExpectedRawDataset;
+import static uk.gov.justice.digital.test.ZoneFixtures.createTestDataset;
 
 @ExtendWith(MockitoExtension.class)
 class RawZoneTest extends BaseSparkTest {
@@ -34,9 +46,23 @@ class RawZoneTest extends BaseSparkTest {
     private SourceReference mockSourceReference;
 
     @Mock
+
     private DataStorageService mockDataStorageService;
+    @Mock
+    private ViolationService mockViolationService;
 
     Dataset<Row> testRecords = createTestDataset(spark);
+
+    private RawZone underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new RawZone(
+                jobArguments,
+                mockDataStorageService,
+                mockViolationService
+        );
+    }
 
     @Test
     public void processShouldCreateAndAppendDistinctRawRecords() throws DataStorageException {
@@ -51,15 +77,34 @@ class RawZoneTest extends BaseSparkTest {
         when(mockSourceReference.getSource()).thenReturn(TABLE_SOURCE);
         when(mockSourceReference.getTable()).thenReturn(TABLE_NAME);
 
-        val underTest = new RawZone(
-                jobArguments,
-                mockDataStorageService
-        );
-
         assertIterableEquals(
                 expectedRecords.collectAsList(),
                 underTest.process(spark, testRecords, mockSourceReference).collectAsList()
         );
+    }
+
+    @Test
+    public void shouldWriteViolationsWhenDataStorageRetriesExhausted() throws DataStorageException {
+        when(mockSourceReference.getSource()).thenReturn(TABLE_SOURCE);
+        when(mockSourceReference.getTable()).thenReturn(TABLE_NAME);
+
+        DataStorageRetriesExhaustedException thrown = new DataStorageRetriesExhaustedException(new Exception("Some problem"));
+        doThrow(thrown).when(mockDataStorageService).appendDistinct(any(), any(), any());
+
+        underTest.process(spark, testRecords, mockSourceReference).collect();
+        verify(mockViolationService).handleRetriesExhausted(any(), eq(testRecords), eq(TABLE_SOURCE), eq(TABLE_NAME), eq(thrown), eq(RAW));
+    }
+
+    @Test
+    public void shouldReturnEmptyDataFrameWhenDataStorageRetriesExhausted() throws DataStorageException {
+        when(mockSourceReference.getSource()).thenReturn(TABLE_SOURCE);
+        when(mockSourceReference.getTable()).thenReturn(TABLE_NAME);
+
+        DataStorageRetriesExhaustedException thrown = new DataStorageRetriesExhaustedException(new Exception("Some problem"));
+        doThrow(thrown).when(mockDataStorageService).appendDistinct(any(), any(), any());
+
+        val resultDf = underTest.process(spark, testRecords, mockSourceReference);
+        assertTrue(resultDf.isEmpty());
     }
 
 }


### PR DESCRIPTION
- DataStorageService now throws DataStorageRetriesExhaustedException when retries exceeded instead of propagating original exception
- Introduce ViolationService to handle violations
- Catch DataStorageRetriesExhaustedException and write violations in each zone (allowing recording the zone within the violations table error message)
- Ensure DataStorageRetriesExhaustedException is propagated upwards - this also involved switching some lambda foreach, etc. out for for loops to allow checked exceptions to propagate