### PR TITLE
DPR2-184: Write inserts, updates and deletes in batches

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/BaseSparkTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/BaseSparkTest.java
@@ -2,11 +2,9 @@ package uk.gov.justice.digital.config;
 
 import io.micronaut.logging.LogLevel;
 import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
@@ -15,8 +13,6 @@ import java.util.Collections;
 
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.from_json;
-import static org.apache.spark.sql.types.DataTypes.StringType;
-import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.RAW;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.RECORD_SCHEMA;
 
 public class BaseSparkTest {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -28,8 +28,6 @@ public class JobArguments {
 
     public static final String AWS_DYNAMODB_ENDPOINT_URL = "dpr.aws.dynamodb.endpointUrl";
     public static final String AWS_REGION = "dpr.aws.region";
-    public static final String SOURCE = "dpr.schema";
-    public static final String TABLE = "dpr.table";
     public static final String LOG_LEVEL = "dpr.log.level";
     public static final String CONTRACT_REGISTRY_NAME = "dpr.contract.registryName";
     public static final String CURATED_S3_PATH = "dpr.curated.s3.path";
@@ -119,14 +117,6 @@ public class JobArguments {
 
     public String getAwsRegion() {
         return getArgument(AWS_REGION);
-    }
-
-    public String getSource() {
-        return getArgument(SOURCE);
-    }
-
-    public String getTable() {
-        return getArgument(TABLE);
     }
 
     public String getAwsDynamoDBEndpointUrl() {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -28,6 +28,8 @@ public class JobArguments {
 
     public static final String AWS_DYNAMODB_ENDPOINT_URL = "dpr.aws.dynamodb.endpointUrl";
     public static final String AWS_REGION = "dpr.aws.region";
+    public static final String SOURCE = "dpr.schema";
+    public static final String TABLE = "dpr.table";
     public static final String LOG_LEVEL = "dpr.log.level";
     public static final String CONTRACT_REGISTRY_NAME = "dpr.contract.registryName";
     public static final String CURATED_S3_PATH = "dpr.curated.s3.path";
@@ -117,6 +119,14 @@ public class JobArguments {
 
     public String getAwsRegion() {
         return getArgument(AWS_REGION);
+    }
+
+    public String getSource() {
+        return getArgument(SOURCE);
+    }
+
+    public String getTable() {
+        return getArgument(TABLE);
     }
 
     public String getAwsDynamoDBEndpointUrl() {

--- a/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/domain/DomainExecutor.java
@@ -269,7 +269,7 @@ public class DomainExecutor {
                 storage.endTableUpdates(spark, target);
                 break;
             case Insert:
-                storage.upsertRecords(spark, target.toPath(), dataFrame, primaryKey);
+                storage.mergeRecords(spark, target.toPath(), dataFrame, primaryKey, Collections.emptyList());
                 storage.endTableUpdates(spark, target);
                 break;
             case Update:

--- a/src/main/java/uk/gov/justice/digital/domain/model/SourceReference.java
+++ b/src/main/java/uk/gov/justice/digital/domain/model/SourceReference.java
@@ -18,7 +18,7 @@ public class SourceReference {
 
     public static class PrimaryKey {
 
-        private Collection<String> keys;
+        public Collection<String> keys;
 
         public PrimaryKey(Collection<?> o) {
             keys = o.stream().map(x -> Objects.toString(x, null)).collect(Collectors.toList());

--- a/src/main/java/uk/gov/justice/digital/writer/Writer.java
+++ b/src/main/java/uk/gov/justice/digital/writer/Writer.java
@@ -4,20 +4,17 @@ import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.converter.dms.DMS_3_4_7;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
 import uk.gov.justice.digital.service.DataStorageService;
 
-import java.util.ArrayList;
-import java.util.Collections;
-
-import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.Operation.getOperation;
+import static org.apache.spark.sql.functions.col;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.Operation.*;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 
 public abstract class Writer {
 
@@ -45,7 +42,7 @@ public abstract class Writer {
             Dataset<Row> validRecords
     ) throws DataStorageException {
         logger.info("Appending {} records to deltalake table: {}", validRecords.count(), destinationPath);
-        storage.appendDistinct(destinationPath, validRecords.drop(OPERATION), primaryKey);
+        storage.appendDistinct(destinationPath, validRecords.drop(OPERATION, TIMESTAMP), primaryKey);
 
         logger.info("Append completed successfully to table: {}", destinationPath);
         storage.updateDeltaManifestForTable(spark, destinationPath);
@@ -61,70 +58,16 @@ public abstract class Writer {
     ) throws DataStorageRetriesExhaustedException {
         logger.info("Applying {} CDC records to deltalake table: {}", validRecords.count(), destinationPath);
 
-        for (Row row: validRecords.collectAsList()) {
-            processRow(spark, storage, destinationPath, primaryKey, row);
-        }
+        val inserts = validRecords.filter(col(OPERATION).equalTo(Insert.getName())).orderBy(TIMESTAMP);
+        val updates = validRecords.filter(col(OPERATION).equalTo(Update.getName())).orderBy(TIMESTAMP);
+        val deletes = validRecords.filter(col(OPERATION).equalTo(Delete.getName())).orderBy(TIMESTAMP);
+
+        storage.upsertRecords(spark, destinationPath, inserts.drop(OPERATION, TIMESTAMP), primaryKey);
+        storage.updateRecords(spark, destinationPath, updates.drop(OPERATION, TIMESTAMP), primaryKey);
+        storage.deleteRecords(spark, destinationPath, deletes.drop(OPERATION, TIMESTAMP), primaryKey);
 
         logger.info("CDC records successfully applied to table: {}", destinationPath);
         storage.updateDeltaManifestForTable(spark, destinationPath);
-    }
-
-    @NotNull
-    protected static void processRow(
-            SparkSession spark,
-            DataStorageService storage,
-            String destinationPath,
-            SourceReference.PrimaryKey primaryKey,
-            Row row
-    ) throws DataStorageRetriesExhaustedException {
-            String unvalidatedOperation = row.getAs(OPERATION);
-            val optionalOperation = getOperation(unvalidatedOperation);
-
-            if (optionalOperation.isPresent()) {
-                val operation = optionalOperation.get();
-                try {
-                    writeRow(spark, storage, destinationPath, primaryKey, operation, row);
-                } catch (DataStorageRetriesExhaustedException ex) {
-                    // We rethrow because we do not want to catch this specific DataStorageException here
-                    throw ex;
-                } catch (DataStorageException ex) {
-                    logger.error("Failed to {}", String.format("%s: %s to %s", operation.getName(), row.json(), destinationPath), ex);
-                }
-            } else {
-                logger.error("Operation {} is invalid for {} to {}", unvalidatedOperation, row.json(), destinationPath);
-            }
-    }
-
-    private static void writeRow(
-            SparkSession spark,
-            DataStorageService storage,
-            String destinationPath,
-            SourceReference.PrimaryKey primaryKey,
-            DMS_3_4_7.Operation operation,
-            Row row
-    ) throws DataStorageException {
-        val list = new ArrayList<>(Collections.singletonList(row));
-        val dataFrame = spark.createDataFrame(list, row.schema()).drop(OPERATION);
-
-        switch (operation) {
-            case Insert:
-                storage.upsertRecords(spark, destinationPath, dataFrame, primaryKey);
-                break;
-            case Update:
-                storage.updateRecords(spark, destinationPath, dataFrame, primaryKey);
-                break;
-            case Delete:
-                storage.deleteRecords(spark, destinationPath, dataFrame, primaryKey);
-                break;
-            default:
-                logger.error(
-                        "Operation {} is not allowed for incremental processing: {} to {}",
-                        operation.getName(),
-                        row.json(),
-                        destinationPath
-                );
-                break;
-        }
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/writer/curated/CuratedZoneCdcWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/curated/CuratedZoneCdcWriter.java
@@ -19,13 +19,14 @@ public class CuratedZoneCdcWriter extends Writer {
         this.storage = storage;
     }
 
-    public void writeValidRecords(
+    public Dataset<Row> writeValidRecords(
             SparkSession spark,
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
     ) throws DataStorageRetriesExhaustedException {
         writeCdcRecords(spark, storage, destinationPath, primaryKey, validRecords);
+        return validRecords;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/writer/curated/CuratedZoneLoadWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/curated/CuratedZoneLoadWriter.java
@@ -20,13 +20,14 @@ public class CuratedZoneLoadWriter extends Writer {
     }
 
     @Override
-    public void writeValidRecords(
+    public Dataset<Row> writeValidRecords(
             SparkSession spark,
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
     ) throws DataStorageException {
         appendDistinctRecords(spark, storage, destinationPath, primaryKey, validRecords);
+        return validRecords;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneCdcWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneCdcWriter.java
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.writer.structured;
 
+import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.exception.DataStorageRetriesExhaustedException;
@@ -13,7 +16,12 @@ import uk.gov.justice.digital.writer.Writer;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.spark.sql.functions.last;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 
 public class StructuredZoneCdcWriter extends Writer {
 
@@ -27,13 +35,15 @@ public class StructuredZoneCdcWriter extends Writer {
     }
 
     @Override
-    public void writeValidRecords(
+    public Dataset<Row> writeValidRecords(
             SparkSession spark,
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
     ) throws DataStorageRetriesExhaustedException {
-        writeCdcRecords(spark, storage, destinationPath, primaryKey, validRecords);
+        val mostRecentUniqueRecords = getMostRecentUniqueRecords(spark, primaryKey, validRecords);
+        writeCdcRecords(spark, storage, destinationPath, primaryKey, mostRecentUniqueRecords);
+        return mostRecentUniqueRecords;
     }
 
     @Override
@@ -47,6 +57,33 @@ public class StructuredZoneCdcWriter extends Writer {
 
         logger.info("Append completed successfully");
         storage.updateDeltaManifestForTable(spark, destinationPath);
+    }
+
+    private static Dataset<Row> getMostRecentUniqueRecords(SparkSession spark, SourceReference.PrimaryKey primaryKey, Dataset<Row> validRecords) {
+        val primaryKeys = JavaConverters
+                .asScalaIteratorConverter(primaryKey.keys.stream().map(functions::col).iterator())
+                .asScala()
+                .toSeq();
+
+        val mostRecentColumnExpressions = Arrays.stream(validRecords.columns())
+                .filter(column -> !primaryKey.keys.contains(column))
+                .map(column -> last(column).as(column));
+
+        val mostRecentColumnExpressionsAsScalaSeq = JavaConverters
+                .asScalaIteratorConverter(mostRecentColumnExpressions.iterator())
+                .asScala()
+                .toSeq();
+
+        if (mostRecentColumnExpressionsAsScalaSeq.nonEmpty()) {
+            return validRecords
+                    .orderBy(TIMESTAMP)
+                    .groupBy(primaryKeys)
+                    .agg(mostRecentColumnExpressionsAsScalaSeq.head(), mostRecentColumnExpressionsAsScalaSeq.tail().toSeq())
+                    .orderBy(TIMESTAMP);
+        } else {
+            logger.warn("Unable to get most recent records: Columns {} is empty", mostRecentColumnExpressionsAsScalaSeq.mkString(", "));
+            return spark.createDataFrame(Collections.emptyList(), validRecords.schema());
+        }
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneLoadWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneLoadWriter.java
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.writer.Writer;
 import javax.inject.Inject;
 
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 
 public class StructuredZoneLoadWriter extends Writer {
 
@@ -42,7 +43,7 @@ public class StructuredZoneLoadWriter extends Writer {
             Dataset<Row> invalidRecords
     ) throws DataStorageException {
         logger.info("Appending {} records to deltalake table: {}", invalidRecords.count(), destinationPath);
-        storage.append(destinationPath, invalidRecords.drop(OPERATION));
+        storage.append(destinationPath, invalidRecords.drop(OPERATION, TIMESTAMP));
 
         logger.info("Append completed successfully");
         storage.updateDeltaManifestForTable(spark, destinationPath);

--- a/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneLoadWriter.java
+++ b/src/main/java/uk/gov/justice/digital/writer/structured/StructuredZoneLoadWriter.java
@@ -27,13 +27,14 @@ public class StructuredZoneLoadWriter extends Writer {
     }
 
     @Override
-    public void writeValidRecords(
+    public Dataset<Row> writeValidRecords(
             SparkSession spark,
             String destinationPath,
             SourceReference.PrimaryKey primaryKey,
             Dataset<Row> validRecords
     ) throws DataStorageException {
         appendDistinctRecords(spark, storage, destinationPath, primaryKey, validRecords);
+        return validRecords;
     }
 
     @Override

--- a/src/test/java/uk/gov/justice/digital/test/Fixtures.java
+++ b/src/test/java/uk/gov/justice/digital/test/Fixtures.java
@@ -74,6 +74,7 @@ public class Fixtures {
             .add(ARRAY_FIELD_KEY, new ArrayType(DataTypes.IntegerType, false), false);
 
     public static final StructType STRUCTURED_RECORD_WITH_OPERATION_SCHEMA = JSON_DATA_SCHEMA
+            .add(TIMESTAMP, DataTypes.StringType, false)
             .add(OPERATION, DataTypes.StringType, false);
 
     public static final String GENERIC_METADATA = "{}";

--- a/src/test/java/uk/gov/justice/digital/test/ZoneFixtures.java
+++ b/src/test/java/uk/gov/justice/digital/test/ZoneFixtures.java
@@ -210,6 +210,17 @@ public class ZoneFixtures {
                     Update.getName()
             );
 
+    public static final Row structuredRecord4SecondUpdate = RowFactory
+            .create(
+                    RECORD_KEY_4,
+                    "second update",
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "4",
+                    Update.getName()
+            );
+
     public static Dataset<Row> createTestDataset(SparkSession spark) {
         val rawData = new ArrayList<>(Arrays.asList(
                 record1Load,
@@ -222,6 +233,82 @@ public class ZoneFixtures {
                 record6Deletion,
                 record5Update
         ));
+
+        return spark.createDataFrame(rawData, ROW_SCHEMA);
+    }
+
+    public static Dataset<Row> createNonUniqueUnorderedTestDataset(SparkSession spark) {
+
+        val record4FirstInsertion = RowFactory.create(
+                "0",
+                RECORD_KEY_4,
+                TABLE_SOURCE,
+                TABLE_NAME,
+                Insert.getName(),
+                ROW_CONVERTER,
+                recordData4.replaceAll(STRING_FIELD_VALUE, "first insert"),
+                recordData4.replaceAll(STRING_FIELD_VALUE, "first insert"),
+                GENERIC_METADATA
+        );
+
+        val record4FirstUpdate = RowFactory.create(
+                "1",
+                RECORD_KEY_4,
+                TABLE_SOURCE,
+                TABLE_NAME,
+                Update.getName(),
+                ROW_CONVERTER,
+                recordData4.replaceAll(STRING_FIELD_VALUE, "first update"),
+                recordData4.replaceAll(STRING_FIELD_VALUE, "first update"),
+                GENERIC_METADATA
+        );
+
+        val record4Deletion = RowFactory.create(
+                "2",
+                RECORD_KEY_4,
+                TABLE_SOURCE,
+                TABLE_NAME,
+                Delete.getName(),
+                ROW_CONVERTER,
+                recordData4.replaceAll(STRING_FIELD_VALUE, "delete"),
+                recordData4.replaceAll(STRING_FIELD_VALUE, "delete"),
+                GENERIC_METADATA
+        );
+
+        val record4SecondInsertion = RowFactory.create(
+                "3",
+                RECORD_KEY_4,
+                TABLE_SOURCE,
+                TABLE_NAME,
+                Insert.getName(),
+                ROW_CONVERTER,
+                recordData4.replaceAll(STRING_FIELD_VALUE, "second insert"),
+                recordData4.replaceAll(STRING_FIELD_VALUE, "second insert"),
+                GENERIC_METADATA
+        );
+
+        val record4SecondUpdate = RowFactory.create(
+                "4",
+                RECORD_KEY_4,
+                TABLE_SOURCE,
+                TABLE_NAME,
+                Update.getName(),
+                ROW_CONVERTER,
+                recordData4.replaceAll(STRING_FIELD_VALUE, "second update"),
+                recordData4.replaceAll(STRING_FIELD_VALUE, "second update"),
+                GENERIC_METADATA
+        );
+
+        val rawData = Arrays.asList(
+                record4FirstInsertion,
+                record4FirstUpdate,
+                record4Deletion,
+                record4SecondInsertion,
+                record4SecondUpdate,
+                record6Insert
+        );
+
+        Collections.shuffle(rawData);
 
         return spark.createDataFrame(rawData, ROW_SCHEMA);
     }
@@ -361,8 +448,6 @@ public class ZoneFixtures {
     public static Dataset<Row> createStructuredIncrementalDataset(SparkSession spark) {
         val expectedIncrementalData = new ArrayList<>(Arrays.asList(
                 structuredRecord4Insertion,
-                structuredRecord5Insertion,
-                structuredRecord6Insertion,
                 structuredRecord7Update,
                 structuredRecord6Deletion,
                 structuredRecord5Update
@@ -371,17 +456,21 @@ public class ZoneFixtures {
         return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
     }
 
+    public static Dataset<Row> createExpectedUniqueMostRecentRecordsInWriteOrder(SparkSession spark) {
+        val expectedIncrementalData = Arrays.asList(
+                structuredRecord4SecondUpdate,
+                structuredRecord6Insertion
+        );
+
+        return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
+    }
+
     public static Dataset<Row> createExpectedRecordsInWriteOrder(SparkSession spark) {
         val expectedIncrementalData = new ArrayList<>(Arrays.asList(
-                // inserts
                 structuredRecord4Insertion,
-                structuredRecord5Insertion,
-                structuredRecord6Insertion,
-                // updates
                 structuredRecord7Update,
-                structuredRecord5Update,
-                // deletes
-                structuredRecord6Deletion
+                structuredRecord6Deletion,
+                structuredRecord5Update
         ));
 
         return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);

--- a/src/test/java/uk/gov/justice/digital/test/ZoneFixtures.java
+++ b/src/test/java/uk/gov/justice/digital/test/ZoneFixtures.java
@@ -117,26 +117,98 @@ public class ZoneFixtures {
 
     // structured load records
     public static final Row structuredRecord2Load = RowFactory
-            .create(RECORD_KEY_2, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Load.getName());
+            .create(
+                    RECORD_KEY_2,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "1",
+                    Load.getName()
+            );
     public static final Row structuredRecord3Load = RowFactory
-            .create(RECORD_KEY_3, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Load.getName());
+            .create(
+                    RECORD_KEY_3,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "2",
+                    Load.getName()
+            );
     public static final Row structuredRecord1Load = RowFactory
-            .create(RECORD_KEY_1, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Load.getName());
+            .create(
+                    RECORD_KEY_1,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "3",
+                    Load.getName()
+            );
 
 
     // structured insert, update, and delete records
     public static final Row structuredRecord4Insertion = RowFactory
-            .create(RECORD_KEY_4, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Insert.getName());
+            .create(
+                    RECORD_KEY_4,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "0",
+                    Insert.getName()
+            );
     public static final Row structuredRecord5Insertion = RowFactory
-            .create(RECORD_KEY_5, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Insert.getName());
+            .create(
+                    RECORD_KEY_5,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "4",
+                    Insert.getName()
+            );
     public static final Row structuredRecord6Insertion = RowFactory
-            .create(RECORD_KEY_6, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Insert.getName());
+            .create(
+                    RECORD_KEY_6,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "5",
+                    Insert.getName()
+            );
     public static final Row structuredRecord7Update = RowFactory
-            .create(RECORD_KEY_7, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Update.getName());
+            .create(
+                    RECORD_KEY_7,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "6",
+                    Update.getName()
+            );
     public static final Row structuredRecord6Deletion = RowFactory
-            .create(RECORD_KEY_6, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Delete.getName());
+            .create(
+                    RECORD_KEY_6,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "7",
+                    Delete.getName()
+            );
     public static final Row structuredRecord5Update = RowFactory
-            .create(RECORD_KEY_5, STRING_FIELD_VALUE, null, NUMBER_FIELD_VALUE, ARRAY_FIELD_VALUE, Update.getName());
+            .create(
+                    RECORD_KEY_5,
+                    STRING_FIELD_VALUE,
+                    null,
+                    NUMBER_FIELD_VALUE,
+                    ARRAY_FIELD_VALUE,
+                    "8",
+                    Update.getName()
+            );
 
     public static Dataset<Row> createTestDataset(SparkSession spark) {
         val rawData = new ArrayList<>(Arrays.asList(
@@ -278,9 +350,9 @@ public class ZoneFixtures {
 
     public static Dataset<Row> createStructuredLoadDataset(SparkSession spark) {
         val expectedLoadData = new ArrayList<>(Arrays.asList(
+                structuredRecord1Load,
                 structuredRecord2Load,
-                structuredRecord3Load,
-                structuredRecord1Load
+                structuredRecord3Load
         ));
 
         return spark.createDataFrame(expectedLoadData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
@@ -294,6 +366,22 @@ public class ZoneFixtures {
                 structuredRecord7Update,
                 structuredRecord6Deletion,
                 structuredRecord5Update
+        ));
+
+        return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);
+    }
+
+    public static Dataset<Row> createExpectedRecordsInWriteOrder(SparkSession spark) {
+        val expectedIncrementalData = new ArrayList<>(Arrays.asList(
+                // inserts
+                structuredRecord4Insertion,
+                structuredRecord5Insertion,
+                structuredRecord6Insertion,
+                // updates
+                structuredRecord7Update,
+                structuredRecord5Update,
+                // deletes
+                structuredRecord6Deletion
         ));
 
         return spark.createDataFrame(expectedIncrementalData, STRUCTURED_RECORD_WITH_OPERATION_SCHEMA);

--- a/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneCdcTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneCdcTest.java
@@ -30,16 +30,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 import static uk.gov.justice.digital.service.ViolationService.ZoneName.CURATED_CDC;
 import static uk.gov.justice.digital.test.Fixtures.CURATED_PATH;
 import static uk.gov.justice.digital.test.Fixtures.PRIMARY_KEY_FIELD;
 import static uk.gov.justice.digital.test.Fixtures.TABLE_NAME;
 import static uk.gov.justice.digital.test.Fixtures.TABLE_SOURCE;
 import static uk.gov.justice.digital.test.Fixtures.getAllCapturedRecords;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredDeleteDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredIncrementalDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredInsertDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredUpdateDataset;
+import static uk.gov.justice.digital.test.ZoneFixtures.*;
 
 @ExtendWith(MockitoExtension.class)
 class CuratedZoneCdcTest extends BaseSparkTest {
@@ -80,6 +78,7 @@ class CuratedZoneCdcTest extends BaseSparkTest {
     @Test
     public void shouldWriteStructuredIncrementalRecordsToDeltaTable() throws DataStorageException {
         val expectedRecords = createStructuredIncrementalDataset(spark);
+        val expectedRecordsInWriteOrder = createExpectedRecordsInWriteOrder(spark);
 
         givenTheSourceReferenceIsValid();
         doNothing().when(mockDataStorage).upsertRecords(eq(spark), eq(curatedPath), dataframeCaptor.capture(), any());
@@ -92,7 +91,7 @@ class CuratedZoneCdcTest extends BaseSparkTest {
         );
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecordsInWriteOrder.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }
@@ -107,7 +106,7 @@ class CuratedZoneCdcTest extends BaseSparkTest {
         underTest.process(spark, expectedRecords, mockSourceReference).collect();
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }
@@ -122,7 +121,7 @@ class CuratedZoneCdcTest extends BaseSparkTest {
         underTest.process(spark, expectedRecords, mockSourceReference).collect();
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }
@@ -137,7 +136,7 @@ class CuratedZoneCdcTest extends BaseSparkTest {
         underTest.process(spark, expectedRecords, mockSourceReference).collect();
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }

--- a/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoadTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoadTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 import static uk.gov.justice.digital.service.ViolationService.ZoneName.CURATED_LOAD;
 import static uk.gov.justice.digital.test.Fixtures.CURATED_PATH;
 import static uk.gov.justice.digital.test.Fixtures.PRIMARY_KEY_FIELD;
@@ -88,7 +89,7 @@ class CuratedZoneLoadTest extends BaseSparkTest {
         );
 
         assertIterableEquals(
-                testDataSet.drop(OPERATION).collectAsList(),
+                testDataSet.drop(OPERATION, TIMESTAMP).collectAsList(),
                 dataframeCaptor.getValue().collectAsList()
         );
     }

--- a/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneCdcTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneCdcTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 import static uk.gov.justice.digital.service.ViolationService.ZoneName.STRUCTURED_CDC;
 import static uk.gov.justice.digital.test.Fixtures.JSON_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.Fixtures.PRIMARY_KEY_FIELD;
@@ -40,11 +41,7 @@ import static uk.gov.justice.digital.test.Fixtures.TABLE_SOURCE;
 import static uk.gov.justice.digital.test.Fixtures.VIOLATIONS_PATH;
 import static uk.gov.justice.digital.test.Fixtures.getAllCapturedRecords;
 import static uk.gov.justice.digital.test.Fixtures.hasNullColumns;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredDeleteDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredIncrementalDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredInsertDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createStructuredUpdateDataset;
-import static uk.gov.justice.digital.test.ZoneFixtures.createTestDataset;
+import static uk.gov.justice.digital.test.ZoneFixtures.*;
 
 @ExtendWith(MockitoExtension.class)
 class StructuredZoneCdcTest extends BaseSparkTest {
@@ -87,6 +84,7 @@ class StructuredZoneCdcTest extends BaseSparkTest {
     @Test
     public void shouldHandleValidIncrementalRecords() throws DataStorageException {
         val expectedRecords = createStructuredIncrementalDataset(spark);
+        val expectedRecordsInWriteOrder = createExpectedRecordsInWriteOrder(spark);
 
         givenTheSourceReferenceIsValid();
         doNothing().when(mockDataStorage).upsertRecords(eq(spark), eq(structuredPath), dataframeCaptor.capture(), eq(primaryKey));
@@ -99,7 +97,7 @@ class StructuredZoneCdcTest extends BaseSparkTest {
         );
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecordsInWriteOrder.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }
@@ -114,7 +112,7 @@ class StructuredZoneCdcTest extends BaseSparkTest {
         underTest.process(spark, testDataSet, mockSourceReference).collect();
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }
@@ -129,7 +127,7 @@ class StructuredZoneCdcTest extends BaseSparkTest {
         underTest.process(spark, testDataSet, mockSourceReference).collect();
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }
@@ -144,7 +142,7 @@ class StructuredZoneCdcTest extends BaseSparkTest {
         underTest.process(spark, testDataSet, mockSourceReference).collect();
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 getAllCapturedRecords(dataframeCaptor)
         );
     }

--- a/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneLoadTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneLoadTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.OPERATION;
+import static uk.gov.justice.digital.converter.dms.DMS_3_4_7.ParsedDataFields.TIMESTAMP;
 import static uk.gov.justice.digital.service.ViolationService.ZoneName.STRUCTURED_LOAD;
 import static uk.gov.justice.digital.test.Fixtures.JSON_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.Fixtures.PRIMARY_KEY_FIELD;
@@ -95,7 +96,7 @@ class StructuredZoneLoadTest extends BaseSparkTest {
         );
 
         assertIterableEquals(
-                expectedRecords.drop(OPERATION).collectAsList(),
+                expectedRecords.drop(OPERATION, TIMESTAMP).collectAsList(),
                 dataframeCaptor.getValue().collectAsList()
         );
     }


### PR DESCRIPTION
This PR
- Selects the latest records in a CDC batch when there is more than one for the same primary key
- Writes the entire batch using a single merge operation
- The records are ordered by ascending timestamp so the most recent record would be applied last