### PR TITLE
DPR2-215: Use avro actual schemas rather than inferring.

### DIFF
--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.job.batchprocessing.S3BatchProcessor;
@@ -95,8 +96,9 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         ValidationService validationService = new ValidationService(violationService);
         StructuredZoneLoadS3 structuredZoneLoadS3 = new StructuredZoneLoadS3(arguments, storageService, violationService);
         CuratedZoneLoadS3 curatedZoneLoad = new CuratedZoneLoadS3(arguments, storageService, violationService);
-        S3BatchProcessor batchProcessor = new S3BatchProcessor(structuredZoneLoadS3, curatedZoneLoad, sourceReferenceService, validationService);
-        underTest = new DataHubBatchJob(arguments, properties, sparkSessionProvider, tableDiscoveryService, batchProcessor);
+        S3BatchProcessor batchProcessor = new S3BatchProcessor(structuredZoneLoadS3, curatedZoneLoad, validationService);
+        S3DataProvider dataProvider = new S3DataProvider(arguments);
+        underTest = new DataHubBatchJob(arguments, properties, sparkSessionProvider, tableDiscoveryService, batchProcessor, dataProvider, sourceReferenceService);
     }
 
     private void givenGlobPatternIsConfigured() {

--- a/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
+++ b/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
@@ -20,6 +20,7 @@ import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
 import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY;
+import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
 
@@ -59,7 +60,7 @@ public class E2ETestBase extends BaseSparkTest {
         when(sourceReference.getSource()).thenReturn(inputSchemaName);
         when(sourceReference.getTable()).thenReturn(inputTableName);
         when(sourceReference.getPrimaryKey()).thenReturn(PRIMARY_KEY);
-        when(sourceReference.getSchema()).thenReturn(TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS);
+        when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
     }
 
     protected void givenRawDataIsAddedToEveryTable(List<Row> initialDataEveryTable) {

--- a/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
@@ -216,14 +216,14 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         CuratedZoneCDCS3 curatedZone = new CuratedZoneCDCS3(arguments, violationService, storageService);
         StructuredZoneCDCS3 structuredZone = new StructuredZoneCDCS3(arguments, violationService, storageService);
         CdcBatchProcessor batchProcessor = new CdcBatchProcessor(validationService, structuredZone, curatedZone);
-        underTest = new TableStreamingQuery(arguments, dataProvider, batchProcessor, inputSchemaName, inputTableName, sourceReference);
+        underTest = new TableStreamingQuery(arguments, dataProvider, batchProcessor, sourceReference);
     }
 
     private void givenAnInputStream() {
         inputStream = new MemoryStream<Row>(1, spark.sqlContext(), Option.apply(10), encoder);
         Dataset<Row> streamingDataframe = inputStream.toDF();
 
-        when(dataProvider.getSourceData(any(), eq(inputSchemaName), eq(inputTableName))).thenReturn(streamingDataframe);
+        when(dataProvider.getSourceData(any(), eq(sourceReference))).thenReturn(streamingDataframe);
     }
 
     private void givenASourceReference() {

--- a/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
@@ -223,7 +223,7 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         inputStream = new MemoryStream<Row>(1, spark.sqlContext(), Option.apply(10), encoder);
         Dataset<Row> streamingDataframe = inputStream.toDF();
 
-        when(dataProvider.getSourceData(any(), eq(sourceReference))).thenReturn(streamingDataframe);
+        when(dataProvider.getSourceDataStreaming(any(), eq(sourceReference))).thenReturn(streamingDataframe);
     }
 
     private void givenASourceReference() {

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -2,24 +2,15 @@ package uk.gov.justice.digital.client.s3;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import org.apache.avro.Schema;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.avro.SchemaConverters;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
 
-import java.io.File;
-import java.io.IOException;
-
-import static java.lang.String.format;
-import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
-import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
 import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 import static uk.gov.justice.digital.common.ResourcePath.ensureEndsWithSlash;
 import static uk.gov.justice.digital.common.ResourcePath.tablePath;

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -2,14 +2,25 @@ package uk.gov.justice.digital.client.s3;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.apache.avro.Schema;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.avro.SchemaConverters;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.domain.model.SourceReference;
 
+import java.io.File;
+import java.io.IOException;
+
+import static java.lang.String.format;
+import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
+import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 import static uk.gov.justice.digital.common.ResourcePath.ensureEndsWithSlash;
 import static uk.gov.justice.digital.common.ResourcePath.tablePath;
 
@@ -29,13 +40,15 @@ public class S3DataProvider {
         this.arguments = arguments;
     }
 
-    public Dataset<Row> getSourceData(SparkSession sparkSession, String schemaName, String tableName) {
-        String tablePath = tablePath(arguments.getRawS3Path(), schemaName, tableName);
+    public Dataset<Row> getSourceData(SparkSession sparkSession, SourceReference sourceReference) {
+        String sourceName = sourceReference.getSource();
+        String tableName = sourceReference.getTable();
+        String tablePath = tablePath(arguments.getRawS3Path(), sourceName, tableName);
+
         String fileGlobPath = ensureEndsWithSlash(tablePath) + arguments.getCdcFileGlobPattern();
-        // Infer schema. Note: If there is no data for a table then the job will fail because Spark will be unable to infer schema
-        StructType schema = sparkSession.read().parquet(tablePath).schema();
-        logger.info("Schema for {}.{}: \n{}", schemaName, tableName, schema.treeString());
-        logger.info("Initialising S3 data source for {}.{} with file glob path {}", schemaName, tableName, fileGlobPath);
+        StructType schema = withMetadataFields(sourceReference.getSchema());
+        logger.info("Schema for {}.{}: \n{}", sourceName, tableName, schema.treeString());
+        logger.info("Initialising S3 data source for {}.{} with file glob path {}", sourceName, tableName, fileGlobPath);
         return sparkSession
                 .readStream()
                 .schema(schema)

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -31,7 +31,9 @@ public class CommonDataFields {
 
     private CommonDataFields() {}
 
-    // TODO: unit test
+    /**
+     * Add the metadata fields to the provided schema
+     */
     public static StructType withMetadataFields(StructType schema) {
         return schema
                 .add(DataTypes.createStructField(OPERATION, DataTypes.StringType, false))

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.common;
 
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+
 public class CommonDataFields {
 
     // The operation column added by DMS. See ShortOperationCode below.
@@ -27,4 +30,10 @@ public class CommonDataFields {
     }
 
     private CommonDataFields() {}
+
+    public static StructType withMetadataFields(StructType schema) {
+        return schema
+                .add(DataTypes.createStructField(OPERATION, DataTypes.StringType, false))
+                .add(DataTypes.createStructField(TIMESTAMP, DataTypes.StringType, false));
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -31,6 +31,7 @@ public class CommonDataFields {
 
     private CommonDataFields() {}
 
+    // TODO: unit test
     public static StructType withMetadataFields(StructType schema) {
         return schema
                 .add(DataTypes.createStructField(OPERATION, DataTypes.StringType, false))

--- a/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQuery.java
+++ b/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQuery.java
@@ -52,7 +52,7 @@ public class TableStreamingQuery {
         String queryCheckpointPath = format("%sDataHubCdcJob/%s", ensureEndsWithSlash(arguments.getCheckpointLocation()), queryName);
 
         logger.info("Initialising query {} with checkpoint path {}", queryName, queryCheckpointPath);
-        Dataset<Row> sourceDf = s3DataProvider.getSourceData(spark, sourceReference);
+        Dataset<Row> sourceDf = s3DataProvider.getSourceDataStreaming(spark, sourceReference);
         try {
             query = sourceDf
                     .writeStream()

--- a/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryProvider.java
+++ b/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryProvider.java
@@ -31,6 +31,6 @@ public class TableStreamingQueryProvider {
 
     public TableStreamingQuery provide(String inputSchemaName, String inputTableName) {
         SourceReference sourceReference = sourceReferenceService.getSourceReferenceOrThrow(inputSchemaName, inputTableName);
-        return new TableStreamingQuery(arguments, s3DataProvider, batchProcessor, inputSchemaName, inputTableName, sourceReference);
+        return new TableStreamingQuery(arguments, s3DataProvider, batchProcessor, sourceReference);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/common/CommonDataFieldsTest.java
+++ b/src/test/java/uk/gov/justice/digital/common/CommonDataFieldsTest.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.common;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
+import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
+
+class CommonDataFieldsTest {
+
+    @Test
+    public void shouldAddMetaDataFields() {
+        StructType originalSchema = new StructType(new StructField[]{
+                new StructField("mycolumn", DataTypes.IntegerType, false, Metadata.empty())
+        });
+
+
+        StructType expectedResultSchema = new StructType(new StructField[]{
+                new StructField("mycolumn", DataTypes.IntegerType, false, Metadata.empty()),
+                new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
+                new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
+        });
+
+        StructType resultSchema = withMetadataFields(originalSchema);
+
+        assertEquals(expectedResultSchema, resultSchema);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/S3BatchProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/S3BatchProcessorTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
-import uk.gov.justice.digital.service.SourceReferenceService;
 import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoadS3;
 import uk.gov.justice.digital.zone.structured.StructuredZoneLoadS3;
@@ -58,8 +57,6 @@ class S3BatchProcessorTest extends BaseSparkTest {
     @Mock
     private CuratedZoneLoadS3 curatedZoneLoad;
     @Mock
-    private SourceReferenceService sourceReferenceService;
-    @Mock
     private SourceReference sourceReference;
     @Mock
     private ValidationService validationService;
@@ -74,8 +71,7 @@ class S3BatchProcessorTest extends BaseSparkTest {
 
     @BeforeEach
     public void setUp() {
-        underTest = new S3BatchProcessor(structuredZoneLoad, curatedZoneLoad, sourceReferenceService, validationService);
-        when(sourceReferenceService.getSourceReferenceOrThrow(source, table)).thenReturn(sourceReference);
+        underTest = new S3BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService);
     }
 
     @Test
@@ -85,7 +81,7 @@ class S3BatchProcessorTest extends BaseSparkTest {
         when(validationService.handleValidation(any(), any(), eq(sourceReference))).thenReturn(validatedDf);
         when(structuredZoneLoad.process(any(), any(), any())).thenReturn(validatedDf);
 
-        underTest.processBatch(spark, source, table, inputDf);
+        underTest.processBatch(spark, sourceReference, inputDf);
 
         verify(structuredZoneLoad, times(1)).process(any(), argumentCaptor.capture(), eq(sourceReference));
         List<Row> result = argumentCaptor.getValue().collectAsList();
@@ -101,7 +97,7 @@ class S3BatchProcessorTest extends BaseSparkTest {
         when(validationService.handleValidation(any(), any(), eq(sourceReference))).thenReturn(validatedDf);
         when(structuredZoneLoad.process(any(), any(), any())).thenReturn(validatedDf);
 
-        underTest.processBatch(spark, source, table, inputDf);
+        underTest.processBatch(spark, sourceReference, inputDf);
 
         verify(curatedZoneLoad, times(1)).process(any(), argumentCaptor.capture(), eq(sourceReference));
         List<Row> result = argumentCaptor.getValue().collectAsList();
@@ -121,7 +117,7 @@ class S3BatchProcessorTest extends BaseSparkTest {
         when(structuredZoneLoad.process(any(), any(), any())).thenReturn(validatedDf);
 
 
-        underTest.processBatch(spark, source, table, mixedOperations);
+        underTest.processBatch(spark, sourceReference, mixedOperations);
 
         verify(validationService, times(1)).handleValidation(any(), argumentCaptor.capture(), eq(sourceReference));
         List<Row> result = argumentCaptor.getValue().collectAsList();

--- a/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
@@ -104,7 +104,7 @@ class TableStreamingQueryTest extends BaseSparkTest {
         inputStream = new MemoryStream<Row>(1, spark.sqlContext(), Option.apply(10), encoder);
         Dataset<Row> streamingDataframe = inputStream.toDF();
 
-        when(dataProvider.getSourceData(any(), eq(sourceReference))).thenReturn(streamingDataframe);
+        when(dataProvider.getSourceDataStreaming(any(), eq(sourceReference))).thenReturn(streamingDataframe);
     }
 
     private void givenJobArguments() {

--- a/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
@@ -36,12 +36,6 @@ import static uk.gov.justice.digital.test.SparkTestHelpers.convertListToSeq;
 
 @ExtendWith(MockitoExtension.class)
 class TableStreamingQueryTest extends BaseSparkTest {
-
-    private static final String inputSchemaName = "my-schema";
-    private static final String inputTableName = "my-table";
-    private static final String structuredPath = "/structured/path";
-    private static final String curatedPath = "/curated/path";
-
     private static List<Row> testData;
     private static Seq<Row> testDataSeq;
     @Mock
@@ -68,7 +62,7 @@ class TableStreamingQueryTest extends BaseSparkTest {
 
     @BeforeEach
     public void setUp() {
-        underTest = new TableStreamingQuery(arguments, dataProvider, batchProcessor, inputSchemaName, inputTableName, sourceReference);
+        underTest = new TableStreamingQuery(arguments, dataProvider, batchProcessor, sourceReference);
 
     }
 
@@ -110,7 +104,7 @@ class TableStreamingQueryTest extends BaseSparkTest {
         inputStream = new MemoryStream<Row>(1, spark.sqlContext(), Option.apply(10), encoder);
         Dataset<Row> streamingDataframe = inputStream.toDF();
 
-        when(dataProvider.getSourceData(any(), eq(inputSchemaName), eq(inputTableName))).thenReturn(streamingDataframe);
+        when(dataProvider.getSourceData(any(), eq(sourceReference))).thenReturn(streamingDataframe);
     }
 
     private void givenJobArguments() {

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -21,7 +21,6 @@ import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
 import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
-import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 
 public class MinimalTestData {
     public static final String PRIMARY_KEY_COLUMN = "pk";
@@ -39,13 +38,15 @@ public class MinimalTestData {
 
     public static final StructType SCHEMA_WITHOUT_METADATA_FIELDS = new StructType(new StructField[]{
             new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
+    });
+
+    public static final StructType TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS = new StructType(new StructField[]{
+            new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()),
             new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
     });
-
-    public static final StructType TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS = withMetadataFields(SCHEMA_WITHOUT_METADATA_FIELDS);
-
     public static Encoder<Row> encoder = RowEncoder.apply(TEST_DATA_SCHEMA);
 
     public static Dataset<Row> inserts(SparkSession spark) {

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -21,6 +21,7 @@ import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
 import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
+import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 
 public class MinimalTestData {
     public static final String PRIMARY_KEY_COLUMN = "pk";
@@ -36,12 +37,14 @@ public class MinimalTestData {
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
     });
 
-    public static final StructType TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS = new StructType(new StructField[]{
+    public static final StructType SCHEMA_WITHOUT_METADATA_FIELDS = new StructType(new StructField[]{
             new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()),
             new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
     });
+
+    public static final StructType TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS = withMetadataFields(SCHEMA_WITHOUT_METADATA_FIELDS);
 
     public static Encoder<Row> encoder = RowEncoder.apply(TEST_DATA_SCHEMA);
 


### PR DESCRIPTION
Also remove distinction between input source/table (e.g. oms_owner) and sourceReference source/table (e.g. nomis) since they are now unified by DMS.