### PR TITLE
DPR2-209: Fix streaming job checkpoint

### DIFF
--- a/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQuery.java
+++ b/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQuery.java
@@ -48,7 +48,7 @@ public class TableStreamingQuery {
 
         logger.info("Initialising per batch processing for {}/{}", sourceReference.getSource(), sourceReference.getTable());
 
-        String queryName = format("Datahub CDC %s.%s", sourceReference.getSource(), sourceReference.getTable());
+        String queryName = format("Datahub_CDC_%s.%s", sourceReference.getSource(), sourceReference.getTable());
         String queryCheckpointPath = format("%sDataHubCdcJob/%s", ensureEndsWithSlash(arguments.getCheckpointLocation()), queryName);
 
         logger.info("Initialising query {} with checkpoint path {}", queryName, queryCheckpointPath);

--- a/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZoneLoadS3.java
+++ b/src/main/java/uk/gov/justice/digital/zone/structured/StructuredZoneLoadS3.java
@@ -48,6 +48,7 @@ public class StructuredZoneLoadS3 {
             logger.info("Appending {} records to deltalake table: {}", dataFrame.count(), path);
             storage.appendDistinct(path, dataFrame, primaryKey);
             logger.info("Append completed successfully to table: {}", path);
+            storage.updateDeltaManifestForTable(spark, path);
             logger.info("Processed batch for structured {}/{} in {}ms", sourceName, tableName, System.currentTimeMillis() - startTime);
         } catch (DataStorageRetriesExhaustedException e) {
             logger.warn("Structured zone load retries exhausted", e);


### PR DESCRIPTION
1. This fixes the error in the streaming checkpoint path by using underscores instead of spaces.
```2023-12-01 17:39:08,978 ERROR [main] job.DataHubCdcJob (DataHubCdcJob.java:waitUntilQueryTerminates(111)): A streaming query terminated with an Exception
org.apache.spark.sql.streaming.StreamingQueryException: Query Datahub CDC nomis.offender_external_movements [id = 440bd988-eaa9-461b-8663-a318e532ccbd, runId = 4c79a356-4bd1-4cb1-81f2-213a5a1e9644] terminated with exception: s3://dpr-glue-jobs-test/checkpoint/dpr-reporting-hub-cdc-test/DataHubCdcJob/Datahub CDC nomis.offender_external_movements/sources/0/29.compact doesn't exist (latestId: 37, compactInterval: 10)
```


2. Updates the manifest for the structured zone after the batch job processing to allow querying of the delta tables in Athena