### PR TITLE
DPR2-210: Change violations schema to support writing datatype changes to violations

### DIFF
--- a/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
+++ b/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
@@ -117,7 +117,7 @@ public class E2ETestBase extends BaseSparkTest {
 
     protected void thenStructuredViolationsContainsForPK(String table, String data, int primaryKey) {
         String violationsTablePath = Paths.get(violationsPath).resolve("structured").resolve(inputSchemaName).resolve(table).toAbsolutePath().toString();
-        assertDeltaTableContainsForPK(violationsTablePath, data, primaryKey);
+        assertViolationsTableContainsForPK(violationsTablePath, data, primaryKey);
     }
 
 }

--- a/src/it/java/uk/gov/justice/digital/service/ViolationServiceIT.java
+++ b/src/it/java/uk/gov/justice/digital/service/ViolationServiceIT.java
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.service;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+
+import java.nio.file.Path;
+
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.lit;
+import static org.apache.spark.sql.functions.to_timestamp;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.common.CommonDataFields.ERROR;
+import static uk.gov.justice.digital.common.CommonDataFields.ERROR_RAW;
+import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
+import static uk.gov.justice.digital.service.ViolationService.ZoneName.STRUCTURED_LOAD;
+import static uk.gov.justice.digital.test.MinimalTestData.DATA_COLUMN;
+import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
+import static uk.gov.justice.digital.test.MinimalTestData.inserts;
+
+@ExtendWith(MockitoExtension.class)
+public class ViolationServiceIT extends BaseSparkTest {
+
+    private static final String source = "some";
+    private static final String table = "table";
+
+    @Mock
+    private JobArguments arguments;
+    @TempDir
+    protected Path violationsRoot;
+
+    private ViolationService underTest;
+
+    @BeforeEach
+    public void setUp() {
+        givenRetrySettingsAreConfigured(arguments);
+        when(arguments.getViolationsS3Path()).thenReturn(violationsRoot.toString());
+        underTest = new ViolationService(arguments, new DataStorageService(arguments));
+    }
+
+    @Test
+    public void shouldWriteDataWithIncompatibleSchemasSoThatItCanBeReadBackAgainUsingSpark() throws Exception {
+        String testCase = "marker";
+        Dataset<Row> original = inserts(spark)
+                .withColumn(ERROR, lit("an error"))
+                .withColumn(testCase, lit("original"));
+        String extraColumn = "extra-column";
+        Dataset<Row> anExtraColumn = original
+                .withColumn(extraColumn, lit(extraColumn))
+                .withColumn(testCase, lit(extraColumn));
+        Dataset<Row> missingAColumn = original
+                .drop(DATA_COLUMN)
+                .withColumn(testCase, lit("missing column"));
+        Dataset<Row> stringColumnChangedToInt = original
+                .withColumn(DATA_COLUMN, lit(1))
+                .withColumn(testCase, lit("string changed to int"));
+        Dataset<Row> intColumnChangedToString = original
+                .withColumn(PRIMARY_KEY_COLUMN, lit("a string"))
+                .withColumn(testCase, lit("int changed to string"));
+        Dataset<Row> intColumnChangedToLong = original
+                .withColumn(PRIMARY_KEY_COLUMN, lit(1L))
+                .withColumn(testCase, lit("int changed to long"));
+
+        String timestampAndIntColumn = "timestamp-and-int";
+        Dataset<Row> tsAndInt1 = original
+                .withColumn(timestampAndIntColumn, lit(1))
+                .withColumn(testCase, lit("timestamp-and-int-1"));
+        Dataset<Row> tsAndInt2 = original
+                .withColumn(timestampAndIntColumn, to_timestamp(
+                        lit("2022-01-01 00:00:00"),
+                        "yyyy-MM-dd HH:mm:ss"
+                ))
+                .withColumn(testCase, lit("timestamp-and-int-2"));
+
+        underTest.handleViolation(spark, original, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, anExtraColumn, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, missingAColumn, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, stringColumnChangedToInt, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, intColumnChangedToString, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, intColumnChangedToLong, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, tsAndInt1, source, table, STRUCTURED_LOAD);
+        underTest.handleViolation(spark, tsAndInt2, source, table, STRUCTURED_LOAD);
+
+        Dataset<Row> result = spark.read().format("delta")
+                .load(violationsRoot.resolve(STRUCTURED_LOAD.getPath()).resolve(source).resolve(table).toString());
+        Dataset<Row> errorRawAsJson = spark.read().json(result.select(ERROR_RAW).as(Encoders.STRING()).javaRDD());
+        errorRawAsJson.show(30, false);
+
+        long expectedCount = original.count();
+
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("original")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("extra-column")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("missing column")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("string changed to int")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("int changed to long")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("int changed to string")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("timestamp-and-int-1")).count());
+        assertEquals(expectedCount, errorRawAsJson.where(col(testCase).equalTo("timestamp-and-int-2")).count());
+
+        assertEquals(DataTypes.StringType, errorRawAsJson.schema().apply(OPERATION).dataType());
+        assertEquals(DataTypes.StringType, errorRawAsJson.schema().apply(TIMESTAMP).dataType());
+        assertEquals(DataTypes.StringType, errorRawAsJson.schema().apply(extraColumn).dataType());
+        // The columns that have had various data types should widen to String
+        assertEquals(DataTypes.StringType, errorRawAsJson.schema().apply(PRIMARY_KEY_COLUMN).dataType());
+        assertEquals(DataTypes.StringType, errorRawAsJson.schema().apply(DATA_COLUMN).dataType());
+        assertEquals(DataTypes.StringType, errorRawAsJson.schema().apply(timestampAndIntColumn).dataType());
+    }
+}

--- a/src/it/java/uk/gov/justice/digital/test/BaseMinimalDataIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/test/BaseMinimalDataIntegrationTest.java
@@ -15,6 +15,7 @@ public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
     protected static final int pk3 = 3;
     protected static final int pk4 = 4;
     protected static final int pk5 = 5;
+    protected static final int pk6 = 6;
 
     protected static final String inputSchemaName = "my-schema";
     protected static final String inputTableName = "my-table";
@@ -38,7 +39,7 @@ public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
                 .resolve(inputTableName)
                 .toAbsolutePath()
                 .toString();
-        assertDeltaTableContainsPK(violationsTablePath, primaryKey);
+        assertViolationsTableContainsPK(violationsTablePath, primaryKey);
     }
 
     protected void thenStructuredViolationsContainsForPK(String data, int primaryKey) {
@@ -48,7 +49,7 @@ public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
                 .resolve(inputTableName)
                 .toAbsolutePath()
                 .toString();
-        assertDeltaTableContainsForPK(violationsTablePath, data, primaryKey);
+        assertViolationsTableContainsForPK(violationsTablePath, data, primaryKey);
     }
 
     protected void thenStructuredAndCuratedDoNotContainPK(int primaryKey) {

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -83,6 +83,7 @@ public class S3DataProvider {
         val scalaFilePaths = JavaConverters.asScalaIteratorConverter(filePaths.iterator()).asScala().toSeq();
         return sparkSession
                 .read()
+                .option("mergeSchema", "true")
                 .parquet(scalaFilePaths);
     }
 

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -11,6 +11,7 @@ public class CommonDataFields {
     public static final String TIMESTAMP = "_timestamp";
     // The error column is added to the schema by the app when writing violations to give error details.
     public static final String ERROR = "error";
+    public static final String ERROR_RAW = "raw";
 
     /**
      * The possible entries in the operation column

--- a/src/main/java/uk/gov/justice/digital/service/ViolationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ViolationService.java
@@ -165,7 +165,7 @@ public class ViolationService {
     ) throws DataStorageException {
         val destinationPath = fullTablePath(source, table, zoneName);
         logger.warn("Violation - for source {}, table {}", source, table);
-        logger.info("Appending {} records to deltalake table: {}", invalidRecords.count(), destinationPath);
+        logger.info("Appending records to deltalake table: {}", destinationPath);
         Column[] columns = Arrays
                 .stream(invalidRecords.columns())
                 .filter(c -> !ERROR.equals(c))


### PR DESCRIPTION
- The violations tables are currently using the schemas of the input tables. 
- This is incompatible with writing data that doesn't match the schema (in certain incompatible ways, such as data type changes). If the data doesn't match the schema then you can't write it to a table that requires that schema!
- This work changes the violations table schemas to allow violations to be written when the schema has changed in an incompatible way since the last write to violations, such as incompatible data type change
- To enable this it changes the schema of violations from that of the input table to two columns: a string containing the error and a string containing the original input converted to json.
- Added tests to show violations with different input schemas can be written to the same violations table
- Also added a test to show that violations data with different input schemas can subsequently be read back in using spark with the data types widening to string if the schemas are incompatible.