### PR TITLE
Fix most compiler warnings and fix build failures due to micronaut version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'org.sonarqube'  version '3.5.0.2730'
     id 'org.owasp.dependencycheck'  version '8.2.1'
     id 'org.gradle.java-test-fixtures'
-    id 'io.micronaut.minimal.library'  version '3.7.5'
+    id 'io.micronaut.minimal.library'  version '3.7.10'
     id 'org.barfuin.gradle.jacocolog' version '3.1.0'
 }
 
@@ -190,6 +190,7 @@ test {
     jacoco.includeNoLocationClasses = true
     testLogging {
         events "passed", "skipped", "failed"
+        exceptionFormat = 'full'
     }
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     println("\nUsing $maxParallelForks executors")

--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ tasks.register('integrationTest', Test) {
 
     testLogging {
         events "passed", "skipped", "failed"
+        exceptionFormat = 'full'
     }
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 

--- a/src/it/java/uk/gov/justice/digital/config/BaseSparkTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/BaseSparkTest.java
@@ -110,7 +110,7 @@ public class BaseSparkTest {
 
 	protected static void assertViolationsTableContainsPK(String tablePath, int primaryKey) {
 		Dataset<Row> df = spark.read().format("delta").load(tablePath);
-		Dataset<Row> errorRawAsJson = spark.read().json(df.select(ERROR_RAW).as(Encoders.STRING()).javaRDD());
+		Dataset<Row> errorRawAsJson = spark.read().json(df.select(ERROR_RAW).as(Encoders.STRING()));
 		List<Row> result = errorRawAsJson
 				.select(PRIMARY_KEY_COLUMN)
 				.where(col(PRIMARY_KEY_COLUMN).equalTo(lit(primaryKey)))
@@ -122,7 +122,7 @@ public class BaseSparkTest {
 
 	protected static void assertViolationsTableContainsForPK(String tablePath, String data, int primaryKey) {
 		Dataset<Row> df = spark.read().format("delta").load(tablePath);
-		Dataset<Row> errorRawAsJson = spark.read().json(df.select(ERROR_RAW).as(Encoders.STRING()).javaRDD());
+		Dataset<Row> errorRawAsJson = spark.read().json(df.select(ERROR_RAW).as(Encoders.STRING()));
 		List<Row> result = errorRawAsJson
 				.select(DATA_COLUMN)
 				.where(col(PRIMARY_KEY_COLUMN).equalTo(lit(primaryKey)))

--- a/src/it/java/uk/gov/justice/digital/service/ViolationServiceIT.java
+++ b/src/it/java/uk/gov/justice/digital/service/ViolationServiceIT.java
@@ -94,7 +94,7 @@ public class ViolationServiceIT extends BaseSparkTest {
 
         Dataset<Row> result = spark.read().format("delta")
                 .load(violationsRoot.resolve(STRUCTURED_LOAD.getPath()).resolve(source).resolve(table).toString());
-        Dataset<Row> errorRawAsJson = spark.read().json(result.select(ERROR_RAW).as(Encoders.STRING()).javaRDD());
+        Dataset<Row> errorRawAsJson = spark.read().json(result.select(ERROR_RAW).as(Encoders.STRING()));
         errorRawAsJson.show(30, false);
 
         long expectedCount = original.count();

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/S3BatchProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/S3BatchProcessorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
@@ -61,6 +62,8 @@ class S3BatchProcessorTest extends BaseSparkTest {
     private SourceReference sourceReference;
     @Mock
     private ValidationService validationService;
+    @Captor
+    private ArgumentCaptor<Dataset<Row>> argumentCaptor;
 
     private S3BatchProcessor underTest;
 
@@ -84,8 +87,6 @@ class S3BatchProcessorTest extends BaseSparkTest {
     }
     @Test
     public void shouldProcessStructured() throws DataStorageException {
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
-
         when(validationService.handleValidation(any(), any(), eq(sourceReference), eq(TEST_DATA_SCHEMA), eq(STRUCTURED_LOAD))).thenReturn(validatedDf);
         when(structuredZoneLoad.process(any(), any(), any())).thenReturn(validatedDf);
 
@@ -100,8 +101,6 @@ class S3BatchProcessorTest extends BaseSparkTest {
 
     @Test
     public void shouldProcessCurated() throws DataStorageException {
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
-
         when(validationService.handleValidation(any(), any(), eq(sourceReference), eq(TEST_DATA_SCHEMA), eq(STRUCTURED_LOAD)))
                 .thenReturn(validatedDf);
         when(structuredZoneLoad.process(any(), any(), any())).thenReturn(validatedDf);
@@ -116,8 +115,6 @@ class S3BatchProcessorTest extends BaseSparkTest {
 
     @Test
     public void shouldDelegateValidationOnlyValidatingInserts() throws DataStorageException {
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
-
         Dataset<Row> mixedOperations = validatedDf
                 .unionAll(validatedDf.withColumn(OPERATION, lit(Update.getName())))
                 .unionAll(validatedDf.withColumn(OPERATION, lit(Delete.getName())));

--- a/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import scala.Option;
@@ -39,6 +40,8 @@ class TableStreamingQueryTest extends BaseSparkTest {
     private VoidFunction2<Dataset<Row>, Long> batchProcessingFunc;
     @TempDir
     private Path testRoot;
+    @Captor
+    private ArgumentCaptor<Dataset<Row>> argumentCaptor;
 
     private TableStreamingQuery underTest;
 
@@ -70,7 +73,6 @@ class TableStreamingQueryTest extends BaseSparkTest {
         StreamingQuery sparkStreamingQuery = underTest.runQuery();
         sparkStreamingQuery.processAllAvailable();
 
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
         verify(batchProcessingFunc, times(1))
                 .call(argumentCaptor.capture(), any());
         List<Row> result = argumentCaptor.getValue().collectAsList();

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
@@ -57,6 +58,8 @@ class ValidationServiceTest extends BaseSparkTest {
     private SourceReference sourceReference;
     @Mock
     private SourceReference.PrimaryKey primaryKey;
+    @Captor
+    private ArgumentCaptor<Dataset<Row>> argumentCaptor;
     private ValidationService underTest;
 
     @BeforeEach
@@ -211,7 +214,6 @@ class ValidationServiceTest extends BaseSparkTest {
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
         when(sourceReference.getSource()).thenReturn(source);
         when(sourceReference.getTable()).thenReturn(table);
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
 
         underTest.handleValidation(spark, inputDf, sourceReference, TEST_DATA_SCHEMA, STRUCTURED_LOAD).collectAsList();
 
@@ -246,7 +248,6 @@ class ValidationServiceTest extends BaseSparkTest {
         when(sourceReference.getVersionNumber()).thenReturn(1L);
         when(sourceReference.getSource()).thenReturn(source);
         when(sourceReference.getTable()).thenReturn(table);
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
 
         underTest.handleValidation(spark, inputDf, sourceReference, misMatchingSchema, STRUCTURED_LOAD).collectAsList();
 

--- a/src/test/java/uk/gov/justice/digital/service/ViolationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ViolationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
@@ -45,6 +46,8 @@ class ViolationServiceTest extends BaseSparkTest {
     private DataStorageService mockDataStorage;
     @Mock
     private DataStorageRetriesExhaustedException mockCause;
+    @Captor
+    private ArgumentCaptor<Dataset<Row>> argumentCaptor;
 
     private ViolationService underTest;
 
@@ -130,7 +133,6 @@ class ViolationServiceTest extends BaseSparkTest {
 
     @Test
     public void handleViolationShouldWriteViolationsUsingCommonSchema() throws DataStorageException {
-        ArgumentCaptor<Dataset<Row>> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
         underTest.handleViolation(spark, testInputDataframe(), "source", "table", STRUCTURED_LOAD);
         verify(mockDataStorage).append(any(), argumentCaptor.capture());
 

--- a/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneCdcTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneCdcTest.java
@@ -52,7 +52,7 @@ class CuratedZoneCdcTest extends BaseSparkTest {
     private ViolationService mockViolationService;
 
     @Captor
-    ArgumentCaptor<Dataset<Row>> dataframeCaptor;
+    private ArgumentCaptor<Dataset<Row>> dataframeCaptor;
 
     private final String curatedPath = createValidatedPath(CURATED_PATH, TABLE_SOURCE, TABLE_NAME);
 

--- a/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoadTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/curated/CuratedZoneLoadTest.java
@@ -53,7 +53,7 @@ class CuratedZoneLoadTest extends BaseSparkTest {
     private ViolationService mockViolationService;
 
     @Captor
-    ArgumentCaptor<Dataset<Row>> dataframeCaptor;
+    private ArgumentCaptor<Dataset<Row>> dataframeCaptor;
 
     private final Dataset<Row> testDataSet = createStructuredLoadDataset(spark);
 

--- a/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneCdcTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneCdcTest.java
@@ -59,7 +59,7 @@ class StructuredZoneCdcTest extends BaseSparkTest {
     private ViolationService mockViolationService;
 
     @Captor
-    ArgumentCaptor<Dataset<Row>> dataframeCaptor;
+    private ArgumentCaptor<Dataset<Row>> dataframeCaptor;
 
     private StructuredZone underTest;
 

--- a/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneLoadTest.java
+++ b/src/test/java/uk/gov/justice/digital/zone/structured/StructuredZoneLoadTest.java
@@ -58,7 +58,7 @@ class StructuredZoneLoadTest extends BaseSparkTest {
     private ViolationService mockViolationService;
 
     @Captor
-    ArgumentCaptor<Dataset<Row>> dataframeCaptor;
+    private ArgumentCaptor<Dataset<Row>> dataframeCaptor;
 
     private StructuredZone underTest;
 


### PR DESCRIPTION
- Change micronaut version which doesn't work in CI build
- Show more of exceptions when tests fail
- Use @Captor to avoid type erasure warning in argument captors
- Create dataframes from json column using Dataset<String> rather than deprecated RDD version