### PR TITLE
DPR2-210: Solve Scala java integration issue

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.client.s3;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.val;
-import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -14,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import scala.collection.JavaConverters;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.domain.model.SourceReference;
-import uk.gov.justice.digital.exception.FailedMergingSchemas;
+import uk.gov.justice.digital.exception.DataProviderFailedMergingSchemasException;
 import uk.gov.justice.digital.exception.NoSchemaNoDataException;
 
 import java.util.List;
@@ -81,7 +80,7 @@ public class S3DataProvider {
         }
     }
 
-    public Dataset<Row> getBatchSourceData(SparkSession sparkSession, List<String> filePaths) throws FailedMergingSchemas {
+    public Dataset<Row> getBatchSourceData(SparkSession sparkSession, List<String> filePaths) throws DataProviderFailedMergingSchemasException {
         try {
             val scalaFilePaths = JavaConverters.asScalaIteratorConverter(filePaths.iterator()).asScala().toSeq();
             return sparkSession
@@ -93,7 +92,7 @@ public class S3DataProvider {
             // that a checked exception type is being thrown and java seems to optimise away the catch block if it
             // thinks the SparkException can't be thrown in the try block.
             if(e.getMessage().startsWith("Failed merging schema")) {
-                throw new FailedMergingSchemas("Failed merging schemas when getting batch source data", e);
+                throw new DataProviderFailedMergingSchemasException("Failed merging schemas when getting batch source data", e);
             } else {
                 throw e;
             }

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -80,7 +80,7 @@ public class S3DataProvider {
         }
     }
 
-    public Dataset<Row> getBatchSourceData(SparkSession sparkSession, List<String> filePaths) throws SparkException {
+    public Dataset<Row> getBatchSourceData(SparkSession sparkSession, List<String> filePaths) {
         val scalaFilePaths = JavaConverters.asScalaIteratorConverter(filePaths.iterator()).asScala().toSeq();
         return sparkSession
                 .read()

--- a/src/main/java/uk/gov/justice/digital/exception/DataProviderFailedMergingSchemasException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/DataProviderFailedMergingSchemasException.java
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.exception;
+
+/**
+ * Thrown when the data provider cannot read the input data due to incompatible schemas.
+ */
+public class DataProviderFailedMergingSchemasException extends Exception {
+
+    private static final long serialVersionUID = -8685733006029513888L;
+    public DataProviderFailedMergingSchemasException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/exception/FailedMergingSchemas.java
+++ b/src/main/java/uk/gov/justice/digital/exception/FailedMergingSchemas.java
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.exception;
-
-public class FailedMergingSchemas extends Exception {
-
-    public FailedMergingSchemas(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/src/main/java/uk/gov/justice/digital/exception/FailedMergingSchemas.java
+++ b/src/main/java/uk/gov/justice/digital/exception/FailedMergingSchemas.java
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.exception;
+
+public class FailedMergingSchemas extends Exception {
+
+    public FailedMergingSchemas(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/DataHubBatchJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubBatchJob.java
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.domain.model.SourceReference;
 import uk.gov.justice.digital.exception.DataStorageException;
-import uk.gov.justice.digital.exception.FailedMergingSchemas;
+import uk.gov.justice.digital.exception.DataProviderFailedMergingSchemasException;
 import uk.gov.justice.digital.job.batchprocessing.S3BatchProcessor;
 import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
@@ -145,7 +145,7 @@ public class DataHubBatchJob implements Runnable {
                 logger.warn("No source reference for table {}.{} - writing all data to violations", schema, table);
                 violationService.handleNoSchemaFoundS3(sparkSession, dataFrame, schema, table, STRUCTURED_LOAD);
             }
-        } catch (FailedMergingSchemas e) {
+        } catch (DataProviderFailedMergingSchemasException e) {
             String msg = String.format("Violation - Incompatible schemas across multiple files for %s.%s", schema, table);
             logger.warn(msg, e);
             violationService.writeBatchDataToViolations(sparkSession, schema, table, msg);

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,7 +44,7 @@ class S3DataProviderTest {
         when(spark.read()).thenReturn(dfReader);
         when(dfReader.option(anyString(), anyString())).thenReturn(dfReader);
         // Can't use thenThrow because scala does not advertise that it throws the checked exception!
-        when(dfReader.parquet(eq(scalaExpectedInput))).thenAnswer(i -> {
+        when(dfReader.parquet(scalaExpectedInput)).thenAnswer(i -> {
             throw new SparkException("Failed merging schema");
         });
 

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.client.s3;
+
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.DataProviderFailedMergingSchemasException;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3DataProviderTest {
+
+    @Mock
+    private JobArguments arguments;
+    @Mock
+    private SparkSession spark;
+    @Mock
+    private DataFrameReader dfReader;
+
+    private S3DataProvider underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new S3DataProvider(arguments);
+    }
+
+    @Test
+    public void getBatchSourceDataShouldRethrowFailedMergingSchemaException() {
+        List<String> input = Collections.singletonList("s3://somepath");
+        Seq<String> scalaExpectedInput = JavaConverters.asScalaIteratorConverter(input.iterator()).asScala().toSeq();
+        when(spark.read()).thenReturn(dfReader);
+        when(dfReader.option(anyString(), anyString())).thenReturn(dfReader);
+        // Can't use thenThrow because scala does not advertise that it throws the checked exception!
+        when(dfReader.parquet(eq(scalaExpectedInput))).thenAnswer(i -> {
+            throw new Exception("Failed merging schema");
+        });
+
+        assertThrows(
+                DataProviderFailedMergingSchemasException.class,
+                () -> underTest.getBatchSourceData(spark, input)
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.client.s3;
 
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,14 +39,14 @@ class S3DataProviderTest {
     }
 
     @Test
-    public void getBatchSourceDataShouldRethrowFailedMergingSchemaException() {
+    public void getBatchSourceDataShouldCatchAndThrowForFailedMergingSchemaException() {
         List<String> input = Collections.singletonList("s3://somepath");
         Seq<String> scalaExpectedInput = JavaConverters.asScalaIteratorConverter(input.iterator()).asScala().toSeq();
         when(spark.read()).thenReturn(dfReader);
         when(dfReader.option(anyString(), anyString())).thenReturn(dfReader);
         // Can't use thenThrow because scala does not advertise that it throws the checked exception!
         when(dfReader.parquet(eq(scalaExpectedInput))).thenAnswer(i -> {
-            throw new Exception("Failed merging schema");
+            throw new SparkException("Failed merging schema");
         });
 
         assertThrows(

--- a/src/test/java/uk/gov/justice/digital/job/DataHubBatchJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/DataHubBatchJobTest.java
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.domain.model.SourceReference;
+import uk.gov.justice.digital.exception.FailedMergingSchemas;
 import uk.gov.justice.digital.job.batchprocessing.S3BatchProcessor;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.SourceReferenceService;
@@ -139,7 +140,7 @@ class DataHubBatchJobTest {
 
     @Test
     public void shouldWriteViolationsWhenDataProviderCannotMergeInputData() throws Exception {
-        SparkException thrown = new SparkException("Failed merging schema");
+        FailedMergingSchemas thrown = new FailedMergingSchemas("Failed merging schema", new Exception());
         when(dataProvider.getBatchSourceData(any(), anyList())).thenThrow(thrown);
         stubRawPath();
         stubDiscoveredTablePaths();
@@ -161,7 +162,7 @@ class DataHubBatchJobTest {
         when(tableDiscoveryService.discoverBatchFilesToLoad(rawPath, spark)).thenReturn(Collections.emptyMap());
     }
 
-    private void stubReadData() throws SparkException {
+    private void stubReadData() throws Exception {
         when(dataProvider.getBatchSourceData(any(), anyList())).thenReturn(dataFrame);
         when(dataFrame.schema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
     }

--- a/src/test/java/uk/gov/justice/digital/job/DataHubBatchJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/DataHubBatchJobTest.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.job;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -14,7 +13,7 @@ import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.domain.model.SourceReference;
-import uk.gov.justice.digital.exception.FailedMergingSchemas;
+import uk.gov.justice.digital.exception.DataProviderFailedMergingSchemasException;
 import uk.gov.justice.digital.job.batchprocessing.S3BatchProcessor;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.SourceReferenceService;
@@ -140,7 +139,7 @@ class DataHubBatchJobTest {
 
     @Test
     public void shouldWriteViolationsWhenDataProviderCannotMergeInputData() throws Exception {
-        FailedMergingSchemas thrown = new FailedMergingSchemas("Failed merging schema", new Exception());
+        DataProviderFailedMergingSchemasException thrown = new DataProviderFailedMergingSchemasException("Failed merging schema", new Exception());
         when(dataProvider.getBatchSourceData(any(), anyList())).thenThrow(thrown);
         stubRawPath();
         stubDiscoveredTablePaths();
@@ -162,7 +161,7 @@ class DataHubBatchJobTest {
         when(tableDiscoveryService.discoverBatchFilesToLoad(rawPath, spark)).thenReturn(Collections.emptyMap());
     }
 
-    private void stubReadData() throws Exception {
+    private void stubReadData() throws DataProviderFailedMergingSchemasException {
         when(dataProvider.getBatchSourceData(any(), anyList())).thenReturn(dataFrame);
         when(dataFrame.schema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
     }


### PR DESCRIPTION
- When Spark reads data it can throw a SparkException (a checked Exception type)
- It does not advertise that it throws this using the scala @throws annotation which means that the bytecode scala generates does not have the equivalent of `throws SparkException`
- This means that the java compiler does not believe the SparkException can be thrown.
- It seems that the `catch (SparkException e)` block is optimised away because Java thinks this block can never be reached.
- The previous code works when the main method is run against an environment using Intellij but does not catch the same exception for the same input data when run in Glue using a packaged jar.
- This change changes the catch to catch a broader exception type.
- It also hides away the scala - java integration nastiness inside the data provider