### PR TITLE
DPR2-33: Use shouldX (or XShouldY if needs be) in all tests.

### DIFF
--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
@@ -22,7 +22,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldCompactDeltaTableWhenRecursingDepth1() throws Exception {
+    public void shouldCompactDeltaTableWhenRecursingWithDepth1() throws Exception {
         int depthLimit = 1;
         assertMultipleParquetFilesPrecondition(offendersTablePath);
         assertMultipleParquetFilesPrecondition(offenderBookingsTablePath);
@@ -54,7 +54,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldCompactDeltaTablesWhenRecursingDepth2() throws Exception {
+    public void shouldCompactDeltaTablesWhenRecursingWithDepth2() throws Exception {
         int depthLimit = 2;
 
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
@@ -66,7 +66,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldCompactDeltaTablesWhenRecursingDepth3() throws Exception {
+    public void shouldCompactDeltaTablesWhenRecursingWithDepth3() throws Exception {
         int depthLimit = 3;
 
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);

--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
@@ -33,7 +33,7 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldVacuumDeltaTablesWhenRecursingDepth1() throws Exception {
+    public void shouldVacuumDeltaTablesWhenRecursingWithDepth1() throws Exception {
         int depthLimit = 1;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
@@ -48,7 +48,7 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldVacuumDeltaTablesWhenRecursingDepth2() throws Exception {
+    public void shouldVacuumDeltaTablesWhenRecursingWithDepth2() throws Exception {
         int depthLimit = 2;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
@@ -63,7 +63,7 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
     }
 
     @Test
-    public void shouldVacuumDeltaTablesWhenRecursingDepth3() throws Exception {
+    public void shouldVacuumDeltaTablesWhenRecursingWithDepth3() throws Exception {
         int depthLimit = 3;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
         underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);

--- a/src/test/java/uk/gov/justice/digital/common/ResourcePathTest.java
+++ b/src/test/java/uk/gov/justice/digital/common/ResourcePathTest.java
@@ -46,13 +46,13 @@ class ResourcePathTest {
     }
 
     @Test
-    public void tablePathRootHasNoSlash() {
+    public void tablePathShouldAddSlashWhenHasNoSlash() {
         String result = tablePath("s3://root", "source", "table");
         assertEquals("s3://root/source/table", result);
     }
 
     @Test
-    public void tablePathRootHasSlash() {
+    public void tablePathRootShouldNotAddSlashWhenHasSlash() {
         String result = tablePath("s3://root/", "source", "table");
         assertEquals("s3://root/source/table", result);
     }

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceSchemasMatchTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceSchemasMatchTest.java
@@ -12,7 +12,7 @@ import static uk.gov.justice.digital.service.ValidationService.schemasMatch;
 
 public class ValidationServiceSchemasMatchTest {
     @Test
-    public void sameObjectShouldMatch() {
+    public void shouldMatchSameObject() {
         StructType schema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, false, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, true, Metadata.empty()),
@@ -21,7 +21,7 @@ public class ValidationServiceSchemasMatchTest {
         assertTrue(schemasMatch(schema, schema));
     }
     @Test
-    public void identicalSchemasShouldMatch() {
+    public void shouldMatchIdenticalSchemas() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, false, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, true, Metadata.empty()),
@@ -36,7 +36,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void sameSchemasButWithDifferentNullabilityShouldMatch() {
+    public void shouldMatchSameSchemasButWithDifferentNullability() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, false, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, true, Metadata.empty()),
@@ -51,7 +51,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void schemaWithExtraColumnShouldNotMatch() {
+    public void ShouldNotMatchSchemaWithExtraColumn() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, false, Metadata.empty()),
@@ -67,7 +67,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void schemaWithMissingColumnShouldNotMatch() {
+    public void shouldNotMatchSchemaWithMissingColumn() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, false, Metadata.empty()),
@@ -83,7 +83,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void sameColumnsExceptDifferentDataTypesShouldNotMatch() {
+    public void shouldNotMatchSameColumnsExceptDifferentDataTypes() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.StringType, false, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, true, Metadata.empty()),
@@ -98,7 +98,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void sameColumnsExceptDifferentMetadataShouldMatch() {
+    public void shouldMatchSameColumnsExceptDifferentMetadata() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.StringType, false, Metadata.fromJson("{ \"x\": \"y\"}")),
                 new StructField("column 2", DataTypes.StringType, true, Metadata.empty()),
@@ -113,7 +113,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void identicalNestedStructsShouldMatch() {
+    public void shouldMatchIdenticalNestedStructs() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", new StructType(new StructField[]{
@@ -140,7 +140,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void differentNestedStructColumnNamesShouldNotMatch() {
+    public void shouldNotMatchDifferentNestedStructColumnNames() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", new StructType(new StructField[]{
@@ -167,7 +167,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void differentNestedStructTypesShouldNotMatch() {
+    public void shouldNotMatchDifferentNestedStructTypes() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", new StructType(new StructField[]{
@@ -194,7 +194,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void differentNestedStructNullabilityShouldMatch() {
+    public void shouldMatchDifferentNestedStructNullability() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", new StructType(new StructField[]{
@@ -221,7 +221,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void differentNestedStructMetadataShouldMatch() {
+    public void shouldMatchDifferentNestedStructMetadata() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", new StructType(new StructField[]{
@@ -248,7 +248,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void schemaWithShortInferredIntSpecifiedShouldMatch() {
+    public void shouldMatchSchemaWithShortInferredIntSpecified() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.ShortType, true, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, false, Metadata.empty()),
@@ -263,7 +263,7 @@ public class ValidationServiceSchemasMatchTest {
     }
 
     @Test
-    public void schemaWithIntInferredShortSpecifiedShouldNotMatch() {
+    public void shouldNotMatchSchemaWithIntInferredShortSpecified() {
         StructType inferredSchema = new StructType(new StructField[]{
                 new StructField("column 1", DataTypes.IntegerType, true, Metadata.empty()),
                 new StructField("column 2", DataTypes.IntegerType, false, Metadata.empty()),

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -120,4 +120,6 @@ public class MinimalTestData {
         }
         return RowFactory.create(pk, timestamp, operationName, data);
      }
+
+     private MinimalTestData() {}
 }

--- a/src/test/java/uk/gov/justice/digital/test/ResourceLoader.java
+++ b/src/test/java/uk/gov/justice/digital/test/ResourceLoader.java
@@ -18,4 +18,6 @@ public class ResourceLoader {
 			.next();
 	}
 
+	private ResourceLoader() {}
+
 }


### PR DESCRIPTION
* Use shouldX naming pattern for tests (with some using XShouldY naming pattern where it helps readability)
* Add a couple of private constructors a la Effective Java coding standards