### PR TITLE
DPR2-46: Implement hive table switch job

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.AbstractMap;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +28,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.CONFIG_KEY, "test-config" },
             { JobArguments.AWS_REGION, "test-region" },
             { JobArguments.CURATED_S3_PATH, "s3://somepath/curated" },
+            { JobArguments.TARGET_S3_PATH, "s3://somepath/target" },
             { JobArguments.DOMAIN_CATALOG_DATABASE_NAME, "SomeDomainCatalogName" },
             { JobArguments.DOMAIN_NAME, "test_domain_name" },
             { JobArguments.DOMAIN_OPERATION, "insert" },
@@ -67,6 +67,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.AWS_DYNAMODB_ENDPOINT_URL, validArguments.getAwsDynamoDBEndpointUrl() },
                 { JobArguments.AWS_REGION, validArguments.getAwsRegion() },
                 { JobArguments.CURATED_S3_PATH, validArguments.getCuratedS3Path() },
+                { JobArguments.TARGET_S3_PATH, validArguments.getTargetS3Path() },
                 { JobArguments.DOMAIN_CATALOG_DATABASE_NAME, validArguments.getDomainCatalogDatabaseName() },
                 { JobArguments.DOMAIN_NAME, validArguments.getDomainName() },
                 { JobArguments.DOMAIN_OPERATION, validArguments.getDomainOperation() },

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -34,6 +34,7 @@ public class JobArguments {
     public static final String SCHEMA_CACHE_MAX_SIZE = "dpr.schema.cache.max.size";
     public static final String SCHEMA_CACHE_EXPIRY_IN_MINUTES = "dpr.schema.cache.expiry.days";
     public static final String CURATED_S3_PATH = "dpr.curated.s3.path";
+    public static final String TARGET_S3_PATH = "dpr.target.s3.path";
     public static final String DOMAIN_CATALOG_DATABASE_NAME = "dpr.domain.catalog.db";
     public static final String DOMAIN_NAME = "dpr.domain.name";
     public static final String DOMAIN_OPERATION = "dpr.domain.operation";
@@ -201,6 +202,10 @@ public class JobArguments {
 
     public String getCuratedS3Path() {
         return getArgument(CURATED_S3_PATH);
+    }
+
+    public String getTargetS3Path() {
+        return getArgument(TARGET_S3_PATH);
     }
 
     public String getDomainTargetPath() {

--- a/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
@@ -1,2 +1,0 @@
-package uk.gov.justice.digital.job;public class S3FileTransferJob {
-}

--- a/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
@@ -1,0 +1,2 @@
+package uk.gov.justice.digital.job;public class S3FileTransferJob {
+}

--- a/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.job;
+
+import com.google.common.collect.ImmutableSet;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.job.context.MicronautContext;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.HiveSchemaService;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+/**
+ * Job that switches the Hive tables from one s3 bucket to another.
+ */
+@CommandLine.Command(name = "SwitchHiveTableJob")
+public class SwitchHiveTableJob implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(SwitchHiveTableJob.class);
+    private final ConfigService configService;
+    private final HiveSchemaService hiveSchemaService;
+    private final JobArguments jobArguments;
+
+    @Inject
+    public SwitchHiveTableJob(
+            ConfigService configService,
+            HiveSchemaService hiveSchemaService,
+            JobArguments jobArguments
+    ) {
+        this.configService = configService;
+        this.hiveSchemaService = hiveSchemaService;
+        this.jobArguments = jobArguments;
+    }
+
+    public static void main(String[] args) {
+        logger.info("Job starting");
+        PicocliRunner.run(SwitchHiveTableJob.class, MicronautContext.withArgs(args));
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("SwitchHiveTableJob running");
+
+            ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
+                    .getConfiguredTables(jobArguments.getConfigKey());
+
+            Set<ImmutablePair<String, String>> failedTables = hiveSchemaService.switchPrisonsTableDataSource(configuredTables);
+
+            if (!failedTables.isEmpty()) {
+                logger.error("Not all schemas were processed");
+                System.exit(1);
+            }
+
+            logger.info("SwitchHiveTableJob finished");
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/SwitchHiveTableJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/SwitchHiveTableJobTest.java
@@ -1,0 +1,98 @@
+package uk.gov.justice.digital.job;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.HiveSchemaServiceException;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.HiveSchemaService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.test.SparkTestHelpers.containsTheSameElementsInOrderAs;
+
+@ExtendWith(MockitoExtension.class)
+public class SwitchHiveTableJobTest extends BaseSparkTest {
+
+    private static final String TEST_CONFIG_KEY = "some-config-key";
+
+    @Mock
+    private ConfigService mockConfigService;
+    @Mock
+    private HiveSchemaService mockHiveSchemaService;
+    @Mock
+    private JobArguments mockJobArguments;
+    @Captor
+    private ArgumentCaptor<ImmutableSet<ImmutablePair<String, String>>> argumentCaptor;
+
+    private SwitchHiveTableJob underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockConfigService, mockHiveSchemaService, mockJobArguments);
+        underTest = new SwitchHiveTableJob(mockConfigService, mockHiveSchemaService, mockJobArguments);
+    }
+
+    @Test
+    public void shouldCompleteSuccessfullyWhenThereAreNoFailedTables() {
+        Set<ImmutablePair<String, String>> expectedTables = new HashSet<>();
+        expectedTables.add(new ImmutablePair<>("schema_1", "table_1"));
+        expectedTables.add(new ImmutablePair<>("schema_1", "table_2"));
+        expectedTables.add(new ImmutablePair<>("schema_2", "table_3"));
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(expectedTables));
+        when(mockHiveSchemaService.switchPrisonsTableDataSource(argumentCaptor.capture())).thenReturn(Collections.emptySet());
+
+        assertDoesNotThrow(() -> underTest.run());
+
+        assertThat(argumentCaptor.getValue(), containsTheSameElementsInOrderAs(new ArrayList<>(expectedTables)));
+    }
+
+    @Test
+    public void shouldFailWhenThereAreFailedTables() throws Exception {
+        ImmutableSet<ImmutablePair<String, String>> failedTables = ImmutableSet.of(ImmutablePair.of("schema", "failed-table-1"));
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(failedTables));
+        when(mockHiveSchemaService.switchPrisonsTableDataSource(any())).thenReturn(failedTables);
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+    }
+
+    @Test
+    public void shouldFailWhenSchemaServiceThrowsAnException() throws Exception {
+        ImmutableSet<ImmutablePair<String, String>> table = ImmutableSet.of(ImmutablePair.of("schema_1", "table_1"));
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(table));
+        when(mockHiveSchemaService.switchPrisonsTableDataSource(any())).thenThrow(new HiveSchemaServiceException("Schema service exception"));
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+    }
+
+    @Test
+    public void shouldFailWhenConfigServiceThrowsAnException() throws Exception {
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenThrow(new RuntimeException("Config service error"));
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+    }
+}


### PR DESCRIPTION
This PR adds a Glue job which takes a config and switches the prisons hive tables to a specified s3 data location.

Example usage:
The below config points the prisons fabric tables for the `movements` domain to the `dpr-temp-reload` s3 bucket
```
--dpr.config.key: movements
--dpr.config.s3.bucket: dpr-glue-jobs-development
--dpr.target.s3.path: dpr-temp-reload
```