### PR TITLE
DPr2-45: Add file transfer and data deletion jobs

### DIFF
--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -178,7 +178,7 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
 
     private static void thenEventually(Thunk thunk) throws Throwable {
         Optional<Throwable> maybeEx = Optional.empty();
-        for (int i = 0; i < 15; i++) {
+        for (int i = 0; i < 20; i++) {
             try {
                 thunk.apply();
                 maybeEx = Optional.empty();

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3FileTransferClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3FileTransferClient.java
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.client.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+import javax.inject.Singleton;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
+
+@Singleton
+public class S3FileTransferClient {
+
+    private final AmazonS3 s3;
+    public static final String DELIMITER = "/";
+
+    public S3FileTransferClient(S3ClientProvider s3ClientProvider) {
+        this.s3 = s3ClientProvider.getClient();
+    }
+
+    public List<String> getObjectsOlderThan(String bucket, String extension, Long retentionDays, Clock clock) {
+        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket);
+        return listObjects(extension, retentionDays, clock, request);
+    }
+
+    public List<String> getObjectsOlderThan(
+            String bucket,
+            String folder,
+            String extension,
+            Long retentionDays,
+            Clock clock
+    ) {
+        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withPrefix(folder);
+        return listObjects(extension, retentionDays, clock, request);
+    }
+
+    private List<String> listObjects(String extension, Long retentionDays, Clock clock, ListObjectsRequest request) {
+        LocalDateTime currentDate = LocalDateTime.now(clock);
+        List<String> objectPaths = new LinkedList<>();
+        ObjectListing objectList;
+        do {
+            objectList = s3.listObjects(request);
+            for (S3ObjectSummary summary : objectList.getObjectSummaries()) {
+
+                LocalDateTime lastModifiedDate = summary.getLastModified().toInstant().atZone(clock.getZone()).toLocalDateTime();
+                boolean isBeforeRetentionPeriod = lastModifiedDate.isBefore(currentDate.minusDays(retentionDays));
+
+                String summaryKey = summary.getKey();
+
+                if (!summaryKey.endsWith(DELIMITER) && summaryKey.endsWith(extension) && isBeforeRetentionPeriod) {
+                    objectPaths.add(summaryKey);
+                }
+            }
+            request.setMarker(objectList.getMarker());
+        } while (objectList.isTruncated());
+
+        return objectPaths;
+    }
+
+    public void moveObject(String objectKey, String sourceBucket, String destinationBucket) {
+        s3.copyObject(sourceBucket, objectKey, destinationBucket, objectKey);
+        s3.deleteObject(sourceBucket, objectKey);
+    }
+
+    public void deleteObject(String objectKey, String sourceBucket) {
+        s3.deleteObject(sourceBucket, objectKey);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/common/ConfigSourceDetails.java
+++ b/src/main/java/uk/gov/justice/digital/common/ConfigSourceDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.common;
+
+public class ConfigSourceDetails {
+
+    private final String bucket;
+    private final String configKey;
+
+    public ConfigSourceDetails(String bucket, String configKey) {
+        this.bucket = bucket;
+        this.configKey = configKey;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getConfigKey() {
+        return configKey;
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.config;
 
+import com.google.common.collect.ImmutableSet;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.CommandLinePropertySource;
 import io.micronaut.context.env.MapPropertySource;
@@ -10,10 +11,8 @@ import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -92,6 +91,12 @@ public class JobArguments {
 
     public static final String BATCH_LOAD_FILE_GLOB_PATTERN = "dpr.batch.load.fileglobpattern";
     public static final String BATCH_LOAD_FILE_GLOB_PATTERN_DEFAULT = "LOAD*parquet";
+    public static final String FILE_TRANSFER_SOURCE_BUCKET_NAME = "dpr.file.transfer.source.bucket";
+    public static final String FILE_TRANSFER_DESTINATION_BUCKET_NAME = "dpr.file.transfer.destination.bucket";
+    public static final String FILE_TRANSFER_RETENTION_DAYS = "dpr.file.transfer.retention.days";
+    static final Long DEFAULT_FILE_TRANSFER_RETENTION_DAYS = 0L;
+    // A comma separated list of buckets to delete files from
+    static final String FILE_DELETION_BUCKETS = "dpr.file.deletion.buckets";
 
     private final Map<String, String> config;
 
@@ -290,6 +295,26 @@ public class JobArguments {
 
     public String getBatchLoadFileGlobPattern() {
         return getArgument(BATCH_LOAD_FILE_GLOB_PATTERN, BATCH_LOAD_FILE_GLOB_PATTERN_DEFAULT);
+    }
+
+    public String getTransferSourceBucket() {
+        return getArgument(FILE_TRANSFER_SOURCE_BUCKET_NAME);
+    }
+
+    public String getTransferDestinationBucket() {
+        return getArgument(FILE_TRANSFER_DESTINATION_BUCKET_NAME);
+    }
+
+    public Long getFileTransferRetentionDays() {
+        return getArgument(FILE_TRANSFER_RETENTION_DAYS, DEFAULT_FILE_TRANSFER_RETENTION_DAYS);
+    }
+
+    public ImmutableSet<String> getBucketsToDeleteFilesFrom() {
+        Set<String> buckets = Arrays.stream(getArgument(FILE_DELETION_BUCKETS).toLowerCase().split(","))
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .collect(Collectors.toSet());
+        return ImmutableSet.copyOf(buckets);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -1,0 +1,88 @@
+package uk.gov.justice.digital.job;
+
+import com.google.common.collect.ImmutableSet;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.job.context.MicronautContext;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.S3FileService;
+
+import javax.inject.Inject;
+import java.util.*;
+
+/**
+ * Job that deletes parquet files from a list of bucket(s).
+ */
+@CommandLine.Command(name = "S3DataDeletionJob")
+public class S3DataDeletionJob implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3DataDeletionJob.class);
+    private final ConfigService configService;
+    private final S3FileService s3FileService;
+    private final JobArguments jobArguments;
+
+    @Inject
+    public S3DataDeletionJob(
+            ConfigService configService,
+            S3FileService s3FileService,
+            JobArguments jobArguments
+    ) {
+        this.configService = configService;
+        this.s3FileService = s3FileService;
+        this.jobArguments = jobArguments;
+    }
+
+    public static void main(String[] args) {
+        logger.info("Job starting");
+        PicocliRunner.run(S3DataDeletionJob.class, MicronautContext.withArgs(args));
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("S3DataDeletionJob running");
+
+            deleteFiles();
+
+            logger.info("S3DataDeletionJob finished");
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+    }
+
+    public void deleteFiles() {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
+                .getConfiguredTables(jobArguments.getConfigKey());
+
+        final ImmutableSet<String> bucketsToDeleteFilesFrom = jobArguments.getBucketsToDeleteFilesFrom();
+
+        Set<String> failedObjects = new HashSet<>();
+
+        for (String bucketToDeleteFilesFrom : bucketsToDeleteFilesFrom) {
+            List<String> objectKeys = new ArrayList<>();
+            if (configuredTables.isEmpty()) {
+                // When no config is provided, all files in s3 bucket are deleted
+                logger.info("Listing files in S3 source location: {}", bucketToDeleteFilesFrom);
+                objectKeys.addAll(s3FileService.listParquetFiles(bucketToDeleteFilesFrom, 0L));
+            } else {
+                // When config is provided, only files belonging to the configured tables are deleted
+                objectKeys.addAll(s3FileService.listParquetFilesForConfig(bucketToDeleteFilesFrom, configuredTables, 0L));
+            }
+
+            logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
+            failedObjects = s3FileService.deleteObjects(objectKeys, bucketToDeleteFilesFrom);
+        }
+
+        if (failedObjects.isEmpty()) {
+            logger.info("Successfully deleted S3 files");
+        } else {
+            logger.warn("Not all S3 files were deleted");
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
@@ -1,0 +1,88 @@
+package uk.gov.justice.digital.job;
+
+import com.google.common.collect.ImmutableSet;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.job.context.MicronautContext;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.S3FileService;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Job that moves parquet files from a source bucket to a destination bucket.
+ */
+@CommandLine.Command(name = "S3FileTransferJob")
+public class S3FileTransferJob implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3FileTransferJob.class);
+    private final ConfigService configService;
+    private final S3FileService s3FileService;
+    private final JobArguments jobArguments;
+
+    @Inject
+    public S3FileTransferJob(
+            ConfigService configService,
+            S3FileService s3FileService,
+            JobArguments jobArguments
+    ) {
+        this.configService = configService;
+        this.s3FileService = s3FileService;
+        this.jobArguments = jobArguments;
+    }
+
+    public static void main(String[] args) {
+        logger.info("Job starting");
+        PicocliRunner.run(S3FileTransferJob.class, MicronautContext.withArgs(args));
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("S3FileTransferJob running");
+
+            transferFiles();
+
+            logger.info("S3FileTransferJob finished");
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+    }
+
+    private void transferFiles() {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
+                .getConfiguredTables(jobArguments.getConfigKey());
+
+        final String sourceBucket = jobArguments.getTransferSourceBucket();
+        final String destinationBucket = jobArguments.getTransferDestinationBucket();
+        final Long retentionDays = jobArguments.getFileTransferRetentionDays();
+
+        List<String> objectKeys = new ArrayList<>();
+        if (configuredTables.isEmpty()) {
+            // When no config is provided, all files in s3 bucket are archived
+            logger.info("Listing files in S3 source location: {}", sourceBucket);
+            objectKeys.addAll(s3FileService.listParquetFiles(sourceBucket, retentionDays));
+        } else {
+            // When config is provided, only files belonging to the configured tables are archived
+            objectKeys.addAll(s3FileService.listParquetFilesForConfig(sourceBucket, configuredTables, retentionDays));
+        }
+
+        logger.info("Moving S3 objects older than {} day(s) from {} to {}", retentionDays, sourceBucket, destinationBucket);
+        Set<String> failedObjects = s3FileService.moveObjects(objectKeys, sourceBucket, destinationBucket);
+
+        if (failedObjects.isEmpty()) {
+            logger.info("Successfully moved {} S3 files", objectKeys.size());
+        } else {
+            logger.warn("Not all S3 files were moved");
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/S3FileService.java
+++ b/src/main/java/uk/gov/justice/digital/service/S3FileService.java
@@ -1,0 +1,99 @@
+package uk.gov.justice.digital.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.client.s3.S3FileTransferClient;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Clock;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static uk.gov.justice.digital.client.s3.S3FileTransferClient.DELIMITER;
+
+@Singleton
+public class S3FileService {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3FileService.class);
+    private final S3FileTransferClient s3Client;
+    private final Clock clock;
+
+    public static final String FILE_EXTENSION = ".parquet";
+
+    @Inject
+    public S3FileService(
+            S3FileTransferClient s3Client,
+            Clock clock
+    ) {
+        this.s3Client = s3Client;
+        this.clock = clock;
+    }
+
+    public List<String> listParquetFiles(String bucket, Long retentionDays) {
+        return s3Client.getObjectsOlderThan(bucket, FILE_EXTENSION, retentionDays, clock);
+    }
+
+    public List<String> listParquetFilesForConfig(
+            String sourceBucket,
+            ImmutableSet<ImmutablePair<String, String>> configuredTables,
+            Long retentionDays
+    ) {
+        return configuredTables.stream()
+                .flatMap(configuredTable -> listFilesForTable(sourceBucket, retentionDays, configuredTable).stream())
+                .collect(Collectors.toList());
+    }
+
+    public Set<String> moveObjects(
+            List<String> objectKeys,
+            String sourceBucket,
+            String destinationBucket
+    ) {
+        Set<String> failedObjects = new HashSet<>();
+
+        for (String objectKey : objectKeys) {
+            try {
+                s3Client.moveObject(objectKey, sourceBucket, destinationBucket);
+            } catch (AmazonServiceException e) {
+                logger.warn("Failed to move S3 object {}: {}", objectKey, e.getErrorMessage());
+                failedObjects.add(objectKey);
+            }
+        }
+
+        return failedObjects;
+    }
+
+    public Set<String> deleteObjects(List<String> objectKeys, String sourceBucket) {
+        Set<String> failedObjects = new HashSet<>();
+
+        for (String objectKey : objectKeys) {
+            try {
+                s3Client.deleteObject(objectKey, sourceBucket);
+            } catch (AmazonServiceException e) {
+                logger.warn("Failed to delete S3 object {}: {}", objectKey, e.getErrorMessage());
+                failedObjects.add(objectKey);
+            }
+        }
+
+        return failedObjects;
+    }
+
+    private List<String> listFilesForTable(
+            String sourceBucket,
+            Long retentionDays,
+            ImmutablePair<String, String> configuredTable
+    ) {
+        String tableKey = configuredTable.left + DELIMITER + configuredTable.right + DELIMITER;
+        logger.info("Listing files in S3 source location {} for table {}", sourceBucket, tableKey);
+        return s3Client.getObjectsOlderThan(
+                sourceBucket,
+                tableKey,
+                FILE_EXTENSION,
+                retentionDays,
+                clock
+        );
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -1,0 +1,148 @@
+package uk.gov.justice.digital.job;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.ConfigServiceException;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.S3FileService;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class S3DataDeletionJobTest extends BaseSparkTest {
+
+    private static final String TEST_CONFIG_KEY = "some-config-key";
+
+    @Mock
+    private ConfigService mockConfigService;
+    @Mock
+    private JobArguments mockJobArguments;
+    @Mock
+    private S3FileService mockS3FileService;
+    @Captor
+    ArgumentCaptor<String> listObjectsBucketCaptor;
+    @Captor
+    ArgumentCaptor<String> deleteObjectsBucketCaptor;
+
+    private final static ImmutableSet<String> bucketsToDeleteFrom = ImmutableSet
+            .of("bucket-to-delete-from-1", "bucket-to-delete-from-2");
+
+    private S3DataDeletionJob underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockConfigService, mockS3FileService, mockJobArguments);
+
+        underTest = new S3DataDeletionJob(
+                mockConfigService,
+                mockS3FileService,
+                mockJobArguments
+        );
+    }
+
+    @Test
+    public void shouldDeleteFilesBelongingToGivenConfiguration() {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema_1", "table_1"),
+                ImmutablePair.of("schema_2", "table_2")
+        );
+
+        List<String> objectsToDelete = new ArrayList<>();
+        objectsToDelete.add("schema_1/table_1/file_1.parquet");
+        objectsToDelete.add("schema_1/table_1/file_2.parquet");
+        objectsToDelete.add("schema_2/table_2/file_3.parquet");
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+
+        when(mockS3FileService.listParquetFilesForConfig(listObjectsBucketCaptor.capture(), eq(configuredTables), eq(0L)))
+                .thenReturn(objectsToDelete);
+
+        when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture()))
+                .thenReturn(Collections.emptySet());
+
+        assertDoesNotThrow(() -> underTest.run());
+
+        assertThat(listObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+        assertThat(deleteObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+    }
+
+    @Test
+    public void shouldDeleteAllFilesWhenNoConfigurationIsGiven() {
+        List<String> objectsToDelete = new ArrayList<>();
+        objectsToDelete.add("schema_1/table_1/file_1.parquet");
+        objectsToDelete.add("schema_1/table_1/file_2.parquet");
+        objectsToDelete.add("schema_2/table_2/file_3.parquet");
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.of());
+
+        when(mockS3FileService.listParquetFiles(listObjectsBucketCaptor.capture(), eq(0L)))
+                .thenReturn(objectsToDelete);
+
+        when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture()))
+                .thenReturn(Collections.emptySet());
+
+        assertDoesNotThrow(() -> underTest.run());
+
+        assertThat(listObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+        assertThat(deleteObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+    }
+
+    @Test
+    public void shouldExitWithFailureStatusWhenThereIsFailureDeletingSomeFiles() throws Exception {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema_1", "table_1"),
+                ImmutablePair.of("schema_2", "table_2")
+        );
+
+        List<String> objectsToDelete = new ArrayList<>();
+        objectsToDelete.add("schema_1/table_1/file_1.parquet");
+        objectsToDelete.add("schema_1/table_1/file_2.parquet");
+        objectsToDelete.add("schema_2/table_2/file_3.parquet");
+
+        Set<String> failedFiles = new HashSet<>();
+        failedFiles.add("schema_2/table_2/file_3.parquet");
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+
+        when(mockS3FileService.listParquetFilesForConfig(listObjectsBucketCaptor.capture(), eq(configuredTables), eq(0L)))
+                .thenReturn(objectsToDelete);
+
+        when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture())).thenReturn(failedFiles);
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+
+        assertThat(listObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+        assertThat(deleteObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+    }
+
+    @Test
+    public void shouldExitWithFailureStatusWhenConfigServiceThrowsAnException() throws Exception {
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenThrow(new ConfigServiceException("config error"));
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+
+        verifyNoInteractions(mockS3FileService);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
@@ -1,0 +1,143 @@
+package uk.gov.justice.digital.job;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.ConfigServiceException;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.S3FileService;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class S3FileTransferJobTest extends BaseSparkTest {
+
+    private static final String TEST_CONFIG_KEY = "some-config-key";
+
+    @Mock
+    private ConfigService mockConfigService;
+    @Mock
+    private JobArguments mockJobArguments;
+    @Mock
+    private S3FileService mockS3FileService;
+
+    private final static String SOURCE_BUCKET = "source-bucket";
+    private final static String DESTINATION_BUCKET = "destination-bucket";
+
+    private static final long RETENTION_DAYS = 2L;
+
+    private S3FileTransferJob underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockConfigService, mockS3FileService, mockJobArguments);
+
+        underTest = new S3FileTransferJob(
+                mockConfigService,
+                mockS3FileService,
+                mockJobArguments
+        );
+    }
+
+    @Test
+    public void shouldMoveFilesBelongingToGivenConfiguration() {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema_1", "table_1"),
+                ImmutablePair.of("schema_2", "table_2")
+        );
+
+        List<String> objectsToMove = new ArrayList<>();
+        objectsToMove.add("schema_1/table_1/file_1.parquet");
+        objectsToMove.add("schema_1/table_1/file_2.parquet");
+        objectsToMove.add("schema_2/table_2/file_3.parquet");
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobArguments.getTransferSourceBucket()).thenReturn(SOURCE_BUCKET);
+        when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
+        when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
+
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+
+        when(mockS3FileService.listParquetFilesForConfig(SOURCE_BUCKET, configuredTables, RETENTION_DAYS))
+                .thenReturn(objectsToMove);
+
+        when(mockS3FileService.moveObjects(objectsToMove, SOURCE_BUCKET, DESTINATION_BUCKET))
+                .thenReturn(Collections.emptySet());
+
+        assertDoesNotThrow(() -> underTest.run());
+    }
+
+    @Test
+    public void shouldMoveAllFilesWhenNoConfigurationIsGiven() {
+        List<String> objectsToMove = new ArrayList<>();
+        objectsToMove.add("schema_1/table_1/file_1.parquet");
+        objectsToMove.add("schema_1/table_1/file_2.parquet");
+        objectsToMove.add("schema_2/table_2/file_3.parquet");
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobArguments.getTransferSourceBucket()).thenReturn(SOURCE_BUCKET);
+        when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
+        when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
+
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.of());
+
+        when(mockS3FileService.listParquetFiles(SOURCE_BUCKET, RETENTION_DAYS))
+                .thenReturn(objectsToMove);
+
+        when(mockS3FileService.moveObjects(objectsToMove, SOURCE_BUCKET, DESTINATION_BUCKET))
+                .thenReturn(Collections.emptySet());
+
+        assertDoesNotThrow(() -> underTest.run());
+    }
+
+    @Test
+    public void shouldExitWithFailureStatusWhenThereIsFailureMovingSomeFiles() throws Exception {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema_1", "table_1"),
+                ImmutablePair.of("schema_2", "table_2")
+        );
+
+        List<String> objectsToMove = new ArrayList<>();
+        objectsToMove.add("schema_1/table_1/file_1.parquet");
+        objectsToMove.add("schema_1/table_1/file_2.parquet");
+        objectsToMove.add("schema_2/table_2/file_3.parquet");
+
+        Set<String> failedFiles = new HashSet<>();
+        failedFiles.add("schema_2/table_2/file_3.parquet");
+
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobArguments.getTransferSourceBucket()).thenReturn(SOURCE_BUCKET);
+        when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
+        when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
+
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+
+        when(mockS3FileService.listParquetFilesForConfig(SOURCE_BUCKET, configuredTables, RETENTION_DAYS))
+                .thenReturn(objectsToMove);
+
+        when(mockS3FileService.moveObjects(objectsToMove, SOURCE_BUCKET, DESTINATION_BUCKET))
+                .thenReturn(failedFiles);
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+    }
+
+    @Test
+    public void shouldExitWithFailureStatusWhenConfigServiceThrowsAnException() throws Exception {
+        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenThrow(new ConfigServiceException("config error"));
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+
+        verifyNoInteractions(mockS3FileService);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/S3FileServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/S3FileServiceTest.java
@@ -1,0 +1,199 @@
+package uk.gov.justice.digital.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.s3.S3FileTransferClient;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static uk.gov.justice.digital.client.s3.S3FileTransferClient.DELIMITER;
+import static uk.gov.justice.digital.service.S3FileService.FILE_EXTENSION;
+import static uk.gov.justice.digital.test.Fixtures.fixedClock;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileServiceTest {
+
+    private static final String SOURCE_BUCKET = "source-bucket";
+    private static final String DESTINATION_BUCKET = "destination-bucket";
+    private static final long RETENTION_DAYS = 2L;
+
+    @Mock
+    private S3FileTransferClient mockS3Client;
+
+    private S3FileService undertest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockS3Client);
+
+        undertest = new S3FileService(mockS3Client, fixedClock);
+    }
+
+    @Test
+    public void listParquetFilesShouldReturnEmptyListWhenThereAreNoParquetFiles() {
+        when(mockS3Client.getObjectsOlderThan(any(), any(), any(), any())).thenReturn(Collections.emptyList());
+
+        List<String> result = undertest.listParquetFiles(SOURCE_BUCKET, RETENTION_DAYS);
+
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    public void listParquetFilesShouldReturnListOfParquetFiles() {
+        List<String> expected = new ArrayList<>();
+        expected.add("file1.parquet");
+        expected.add("file2.parquet");
+        expected.add("file3.parquet");
+        expected.add("file4.parquet");
+
+        when(mockS3Client.getObjectsOlderThan(SOURCE_BUCKET, FILE_EXTENSION, RETENTION_DAYS, fixedClock))
+                .thenReturn(expected);
+
+        List<String> result = undertest.listParquetFiles(SOURCE_BUCKET, RETENTION_DAYS);
+
+        assertThat(result, containsInAnyOrder(expected.toArray()));
+    }
+
+    @Test
+    public void listParquetFilesForConfigShouldReturnEmptyListWhenThereAreNoParquetFilesForConfiguredTables() {
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema_1", "table_1"),
+                ImmutablePair.of("schema_2", "table_2")
+        );
+
+        when(mockS3Client.getObjectsOlderThan(any(), any(), any(), any(), any())).thenReturn(Collections.emptyList());
+
+        List<String> result = undertest.listParquetFilesForConfig(SOURCE_BUCKET, configuredTables, RETENTION_DAYS);
+
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    public void listParquetFilesForConfigShouldReturnListOfParquetFilesRelatedToConfiguredTables() {
+        String configuredTable1 = "schema_1/table_1";
+        String configuredTable2 = "schema_2/table_2";
+
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema_1", "table_1"),
+                ImmutablePair.of("schema_2", "table_2")
+        );
+
+        List<String> expectedFilesForTable1 = new ArrayList<>();
+        expectedFilesForTable1.add("file1.parquet");
+        expectedFilesForTable1.add("file2.parquet");
+        expectedFilesForTable1.add("file3.parquet");
+
+        List<String> expectedFilesForTable2 = new ArrayList<>();
+        expectedFilesForTable2.add("file4.parquet");
+        expectedFilesForTable2.add("file5.parquet");
+
+        when(mockS3Client.getObjectsOlderThan(
+                SOURCE_BUCKET,
+                configuredTable1 + DELIMITER,
+                FILE_EXTENSION,
+                RETENTION_DAYS,
+                fixedClock)).thenReturn(expectedFilesForTable1);
+
+        when(mockS3Client.getObjectsOlderThan(
+                SOURCE_BUCKET,
+                configuredTable2 + DELIMITER,
+                FILE_EXTENSION,
+                RETENTION_DAYS,
+                fixedClock)).thenReturn(expectedFilesForTable2);
+
+        List<String> result = undertest.listParquetFilesForConfig(SOURCE_BUCKET, configuredTables, RETENTION_DAYS);
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.addAll(expectedFilesForTable1);
+        expectedResult.addAll(expectedFilesForTable2);
+
+        assertThat(result, containsInAnyOrder(expectedResult.toArray()));
+    }
+
+    @Test
+    public void moveObjectsShouldTransferGivenObjectsFromSourceToDestinationBuckets() {
+        List<String> objectKeys = new ArrayList<>();
+        objectKeys.add("file1.parquet");
+        objectKeys.add("file2.parquet");
+        objectKeys.add("file3.parquet");
+        objectKeys.add("file4.parquet");
+
+        Set<String> failedObjects = undertest.moveObjects(objectKeys, SOURCE_BUCKET, DESTINATION_BUCKET);
+
+        verify(mockS3Client, times(objectKeys.size())).moveObject(any(), eq(SOURCE_BUCKET), eq(DESTINATION_BUCKET));
+
+        assertThat(failedObjects, is(empty()));
+    }
+
+    @Test
+    public void moveObjectsShouldReturnListOfFailedObjects() {
+        List<String> objectKeys = new ArrayList<>();
+        objectKeys.add("file1.parquet");
+        objectKeys.add("file2.parquet");
+        objectKeys.add("file3.parquet");
+        objectKeys.add("file4.parquet");
+
+        Set<String> expectedFailedObjects = new HashSet<>();
+        expectedFailedObjects.add("file1.parquet");
+        expectedFailedObjects.add("file2.parquet");
+        expectedFailedObjects.add("file4.parquet");
+
+        doThrow(new AmazonServiceException("failure")).when(mockS3Client).moveObject(any(), any(), any());
+        doNothing().when(mockS3Client).moveObject(eq("file3.parquet"), any(), any());
+
+        Set<String> failedObjects = undertest.moveObjects(objectKeys, SOURCE_BUCKET, DESTINATION_BUCKET);
+
+        assertEquals(failedObjects, expectedFailedObjects);
+    }
+
+    @Test
+    public void deleteObjectsShouldDeleteGivenObjectsFromS3() {
+        List<String> objectKeys = new ArrayList<>();
+        objectKeys.add("file1.parquet");
+        objectKeys.add("file2.parquet");
+        objectKeys.add("file3.parquet");
+        objectKeys.add("file4.parquet");
+
+        Set<String> failedObjects = undertest.deleteObjects(objectKeys, SOURCE_BUCKET);
+
+        verify(mockS3Client, times(objectKeys.size())).deleteObject(any(), eq(SOURCE_BUCKET));
+
+        assertThat(failedObjects, is(empty()));
+    }
+
+    @Test
+    public void deleteObjectsShouldReturnListOfObjectsWhichFailedDeletion() {
+        List<String> objectKeys = new ArrayList<>();
+        objectKeys.add("file1.parquet");
+        objectKeys.add("file2.parquet");
+        objectKeys.add("file3.parquet");
+        objectKeys.add("file4.parquet");
+
+        doNothing().when(mockS3Client).deleteObject("file1.parquet", SOURCE_BUCKET);
+        doNothing().when(mockS3Client).deleteObject("file3.parquet", SOURCE_BUCKET);
+
+        doThrow(new AmazonServiceException("failure")).when(mockS3Client).deleteObject("file2.parquet", SOURCE_BUCKET);
+        doThrow(new AmazonServiceException("failure")).when(mockS3Client).deleteObject("file4.parquet", SOURCE_BUCKET);
+
+        Set<String> failedObjects = undertest.deleteObjects(objectKeys, SOURCE_BUCKET);
+
+        List<String> expectedFailedObjects = new ArrayList<>();
+        expectedFailedObjects.add("file2.parquet");
+        expectedFailedObjects.add("file4.parquet");
+        assertThat(failedObjects, containsInAnyOrder(expectedFailedObjects.toArray()));
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/test/Fixtures.java
+++ b/src/test/java/uk/gov/justice/digital/test/Fixtures.java
@@ -4,6 +4,11 @@ import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
 public class Fixtures {
     public static final String TABLE_NAME = "agency_internal_locations";
     public static final String PRIMARY_KEY_FIELD = "primary-key";
@@ -18,6 +23,12 @@ public class Fixtures {
             .add(NULL_FIELD_KEY, DataTypes.StringType, true)
             .add(NUMBER_FIELD_KEY, DataTypes.FloatType, false)
             .add(ARRAY_FIELD_KEY, new ArrayType(DataTypes.IntegerType, false), false);
+
+    public static final ZoneId utcZoneId = ZoneId.of("UTC");
+
+    public static final LocalDateTime fixedDateTime = LocalDateTime.now();
+
+    public static Clock fixedClock = Clock.fixed(fixedDateTime.toInstant(ZoneOffset.UTC), utcZoneId);
 
 
     // Private constructor to prevent instantiation.


### PR DESCRIPTION
This PR adds two jobs:

1. `S3FileTransferJob`: moves parquet files from a source bucket to a destination bucket

```
--dpr.config.key // key for the domain config
--dpr.config.s3.bucket // s3 bucket containing the domain config
--dpr.file.transfer.source.bucket // s3 bucket where files are to me moved from
--dpr.file.transfer.destination.bucket // s3 bucket where files are to me moved to
--dpr.file.transfer.retention.days // files older than the number of days will be moved. Moves all files when omitted
```
2. `S3DataDeletionJob`: deletes parquet files from a list of bucket(s)
```
--dpr.config.key // key for the domain config
--dpr.config.s3.bucket // s3 bucket containing the domain config
--dpr.file.deletion.buckets // comma separated list of buckets from which to delete files
```