### PR TITLE
DPR2-46: Add stop glue instance job

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -59,7 +59,9 @@ class JobArgumentsIntegrationTest {
             { JobArguments.MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH, "1" },
             { JobArguments.FILE_TRANSFER_SOURCE_BUCKET_NAME, "dpr-source-bucket" },
             { JobArguments.FILE_TRANSFER_DESTINATION_BUCKET_NAME, "dpr-destination-bucket" },
-            { JobArguments.FILE_TRANSFER_RETENTION_DAYS, "2" }
+            { JobArguments.FILE_TRANSFER_RETENTION_DAYS, "2" },
+            { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, "5" },
+            { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, "10" }
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -100,7 +102,9 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.MAINTENANCE_LIST_TABLE_RECURSE_MAX_DEPTH, Integer.toString(validArguments.getMaintenanceListTableRecurseMaxDepth()) },
                 { JobArguments.FILE_TRANSFER_SOURCE_BUCKET_NAME, validArguments.getTransferSourceBucket() },
                 { JobArguments.FILE_TRANSFER_DESTINATION_BUCKET_NAME, validArguments.getTransferDestinationBucket() },
-                { JobArguments.FILE_TRANSFER_RETENTION_DAYS, validArguments.getFileTransferRetentionDays() }
+                { JobArguments.FILE_TRANSFER_RETENTION_DAYS, validArguments.getFileTransferRetentionDays() },
+                { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, validArguments.glueOrchestrationWaitIntervalSeconds() },
+                { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, validArguments.glueOrchestrationMaxAttempts() }
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -257,6 +261,22 @@ class JobArgumentsIntegrationTest {
                 jobArguments.getBucketsToDeleteFilesFrom(),
                 containsInAnyOrder(ImmutableSet.of("dpr-delete-bucket-1", "dpr-delete-bucket-2").toArray())
         );
+    }
+
+    @Test
+    public void shouldDefaultGlueOrchestrationWaitIntervalSecondsWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(10, jobArguments.glueOrchestrationWaitIntervalSeconds());
+    }
+
+    @Test
+    public void shouldDefaultGlueOrchestrationMaxAttemptsWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(20, jobArguments.glueOrchestrationMaxAttempts());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
@@ -7,17 +7,21 @@ import jakarta.inject.Singleton;
 import lombok.val;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.exception.GlueClientException;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Singleton
-public class GlueHiveTableClient {
+public class GlueClient {
 
-    private static final Logger logger = LoggerFactory.getLogger(GlueHiveTableClient.class);
+    private static final Logger logger = LoggerFactory.getLogger(GlueClient.class);
 
     public static final String MAPRED_PARQUET_INPUT_FORMAT = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat";
     public static final String SYMLINK_INPUT_FORMAT = "org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat";
@@ -25,7 +29,7 @@ public class GlueHiveTableClient {
     private final AWSGlue glueClient;
 
     @Inject
-    public GlueHiveTableClient(GlueClientProvider glueClientProvider) {
+    public GlueClient(GlueClientProvider glueClientProvider) {
         this.glueClient = glueClientProvider.getClient();
     }
 
@@ -52,6 +56,26 @@ public class GlueHiveTableClient {
         } catch (EntityNotFoundException e) {
             logger.info("Did not delete non-existent table {}.{}", database, table);
         }
+    }
+
+    public void stopJob(String jobName, int waitIntervalSeconds, int maxAttempts) {
+        BatchStopJobRunRequest batchStopJobRunRequest = new BatchStopJobRunRequest().withJobName(jobName);
+        Optional<String> optionalRunningJobId = getRunningJobId(jobName);
+
+        optionalRunningJobId.ifPresent(
+                runId -> {
+                    batchStopJobRunRequest.withJobRunIds(runId);
+                    logger.info("Stopping job {} with runId {}", jobName, runId);
+                    glueClient.batchStopJobRun(batchStopJobRunRequest);
+
+                    try {
+                        ensureState(jobName, runId, "STOPPED", waitIntervalSeconds, maxAttempts);
+                    } catch (InterruptedException e) {
+                        logger.error("Error while ensuring job has stopped", e);
+                        throw new GlueClientException(e.getMessage());
+                    }
+                }
+        );
     }
 
     private void createTable(String database, String table, StorageDescriptor storageDescriptor) {
@@ -111,5 +135,33 @@ public class GlueHiveTableClient {
             columns.add(column);
         }
         return columns;
+    }
+
+    @NotNull
+    private Optional<String> getRunningJobId(String jobName) {
+        logger.info("Retrieving the Id of the running instance of job {}", jobName);
+        GetJobRunsRequest getJobRunsRequest = new GetJobRunsRequest().withJobName(jobName).withMaxResults(1000);
+        List<JobRun> jobRuns = glueClient.getJobRuns(getJobRunsRequest).getJobRuns();
+        return jobRuns.stream()
+                .filter(jobRun -> jobRun.getJobRunState().equalsIgnoreCase("RUNNING"))
+                .map(JobRun::getId)
+                .findFirst();
+    }
+
+    private void ensureState(String jobName, String runId, String state, int waitIntervalSeconds, int maxAttempts) throws InterruptedException {
+        GetJobRunRequest getJobRunRequest;
+        String jobRunState;
+
+        for (int attempts = 0; attempts < maxAttempts; attempts++) {
+            logger.info("Ensuring job {} with runId {} is in {} state. Attempt {}", jobName, runId, state, attempts);
+            getJobRunRequest = new GetJobRunRequest().withJobName(jobName).withRunId(runId);
+            jobRunState = glueClient.getJobRun(getJobRunRequest).getJobRun().getJobRunState();
+            TimeUnit.SECONDS.sleep(waitIntervalSeconds);
+
+            if (jobRunState.equalsIgnoreCase(state)) return;
+        }
+
+        String errorMessage = String.format("Exhausted attempts waiting for job %s with runId %s to be %s", jobName, runId, state);
+        throw new GlueClientException(errorMessage);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -97,6 +97,11 @@ public class JobArguments {
     static final Long DEFAULT_FILE_TRANSFER_RETENTION_DAYS = 0L;
     // A comma separated list of buckets to delete files from
     static final String FILE_DELETION_BUCKETS = "dpr.file.deletion.buckets";
+    static final String GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.glue.orchestration.wait.interval.seconds";
+    static final int DEFAULT_GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 10;
+    static final String GLUE_ORCHESTRATION_MAX_ATTEMPTS = "dpr.glue.orchestration.max.attempts";
+    static final int DEFAULT_GLUE_ORCHESTRATION_MAX_ATTEMPTS = 20;
+    static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";
 
     private final Map<String, String> config;
 
@@ -315,6 +320,18 @@ public class JobArguments {
                 .filter(item -> !item.isEmpty())
                 .collect(Collectors.toSet());
         return ImmutableSet.copyOf(buckets);
+    }
+
+    public String getStopGlueInstanceJobName() {
+        return getArgument(STOP_GLUE_INSTANCE_JOB_NAME);
+    }
+
+    public int glueOrchestrationWaitIntervalSeconds() {
+        return getArgument(GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, DEFAULT_GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS);
+    }
+
+    public int glueOrchestrationMaxAttempts() {
+        return getArgument(GLUE_ORCHESTRATION_MAX_ATTEMPTS, DEFAULT_GLUE_ORCHESTRATION_MAX_ATTEMPTS);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/exception/GlueClientException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/GlueClientException.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.exception;
+
+public class GlueClientException extends RuntimeException {
+
+    private static final long serialVersionUID = -7832951603298104749L;
+
+    public GlueClientException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public GlueClientException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/job/StopGlueInstanceJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/StopGlueInstanceJob.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.job;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.job.context.MicronautContext;
+import uk.gov.justice.digital.service.GlueOrchestrationService;
+
+import javax.inject.Inject;
+
+/**
+ * Job stops a running instance of a Glue job.
+ */
+@CommandLine.Command(name = "StopGlueInstanceJob")
+public class StopGlueInstanceJob implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(StopGlueInstanceJob.class);
+    private final GlueOrchestrationService glueOrchestrationService;
+    private final JobArguments jobArguments;
+
+    @Inject
+    public StopGlueInstanceJob(
+            GlueOrchestrationService glueOrchestrationService,
+            JobArguments jobArguments
+    ) {
+        this.glueOrchestrationService = glueOrchestrationService;
+        this.jobArguments = jobArguments;
+    }
+
+    public static void main(String[] args) {
+        logger.info("Job starting");
+        PicocliRunner.run(StopGlueInstanceJob.class, MicronautContext.withArgs(args));
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("StopGlueInstanceJob running");
+
+            glueOrchestrationService.stopJob(jobArguments.getStopGlueInstanceJobName());
+
+            logger.info("StopGlueInstanceJob finished");
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/GlueOrchestrationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/GlueOrchestrationService.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.client.glue.GlueClient;
+import uk.gov.justice.digital.config.JobArguments;
+
+public class GlueOrchestrationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlueOrchestrationService.class);
+
+    private final JobArguments jobArguments;
+
+    private final GlueClient glueClient;
+
+    public GlueOrchestrationService(JobArguments jobArguments, GlueClient glueClient) {
+        this.jobArguments = jobArguments;
+        this.glueClient = glueClient;
+    }
+
+    public void stopJob(String jobName) {
+        int waitIntervalSeconds = jobArguments.glueOrchestrationWaitIntervalSeconds();
+        int maxAttempts = jobArguments.glueOrchestrationMaxAttempts();
+
+        logger.info("Stopping Glue job {}", jobName);
+        glueClient.stopJob(jobName, waitIntervalSeconds, maxAttempts);
+        logger.info("Stopped Glue job {}", jobName);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/HiveSchemaService.java
+++ b/src/main/java/uk/gov/justice/digital/service/HiveSchemaService.java
@@ -6,7 +6,7 @@ import org.apache.spark.sql.types.StructType;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.client.glue.GlueHiveTableClient;
+import uk.gov.justice.digital.client.glue.GlueClient;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.HiveSchemaServiceException;
@@ -31,17 +31,17 @@ public class HiveSchemaService {
 
     private final JobArguments jobArguments;
     private final SourceReferenceService sourceReferenceService;
-    private final GlueHiveTableClient glueHiveTableClient;
+    private final GlueClient glueClient;
 
     @Inject
     public HiveSchemaService(
             JobArguments jobArguments,
             SourceReferenceService sourceReferenceService,
-            GlueHiveTableClient glueHiveTableClient
+            GlueClient glueClient
     ) {
         this.jobArguments = jobArguments;
         this.sourceReferenceService = sourceReferenceService;
-        this.glueHiveTableClient = glueHiveTableClient;
+        this.glueClient = glueClient;
     }
 
     public Set<ImmutablePair<String, String>> replaceTables(ImmutableSet<ImmutablePair<String, String>> tables) {
@@ -122,13 +122,13 @@ public class HiveSchemaService {
     }
 
     private void replaceParquetInputTables(String databaseName, String tableName, String dataPath, StructType schema) {
-        glueHiveTableClient.deleteTable(databaseName, tableName);
-        glueHiveTableClient.createParquetTable(databaseName, tableName, dataPath, schema);
+        glueClient.deleteTable(databaseName, tableName);
+        glueClient.createParquetTable(databaseName, tableName, dataPath, schema);
     }
 
     private void replaceSymlinkInputTables(String databaseName, String tableName, String curatedPath, StructType schema) {
-        glueHiveTableClient.deleteTable(databaseName, tableName);
-        glueHiveTableClient.createTableWithSymlink(databaseName, tableName, curatedPath, schema);
+        glueClient.deleteTable(databaseName, tableName);
+        glueClient.createTableWithSymlink(databaseName, tableName, curatedPath, schema);
     }
 
     private void validateTableName(String tableName) throws HiveSchemaServiceException {

--- a/src/test/java/uk/gov/justice/digital/job/StopGlueInstanceJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/StopGlueInstanceJobTest.java
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.job;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.GlueClientException;
+import uk.gov.justice.digital.service.GlueOrchestrationService;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class StopGlueInstanceJobTest extends BaseSparkTest {
+
+    @Mock
+    GlueOrchestrationService mockGlueOrchestrationService;
+    @Mock
+    JobArguments mockJobArguments;
+
+    private static final String TEST_JOB_NAME = "test_glue_job";
+
+    private StopGlueInstanceJob underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockGlueOrchestrationService, mockJobArguments);
+
+        underTest = new StopGlueInstanceJob(mockGlueOrchestrationService, mockJobArguments);
+    }
+
+    @Test
+    public void shouldStopGlueJobWithGivenName() {
+        when(mockJobArguments.getStopGlueInstanceJobName()).thenReturn(TEST_JOB_NAME);
+
+        underTest.run();
+
+        verify(mockGlueOrchestrationService, times(1)).stopJob(TEST_JOB_NAME);
+    }
+
+    @Test
+    public void shouldFailWhenAnExceptionOccursInService() throws Exception {
+        when(mockJobArguments.getStopGlueInstanceJobName()).thenReturn(TEST_JOB_NAME);
+        doThrow(new GlueClientException("error")).when(mockGlueOrchestrationService).stopJob(any());
+
+        SystemLambda.catchSystemExit(() -> underTest.run());
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/GlueOrchestrationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/GlueOrchestrationServiceTest.java
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.glue.GlueClient;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.GlueClientException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GlueOrchestrationServiceTest {
+
+    @Mock
+    private JobArguments mockJobArguments;
+    @Mock
+    private GlueClient mockGlueClient;
+
+    private static final String TEST_JOB_NAME = "test_glue_job";
+    private static final int WAIT_INTERVAL_SECONDS = 2;
+    private static final int MAX_ATTEMPTS = 10;
+
+    private GlueOrchestrationService underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockJobArguments, mockGlueClient);
+
+        underTest = new GlueOrchestrationService(mockJobArguments, mockGlueClient);
+    }
+
+    @Test
+    public void stopJobShouldStopGlueJobWithGivenName() {
+        when(mockJobArguments.glueOrchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
+        when(mockJobArguments.glueOrchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+
+        underTest.stopJob(TEST_JOB_NAME);
+
+        verify(mockGlueClient, times(1)).stopJob(TEST_JOB_NAME, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+    }
+
+    @Test
+    public void stopJobShouldFailWhenGlueClientThrowsAnException() {
+        when(mockJobArguments.glueOrchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
+        when(mockJobArguments.glueOrchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+
+        doThrow(new GlueClientException("Client error")).when(mockGlueClient)
+                .stopJob(TEST_JOB_NAME, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+
+        assertThrows(GlueClientException.class, () -> underTest.stopJob(TEST_JOB_NAME));
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/HiveSchemaServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/HiveSchemaServiceTest.java
@@ -11,7 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.justice.digital.client.glue.GlueHiveTableClient;
+import uk.gov.justice.digital.client.glue.GlueClient;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.HiveSchemaServiceException;
@@ -39,7 +39,7 @@ public class HiveSchemaServiceTest {
     @Mock
     private SourceReferenceService mockSourceReferenceService;
     @Mock
-    private GlueHiveTableClient mockGlueHiveTableClient;
+    private GlueClient mockGlueClient;
 
     @Captor
     ArgumentCaptor<String> deleteDatabaseArgCaptor, createArchiveDatabaseArgCaptor, createSymlinkDatabaseArgCaptor;
@@ -66,7 +66,7 @@ public class HiveSchemaServiceTest {
 
     @BeforeEach
     public void setup() {
-        underTest = new HiveSchemaService(mockJobArguments, mockSourceReferenceService, mockGlueHiveTableClient);
+        underTest = new HiveSchemaService(mockJobArguments, mockSourceReferenceService, mockGlueClient);
     }
 
     @Test
@@ -145,14 +145,14 @@ public class HiveSchemaServiceTest {
         assertThat((Collection<ImmutablePair<String, String>>) underTest.replaceTables(schemaGroup), is(empty()));
 
         // verify all Hive tables get deleted
-        verify(mockGlueHiveTableClient, times(8))
+        verify(mockGlueClient, times(8))
                 .deleteTable(deleteDatabaseArgCaptor.capture(), deleteTableArgCaptor.capture());
 
         assertThat(deleteDatabaseArgCaptor.getAllValues(), containsTheSameElementsInOrderAs(expectedDeleteDatabaseArgs));
         assertThat(deleteTableArgCaptor.getAllValues(), containsTheSameElementsInOrderAs(expectedDeleteTableArgs));
 
         // verify raw_archive tables are created as parquet format
-        verify(mockGlueHiveTableClient, times(2))
+        verify(mockGlueClient, times(2))
                 .createParquetTable(
                         createArchiveDatabaseArgCaptor.capture(),
                         createArchiveTableArgCaptor.capture(),
@@ -170,7 +170,7 @@ public class HiveSchemaServiceTest {
         );
 
         // verify structured, curated and prisons tables are created with symlink format
-        verify(mockGlueHiveTableClient, times(6))
+        verify(mockGlueClient, times(6))
                 .createTableWithSymlink(
                         createSymlinkDatabaseArgCaptor.capture(),
                         createSymlinkTableArgCaptor.capture(),
@@ -241,14 +241,14 @@ public class HiveSchemaServiceTest {
         assertThat((Collection<ImmutablePair<String, String>>) underTest.switchPrisonsTableDataSource(schemaGroup), is(empty()));
 
         // verify configured Hive tables get deleted
-        verify(mockGlueHiveTableClient, times(2))
+        verify(mockGlueClient, times(2))
                 .deleteTable(deleteDatabaseArgCaptor.capture(), deleteTableArgCaptor.capture());
 
         assertThat(deleteDatabaseArgCaptor.getAllValues(), containsTheSameElementsInOrderAs(expectedDeleteDatabaseArgs));
         assertThat(deleteTableArgCaptor.getAllValues(), containsTheSameElementsInOrderAs(expectedDeleteTableArgs));
 
         // verify prisons tables are created with symlink format
-        verify(mockGlueHiveTableClient, times(2))
+        verify(mockGlueClient, times(2))
                 .createTableWithSymlink(
                         createSymlinkDatabaseArgCaptor.capture(),
                         createSymlinkTableArgCaptor.capture(),


### PR DESCRIPTION
This PR migrates the StopGlueJobLambda to a glue job StopGlueInstanceJob.
This prevents lambda timeout errors and also provide automatic sync thereby eliminating the need to make a callback to the step functions.

The job takes the below args:
```
--dpr.stop.glue.instance.job.name // the name of the Glue job to stop
--dpr.glue.orchestration.wait.interval.seconds // wait interval between checks that the glue job has stopped. Defaults to 10 seconds
--dpr.glue.orchestration.max.attempts // max attempts to check the job state. Defaults to 20
```