### PR TITLE
DPR2-46: Add copy only mode for file transfer job

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -10,10 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.AbstractMap;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,7 +28,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.CONFIG_KEY, "test-config" },
             { JobArguments.AWS_REGION, "test-region" },
             { JobArguments.CURATED_S3_PATH, "s3://somepath/curated" },
-            { JobArguments.TARGET_S3_PATH, "s3://somepath/target" },
+            { JobArguments.PRISONS_DATA_SWITCH_TARGET_S3_PATH, "s3://somepath/target" },
             { JobArguments.DOMAIN_CATALOG_DATABASE_NAME, "SomeDomainCatalogName" },
             { JobArguments.DOMAIN_NAME, "test_domain_name" },
             { JobArguments.DOMAIN_OPERATION, "insert" },
@@ -75,7 +72,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.AWS_DYNAMODB_ENDPOINT_URL, validArguments.getAwsDynamoDBEndpointUrl() },
                 { JobArguments.AWS_REGION, validArguments.getAwsRegion() },
                 { JobArguments.CURATED_S3_PATH, validArguments.getCuratedS3Path() },
-                { JobArguments.TARGET_S3_PATH, validArguments.getTargetS3Path() },
+                { JobArguments.PRISONS_DATA_SWITCH_TARGET_S3_PATH, validArguments.getPrisonsDataSwitchTargetS3Path() },
                 { JobArguments.DOMAIN_CATALOG_DATABASE_NAME, validArguments.getDomainCatalogDatabaseName() },
                 { JobArguments.DOMAIN_NAME, validArguments.getDomainName() },
                 { JobArguments.DOMAIN_OPERATION, validArguments.getDomainOperation() },
@@ -277,6 +274,21 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(20, jobArguments.glueOrchestrationMaxAttempts());
+    }
+
+    @Test
+    public void getOptionalConfigKeyShouldDefaultToEmptyOptionWhenNoConfigKeyIsProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.CONFIG_KEY);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(Optional.empty(), jobArguments.getOptionalConfigKey());
+    }
+
+    @Test
+    public void getOptionalConfigKeyShouldReturnOptionalWithConfigKeyPresentWhenConfigKeyIsProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(Optional.of("test-config"), jobArguments.getOptionalConfigKey());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3FileTransferClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3FileTransferClient.java
@@ -60,9 +60,8 @@ public class S3FileTransferClient {
         return objectPaths;
     }
 
-    public void moveObject(String objectKey, String sourceBucket, String destinationBucket) {
+    public void copyObject(String objectKey, String sourceBucket, String destinationBucket) {
         s3.copyObject(sourceBucket, objectKey, destinationBucket, objectKey);
-        s3.deleteObject(sourceBucket, objectKey);
     }
 
     public void deleteObject(String objectKey, String sourceBucket) {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -33,7 +33,7 @@ public class JobArguments {
     public static final String SCHEMA_CACHE_MAX_SIZE = "dpr.schema.cache.max.size";
     public static final String SCHEMA_CACHE_EXPIRY_IN_MINUTES = "dpr.schema.cache.expiry.days";
     public static final String CURATED_S3_PATH = "dpr.curated.s3.path";
-    public static final String TARGET_S3_PATH = "dpr.target.s3.path";
+    public static final String PRISONS_DATA_SWITCH_TARGET_S3_PATH = "dpr.prisons.data.switch.target.s3.path";
     public static final String DOMAIN_CATALOG_DATABASE_NAME = "dpr.domain.catalog.db";
     public static final String DOMAIN_NAME = "dpr.domain.name";
     public static final String DOMAIN_OPERATION = "dpr.domain.operation";
@@ -95,6 +95,9 @@ public class JobArguments {
     public static final String FILE_TRANSFER_DESTINATION_BUCKET_NAME = "dpr.file.transfer.destination.bucket";
     public static final String FILE_TRANSFER_RETENTION_DAYS = "dpr.file.transfer.retention.days";
     static final Long DEFAULT_FILE_TRANSFER_RETENTION_DAYS = 0L;
+
+    public static final String FILE_TRANSFER_DELETE_COPIED_FILES_FLAG = "dpr.file.transfer.delete.copied.files";
+
     // A comma separated list of buckets to delete files from
     static final String FILE_DELETION_BUCKETS = "dpr.file.deletion.buckets";
     static final String GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.glue.orchestration.wait.interval.seconds";
@@ -214,8 +217,8 @@ public class JobArguments {
         return getArgument(CURATED_S3_PATH);
     }
 
-    public String getTargetS3Path() {
-        return getArgument(TARGET_S3_PATH);
+    public String getPrisonsDataSwitchTargetS3Path() {
+        return getArgument(PRISONS_DATA_SWITCH_TARGET_S3_PATH);
     }
 
     public String getDomainTargetPath() {
@@ -260,6 +263,10 @@ public class JobArguments {
 
     public String getConfigKey() {
         return getArgument(CONFIG_KEY);
+    }
+
+    public Optional<String> getOptionalConfigKey() {
+        return Optional.ofNullable(config.get(CONFIG_KEY));
     }
 
     public String getMaintenanceTablesRootPath() {
@@ -312,6 +319,10 @@ public class JobArguments {
 
     public Long getFileTransferRetentionDays() {
         return getArgument(FILE_TRANSFER_RETENTION_DAYS, DEFAULT_FILE_TRANSFER_RETENTION_DAYS);
+    }
+
+    public boolean getFileTransferDeleteCopiedFilesFlag() {
+        return getArgument(FILE_TRANSFER_DELETE_COPIED_FILES_FLAG, false);
     }
 
     public ImmutableSet<String> getBucketsToDeleteFilesFrom() {

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -55,7 +55,7 @@ public class S3DataDeletionJob implements Runnable {
         }
     }
 
-    public void deleteFiles() {
+    private void deleteFiles() {
         ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                 .getConfiguredTables(jobArguments.getConfigKey());
 
@@ -64,15 +64,7 @@ public class S3DataDeletionJob implements Runnable {
         Set<String> failedObjects = new HashSet<>();
 
         for (String bucketToDeleteFilesFrom : bucketsToDeleteFilesFrom) {
-            List<String> objectKeys = new ArrayList<>();
-            if (configuredTables.isEmpty()) {
-                // When no config is provided, all files in s3 bucket are deleted
-                logger.info("Listing files in S3 source location: {}", bucketToDeleteFilesFrom);
-                objectKeys.addAll(s3FileService.listParquetFiles(bucketToDeleteFilesFrom, 0L));
-            } else {
-                // When config is provided, only files belonging to the configured tables are deleted
-                objectKeys.addAll(s3FileService.listParquetFilesForConfig(bucketToDeleteFilesFrom, configuredTables, 0L));
-            }
+            List<String> objectKeys = new ArrayList<>(s3FileService.listParquetFilesForConfig(bucketToDeleteFilesFrom, configuredTables, 0L));
 
             logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
             failedObjects = s3FileService.deleteObjects(objectKeys, bucketToDeleteFilesFrom);

--- a/src/main/java/uk/gov/justice/digital/service/HiveSchemaService.java
+++ b/src/main/java/uk/gov/justice/digital/service/HiveSchemaService.java
@@ -91,7 +91,7 @@ public class HiveSchemaService {
             String tableName = sourceReference.getTable();
 
             String hiveTableName = sourceName + "_" + tableName;
-            String targetS3Path = jobArguments.getTargetS3Path();
+            String targetS3Path = jobArguments.getPrisonsDataSwitchTargetS3Path();
 
             logger.info("Processing {}", hiveTableName);
             try {

--- a/src/main/java/uk/gov/justice/digital/service/S3FileService.java
+++ b/src/main/java/uk/gov/justice/digital/service/S3FileService.java
@@ -47,16 +47,18 @@ public class S3FileService {
                 .collect(Collectors.toList());
     }
 
-    public Set<String> moveObjects(
+    public Set<String> copyObjects(
             List<String> objectKeys,
             String sourceBucket,
-            String destinationBucket
+            String destinationBucket,
+            boolean deleteCopiedFiles
     ) {
         Set<String> failedObjects = new HashSet<>();
 
         for (String objectKey : objectKeys) {
             try {
-                s3Client.moveObject(objectKey, sourceBucket, destinationBucket);
+                s3Client.copyObject(objectKey, sourceBucket, destinationBucket);
+                if (deleteCopiedFiles) s3Client.deleteObject(objectKey, sourceBucket);
             } catch (AmazonServiceException e) {
                 logger.warn("Failed to move S3 object {}: {}", objectKey, e.getErrorMessage());
                 failedObjects.add(objectKey);

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -84,26 +84,10 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
     }
 
     @Test
-    public void shouldDeleteAllFilesWhenNoConfigurationIsGiven() {
-        List<String> objectsToDelete = new ArrayList<>();
-        objectsToDelete.add("schema_1/table_1/file_1.parquet");
-        objectsToDelete.add("schema_1/table_1/file_2.parquet");
-        objectsToDelete.add("schema_2/table_2/file_3.parquet");
+    public void shouldFailWhenNoConfigurationIsGiven() throws Exception {
+        when(mockJobArguments.getConfigKey()).thenThrow(new IllegalStateException("error"));
 
-        when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
-        when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
-        when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.of());
-
-        when(mockS3FileService.listParquetFiles(listObjectsBucketCaptor.capture(), eq(0L)))
-                .thenReturn(objectsToDelete);
-
-        when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture()))
-                .thenReturn(Collections.emptySet());
-
-        assertDoesNotThrow(() -> underTest.run());
-
-        assertThat(listObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
-        assertThat(deleteObjectsBucketCaptor.getAllValues(), containsInAnyOrder(bucketsToDeleteFrom.toArray()));
+        SystemLambda.catchSystemExit(() -> underTest.run());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/HiveSchemaServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/HiveSchemaServiceTest.java
@@ -234,7 +234,7 @@ public class HiveSchemaServiceTest {
         expectedCreateSymlinkPathArgs.add(createPath(TEMP_RELOAD_BUCKET, 0));
         expectedCreateSymlinkPathArgs.add(createPath(TEMP_RELOAD_BUCKET, 1));
 
-        when(mockJobArguments.getTargetS3Path()).thenReturn(TEMP_RELOAD_BUCKET);
+        when(mockJobArguments.getPrisonsDataSwitchTargetS3Path()).thenReturn(TEMP_RELOAD_BUCKET);
         when(mockJobArguments.getPrisonsDatabase()).thenReturn(PRISONS_DATABASE);
         when(mockSourceReferenceService.getAllSourceReferences(any())).thenReturn(sourceReferences);
 


### PR DESCRIPTION
This PR:
- Adds a flag on whether the S3 file transfer job should also delete copied objects
- Makes the config key optional for the S3 file transfer job. When not provides all files are transferred. This is used in the case of the scheduled job which archives all files older than 2 days