### PR TITLE
DPR2-46: Make s3 file copy accept a list of extensions

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -261,6 +261,38 @@ class JobArgumentsIntegrationTest {
     }
 
     @Test
+    public void shouldThrowAnExceptionWhenSetOfBucketsToDeleteFilesFromIsEmpty() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.FILE_DELETION_BUCKETS, "");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertThrows(IllegalStateException.class, jobArguments::getBucketsToDeleteFilesFrom);
+    }
+
+    @Test
+    public void shouldReturnLowerCasedSetOfAllowedS3FileExtensionsWithoutDuplicates() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.ALLOWED_S3_FILE_EXTENSIONS, ".parquet,.jpg,.txt,.JPG");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(ImmutableSet.of(".parquet", ".jpg", ".txt"), jobArguments.getAllowedS3FileExtensions());
+    }
+
+    @Test
+    public void shouldThrowAnExceptionWhenSetOfAllowedS3FileExtensionsIsEmpty() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.ALLOWED_S3_FILE_EXTENSIONS, "");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertThrows(IllegalStateException.class, jobArguments::getAllowedS3FileExtensions);
+    }
+
+    @Test
+    public void shouldReturnWildcardWhenTheAllowedS3FileExtensionsContainsOne() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.ALLOWED_S3_FILE_EXTENSIONS, ".parquet,*,.txt");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(ImmutableSet.of("*"), jobArguments.getAllowedS3FileExtensions());
+    }
+
+    @Test
     public void shouldDefaultGlueOrchestrationWaitIntervalSecondsWhenMissing() {
         HashMap<String, String> args = cloneTestArguments();
         args.remove(JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS);

--- a/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
@@ -140,7 +140,7 @@ public class GlueClient {
     @NotNull
     private Optional<String> getRunningJobId(String jobName) {
         logger.info("Retrieving the Id of the running instance of job {}", jobName);
-        GetJobRunsRequest getJobRunsRequest = new GetJobRunsRequest().withJobName(jobName).withMaxResults(1000);
+        GetJobRunsRequest getJobRunsRequest = new GetJobRunsRequest().withJobName(jobName).withMaxResults(200);
         List<JobRun> jobRuns = awsGlue.getJobRuns(getJobRunsRequest).getJobRuns();
         return jobRuns.stream()
                 .filter(jobRun -> jobRun.getJobRunState().equalsIgnoreCase("RUNNING"))

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -332,7 +332,7 @@ public class JobArguments {
                 .map(String::trim)
                 .filter(item -> !item.isEmpty())
                 .collect(Collectors.toSet());
-        if (buckets.isEmpty()) throw new IllegalStateException("Argument " + ALLOWED_S3_FILE_EXTENSIONS + " evaluated to empty set");
+        if (buckets.isEmpty()) throw new IllegalStateException("Argument " + FILE_DELETION_BUCKETS + " evaluated to empty set");
         return ImmutableSet.copyOf(buckets);
     }
 

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -100,6 +100,8 @@ public class JobArguments {
 
     // A comma separated list of buckets to delete files from
     static final String FILE_DELETION_BUCKETS = "dpr.file.deletion.buckets";
+    // A comma separated list of s3 file extensions. The wildcard '*' includes all extensions.
+    static final String ALLOWED_S3_FILE_EXTENSIONS = "dpr.allowed.s3.file.extensions";
     static final String GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.glue.orchestration.wait.interval.seconds";
     static final int DEFAULT_GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 10;
     static final String GLUE_ORCHESTRATION_MAX_ATTEMPTS = "dpr.glue.orchestration.max.attempts";
@@ -330,7 +332,23 @@ public class JobArguments {
                 .map(String::trim)
                 .filter(item -> !item.isEmpty())
                 .collect(Collectors.toSet());
+        if (buckets.isEmpty()) throw new IllegalStateException("Argument " + ALLOWED_S3_FILE_EXTENSIONS + " evaluated to empty set");
         return ImmutableSet.copyOf(buckets);
+    }
+
+    public ImmutableSet<String> getAllowedS3FileExtensions() {
+        Set<String> extensions = Arrays.stream(getArgument(ALLOWED_S3_FILE_EXTENSIONS).toLowerCase().split(","))
+                .map(item -> item.trim().toLowerCase())
+                .filter(item -> !item.isEmpty())
+                .collect(Collectors.toSet());
+
+        if (extensions.isEmpty()) throw new IllegalStateException("Argument " + ALLOWED_S3_FILE_EXTENSIONS + " evaluated to empty set");
+
+        if (extensions.contains("*")) {
+            return ImmutableSet.of("*");
+        } else {
+            return ImmutableSet.copyOf(extensions);
+        }
     }
 
     public String getStopGlueInstanceJobName() {

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -69,10 +69,8 @@ public class S3DataDeletionJob implements Runnable {
             List<String> listedFiles = s3FileService
                     .listFilesForConfig(bucketToDeleteFilesFrom, configuredTables, allowedExtensions, 0L);
 
-            List<String> objectKeys = new ArrayList<>(listedFiles);
-
             logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
-            failedObjects = s3FileService.deleteObjects(objectKeys, bucketToDeleteFilesFrom);
+            failedObjects = s3FileService.deleteObjects(listedFiles, bucketToDeleteFilesFrom);
         }
 
         if (failedObjects.isEmpty()) {

--- a/src/main/java/uk/gov/justice/digital/service/ConfigService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ConfigService.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import uk.gov.justice.digital.client.s3.S3ConfigReaderClient;
 import uk.gov.justice.digital.exception.ConfigServiceException;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
@@ -12,6 +13,7 @@ public class ConfigService {
 
     private final S3ConfigReaderClient configClient;
 
+    @Inject
     public ConfigService(S3ConfigReaderClient configClient) {
         this.configClient = configClient;
     }

--- a/src/main/java/uk/gov/justice/digital/service/GlueOrchestrationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/GlueOrchestrationService.java
@@ -5,6 +5,10 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.client.glue.GlueClient;
 import uk.gov.justice.digital.config.JobArguments;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
 public class GlueOrchestrationService {
 
     private static final Logger logger = LoggerFactory.getLogger(GlueOrchestrationService.class);
@@ -13,6 +17,7 @@ public class GlueOrchestrationService {
 
     private final GlueClient glueClient;
 
+    @Inject
     public GlueOrchestrationService(JobArguments jobArguments, GlueClient glueClient) {
         this.jobArguments = jobArguments;
         this.glueClient = glueClient;

--- a/src/test/java/uk/gov/justice/digital/client/glue/GlueClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/glue/GlueClientTest.java
@@ -167,7 +167,7 @@ class GlueClientTest {
 
         GetJobRunsRequest getJobRunsRequestCaptorValue = getJobRunsRequestCaptor.getValue();
         assertThat(getJobRunsRequestCaptorValue.getJobName(), is(equalTo(TEST_JOB_NAME)));
-        assertThat(getJobRunsRequestCaptorValue.getMaxResults(), is(equalTo(1000)));
+        assertThat(getJobRunsRequestCaptorValue.getMaxResults(), is(equalTo(200)));
         assertThat(stopJobRunRequestCaptor.getValue().getJobName(), is(equalTo(TEST_JOB_NAME)));
         assertThat(getJobRunRequestCaptor.getValue().getJobName(), is(equalTo(TEST_JOB_NAME)));
     }
@@ -183,7 +183,7 @@ class GlueClientTest {
 
         GetJobRunsRequest getJobRunsRequestCaptorValue = getJobRunsRequestCaptor.getValue();
         assertThat(getJobRunsRequestCaptorValue.getJobName(), is(equalTo(TEST_JOB_NAME)));
-        assertThat(getJobRunsRequestCaptorValue.getMaxResults(), is(equalTo(1000)));
+        assertThat(getJobRunsRequestCaptorValue.getMaxResults(), is(equalTo(200)));
         verifyNoInteractions(mockGetJobRunResult);
     }
 

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3FileTransferClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3FileTransferClientTest.java
@@ -1,0 +1,217 @@
+package uk.gov.justice.digital.client.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static uk.gov.justice.digital.test.Fixtures.fixedClock;
+import static uk.gov.justice.digital.test.Fixtures.fixedDateTime;
+
+@ExtendWith(MockitoExtension.class)
+public class S3FileTransferClientTest {
+
+    @Mock
+    S3ClientProvider mockS3ClientProvider;
+    @Mock
+    AmazonS3 mockS3Client;
+    @Mock
+    ObjectListing mockObjectListing;
+    @Captor
+    ArgumentCaptor<ListObjectsRequest> listObjectsRequestCaptor;
+
+    private static final String OBJECT_KEY = "test-object-key";
+    private static final String SOURCE_BUCKET = "test-source-bucket";
+    private static final String DESTINATION_BUCKET = "test-destination-bucket";
+    private static final ImmutableSet<String> allowedExtensions = ImmutableSet.of(".parquet", ".json");
+
+    private S3FileTransferClient underTest;
+    @BeforeEach
+    public void setUp() {
+        when(mockS3ClientProvider.getClient()).thenReturn(mockS3Client);
+        underTest = new S3FileTransferClient(mockS3ClientProvider);
+    }
+
+    @Test
+    public void copyObjectShouldDeleteObjects() {
+        underTest.copyObject(OBJECT_KEY, SOURCE_BUCKET, DESTINATION_BUCKET);
+
+        verify(mockS3Client, times(1)).copyObject(SOURCE_BUCKET, OBJECT_KEY, DESTINATION_BUCKET, OBJECT_KEY);
+    }
+
+    @Test
+    public void copyObjectShouldFailWhenClientThrowsAnException() {
+        doThrow(new RuntimeException("client exception")).when(mockS3Client).copyObject(any(), any(), any(), any());
+
+        assertThrows(RuntimeException.class, () -> underTest.copyObject(OBJECT_KEY, SOURCE_BUCKET, DESTINATION_BUCKET));
+    }
+
+    @Test
+    public void deleteObjectShouldDeleteObjects() {
+        underTest.deleteObject(OBJECT_KEY, SOURCE_BUCKET);
+
+        verify(mockS3Client, times(1)).deleteObject(SOURCE_BUCKET, OBJECT_KEY);
+    }
+
+    @Test
+    public void deleteObjectShouldFailWhenClientThrowsAnException() {
+        doThrow(new RuntimeException("client exception")).when(mockS3Client).deleteObject(any(), any());
+
+        assertThrows(RuntimeException.class, () -> underTest.deleteObject(OBJECT_KEY, SOURCE_BUCKET));
+    }
+
+    @Test
+    public void getObjectsOlderThanShouldReturnListOfObjectsMatchingAllowedExtensions() {
+        ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".txt"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file3", ".json"),
+                ImmutablePair.of("file4", ".jpg"),
+                ImmutablePair.of("file5", ".JSON"),
+                ImmutablePair.of("file6", ".PARQUET")
+        );
+
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file2.parquet");
+        expectedObjectKeys.add("file6.PARQUET");
+        expectedObjectKeys.add("file3.json");
+        expectedObjectKeys.add("file5.JSON");
+
+        Date lastModifiedDate = new Date();
+        lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+        givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
+
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, allowedExtensions, 0L, fixedClock);
+
+        assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
+    }
+
+    @Test
+    public void getObjectsOlderThanShouldReturnListOfAllObjectsWhenGivenWildCardExtension() {
+        ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".txt"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file3", ".json"),
+                ImmutablePair.of("file4", ".jpg"),
+                ImmutablePair.of("file5", ".JSON"),
+                ImmutablePair.of("file6", ".PARQUET")
+        );
+
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file1.txt");
+        expectedObjectKeys.add("file2.parquet");
+        expectedObjectKeys.add("file3.json");
+        expectedObjectKeys.add("file4.jpg");
+        expectedObjectKeys.add("file5.JSON");
+        expectedObjectKeys.add("file6.PARQUET");
+
+        Date lastModifiedDate = new Date();
+        lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+        givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
+
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, ImmutableSet.of("*"), 0L, fixedClock);
+
+        assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
+    }
+
+    @Test
+    public void getObjectsOlderThanShouldReturnListOfObjectsOlderThanSpecifiedNumberOfRetentionDays() {
+        ImmutableSet<ImmutablePair<String, String>> recentObjectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".parquet"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file3", ".parquet")
+        );
+
+        ImmutableSet<ImmutablePair<String, String>> oldObjectKeys = ImmutableSet.of(
+                ImmutablePair.of("file4", ".parquet"),
+                ImmutablePair.of("file5", ".parquet")
+        );
+
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file4.parquet");
+        expectedObjectKeys.add("file5.parquet");
+
+        Date recentLastModifiedDate = new Date();
+        recentLastModifiedDate.setTime(fixedDateTime.plusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        Date oldLastModifiedDate = new Date();
+        oldLastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        List<S3ObjectSummary> recentObjectSummaries = createObjectSummaries(recentObjectKeys, recentLastModifiedDate);
+        List<S3ObjectSummary> oldObjectSummaries = createObjectSummaries(oldObjectKeys, oldLastModifiedDate);
+        List<S3ObjectSummary> allObjectSummaries = Stream.concat(recentObjectSummaries.stream(), oldObjectSummaries.stream()).collect(Collectors.toList());
+
+        givenObjectListingSucceeds(allObjectSummaries);
+
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, allowedExtensions, 0L, fixedClock);
+
+        assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
+    }
+
+    @Test
+    public void getObjectsOlderThanShouldListObjectsWithinGivenFolderPrefix() {
+        String folder = "test-folder";
+
+        ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".parquet"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file6", ".parquet")
+        );
+
+        Date lastModifiedDate = new Date();
+        lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+        givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
+
+        underTest.getObjectsOlderThan(SOURCE_BUCKET, folder, allowedExtensions, 0L, fixedClock);
+
+        assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(listObjectsRequestCaptor.getValue().getPrefix(), is(equalTo(folder)));
+    }
+
+    @NotNull
+    private static List<S3ObjectSummary> createObjectSummaries(
+            ImmutableSet<ImmutablePair<String, String>> objectKeys,
+            Date lastModifiedDate
+    ) {
+        return objectKeys.stream()
+                .map(objectKey -> {
+                    S3ObjectSummary objectSummary = new S3ObjectSummary();
+                    String extension = objectKey.getRight();
+                    objectSummary.setKey(objectKey.getLeft() + extension);
+                    objectSummary.setLastModified(lastModifiedDate);
+                    return objectSummary;
+                }).collect(Collectors.toList());
+    }
+
+    private void givenObjectListingSucceeds(List<S3ObjectSummary> objectSummaries) {
+        when(mockObjectListing.getObjectSummaries()).thenReturn(objectSummaries);
+        when(mockObjectListing.isTruncated()).thenReturn(false);
+        when(mockS3Client.listObjects(listObjectsRequestCaptor.capture())).thenReturn(mockObjectListing);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -42,6 +42,8 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
     private final static ImmutableSet<String> bucketsToDeleteFrom = ImmutableSet
             .of("bucket-to-delete-from-1", "bucket-to-delete-from-2");
 
+    private static final ImmutableSet<String> parquetFileExtension = ImmutableSet.of(".parquet");
+
     private S3DataDeletionJob underTest;
 
     @BeforeEach
@@ -69,10 +71,15 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
         when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
+        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listParquetFilesForConfig(listObjectsBucketCaptor.capture(), eq(configuredTables), eq(0L)))
-                .thenReturn(objectsToDelete);
+        when(mockS3FileService.listFilesForConfig(
+                listObjectsBucketCaptor.capture(),
+                eq(configuredTables),
+                eq(parquetFileExtension),
+                eq(0L)
+        )).thenReturn(objectsToDelete);
 
         when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture()))
                 .thenReturn(Collections.emptySet());
@@ -108,9 +115,14 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
         when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
-        when(mockS3FileService.listParquetFilesForConfig(listObjectsBucketCaptor.capture(), eq(configuredTables), eq(0L)))
-                .thenReturn(objectsToDelete);
+        when(mockS3FileService.listFilesForConfig(
+                listObjectsBucketCaptor.capture(),
+                eq(configuredTables),
+                eq(parquetFileExtension),
+                eq(0L)
+        )).thenReturn(objectsToDelete);
 
         when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture())).thenReturn(failedFiles);
 

--- a/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class S3FileTransferJobTest extends BaseSparkTest {
 
-    private static final String TEST_CONFIG_KEY = "some-config-key";
-
     @Mock
     private ConfigService mockConfigService;
     @Mock
@@ -31,10 +29,13 @@ public class S3FileTransferJobTest extends BaseSparkTest {
     @Mock
     private S3FileService mockS3FileService;
 
+    private static final String TEST_CONFIG_KEY = "some-config-key";
     private final static String SOURCE_BUCKET = "source-bucket";
     private final static String DESTINATION_BUCKET = "destination-bucket";
 
     private static final long RETENTION_DAYS = 2L;
+
+    private static final ImmutableSet<String> parquetFileExtension = ImmutableSet.of(".parquet");
 
     private S3FileTransferJob underTest;
 
@@ -66,10 +67,11 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
         when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
+        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listParquetFilesForConfig(SOURCE_BUCKET, configuredTables, RETENTION_DAYS))
+        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, configuredTables, parquetFileExtension, RETENTION_DAYS))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, DESTINATION_BUCKET, true))
@@ -90,8 +92,9 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
         when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
+        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
-        when(mockS3FileService.listParquetFiles(SOURCE_BUCKET, RETENTION_DAYS))
+        when(mockS3FileService.listFiles(SOURCE_BUCKET, parquetFileExtension, RETENTION_DAYS))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, DESTINATION_BUCKET, true))
@@ -120,10 +123,11 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
         when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
+        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listParquetFilesForConfig(SOURCE_BUCKET, configuredTables, RETENTION_DAYS))
+        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, configuredTables, parquetFileExtension, RETENTION_DAYS))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, DESTINATION_BUCKET, true))


### PR DESCRIPTION
This PR:
Makes the file copy/delete job configurable for multiple file types by supplying a comma separated list of extensions e.g. `.parquet,.json,.txt`. When a wildcard `*` is given or the list contains a wildcard then all files are processed.