### PR TITLE
DPR2-46: Update manifest after switching prisons data source

### DIFF
--- a/src/main/java/uk/gov/justice/digital/job/HiveTableCreationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/HiveTableCreationJob.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.ConfigService;
-import uk.gov.justice.digital.service.HiveSchemaService;
+import uk.gov.justice.digital.service.HiveTableService;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -23,17 +23,17 @@ public class HiveTableCreationJob implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(HiveTableCreationJob.class);
     private final ConfigService configService;
-    private final HiveSchemaService hiveSchemaService;
+    private final HiveTableService hiveTableService;
     private final JobArguments jobArguments;
 
     @Inject
     public HiveTableCreationJob(
             ConfigService configService,
-            HiveSchemaService hiveSchemaService,
+            HiveTableService hiveTableService,
             JobArguments jobArguments
     ) {
         this.configService = configService;
-        this.hiveSchemaService = hiveSchemaService;
+        this.hiveTableService = hiveTableService;
         this.jobArguments = jobArguments;
     }
 
@@ -50,7 +50,7 @@ public class HiveTableCreationJob implements Runnable {
             ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                     .getConfiguredTables(jobArguments.getConfigKey());
 
-            Set<ImmutablePair<String, String>> failedTables = hiveSchemaService.replaceTables(configuredTables);
+            Set<ImmutablePair<String, String>> failedTables = hiveTableService.replaceTables(configuredTables);
 
             if (!failedTables.isEmpty()) {
                 logger.error("Not all schemas were processed");

--- a/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
@@ -3,13 +3,15 @@ package uk.gov.justice.digital.job;
 import com.google.common.collect.ImmutableSet;
 import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.job.context.MicronautContext;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.ConfigService;
-import uk.gov.justice.digital.service.HiveSchemaService;
+import uk.gov.justice.digital.service.HiveTableService;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -21,17 +23,20 @@ import java.util.Set;
 public class SwitchHiveTableJob implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(SwitchHiveTableJob.class);
     private final ConfigService configService;
-    private final HiveSchemaService hiveSchemaService;
+    private final HiveTableService hiveTableService;
+    private final SparkSessionProvider sparkSessionProvider;
     private final JobArguments jobArguments;
 
     @Inject
     public SwitchHiveTableJob(
             ConfigService configService,
-            HiveSchemaService hiveSchemaService,
+            HiveTableService hiveTableService,
+            SparkSessionProvider sparkSessionProvider,
             JobArguments jobArguments
     ) {
         this.configService = configService;
-        this.hiveSchemaService = hiveSchemaService;
+        this.hiveTableService = hiveTableService;
+        this.sparkSessionProvider = sparkSessionProvider;
         this.jobArguments = jobArguments;
     }
 
@@ -44,11 +49,12 @@ public class SwitchHiveTableJob implements Runnable {
     public void run() {
         try {
             logger.info("SwitchHiveTableJob running");
+            SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(jobArguments.getLogLevel());
 
             ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                     .getConfiguredTables(jobArguments.getConfigKey());
 
-            Set<ImmutablePair<String, String>> failedTables = hiveSchemaService.switchPrisonsTableDataSource(configuredTables);
+            Set<ImmutablePair<String, String>> failedTables = hiveTableService.switchPrisonsTableDataSource(spark, configuredTables);
 
             if (!failedTables.isEmpty()) {
                 logger.error("Not all schemas were processed");

--- a/src/test/java/uk/gov/justice/digital/job/HiveTableCreationJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/HiveTableCreationJobTest.java
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.exception.HiveSchemaServiceException;
 import uk.gov.justice.digital.service.ConfigService;
-import uk.gov.justice.digital.service.HiveSchemaService;
+import uk.gov.justice.digital.service.HiveTableService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,7 +36,7 @@ public class HiveTableCreationJobTest extends BaseSparkTest {
     @Mock
     private ConfigService mockConfigService;
     @Mock
-    private HiveSchemaService mockHiveSchemaService;
+    private HiveTableService mockHiveTableService;
     @Mock
     private JobArguments mockJobArguments;
     @Captor
@@ -46,8 +46,8 @@ public class HiveTableCreationJobTest extends BaseSparkTest {
 
     @BeforeEach
     public void setup() {
-        reset(mockConfigService, mockHiveSchemaService, mockJobArguments);
-        underTest = new HiveTableCreationJob(mockConfigService, mockHiveSchemaService, mockJobArguments);
+        reset(mockConfigService, mockHiveTableService, mockJobArguments);
+        underTest = new HiveTableCreationJob(mockConfigService, mockHiveTableService, mockJobArguments);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class HiveTableCreationJobTest extends BaseSparkTest {
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(expectedTables));
-        when(mockHiveSchemaService.replaceTables(argumentCaptor.capture())).thenReturn(Collections.emptySet());
+        when(mockHiveTableService.replaceTables(argumentCaptor.capture())).thenReturn(Collections.emptySet());
 
         assertDoesNotThrow(() -> underTest.run());
 
@@ -72,7 +72,7 @@ public class HiveTableCreationJobTest extends BaseSparkTest {
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(failedTables));
-        when(mockHiveSchemaService.replaceTables(any())).thenReturn(failedTables);
+        when(mockHiveTableService.replaceTables(any())).thenReturn(failedTables);
 
         SystemLambda.catchSystemExit(() -> underTest.run());
     }
@@ -83,7 +83,7 @@ public class HiveTableCreationJobTest extends BaseSparkTest {
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(table));
-        when(mockHiveSchemaService.replaceTables(any())).thenThrow(new HiveSchemaServiceException("Schema service exception"));
+        when(mockHiveTableService.replaceTables(any())).thenThrow(new HiveSchemaServiceException("Schema service exception"));
 
         SystemLambda.catchSystemExit(() -> underTest.run());
     }


### PR DESCRIPTION
This PR:
- Updates the delta manifest so the prisons table is still queryable after it has been switched to use the data located in the temp-reload bucket
- Renames HiveSchemaService to HiveTableService