### PR TITLE
DPR2-387: Fix pagination issue in s3 object listing

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -58,7 +58,8 @@ class JobArgumentsIntegrationTest {
             { JobArguments.FILE_TRANSFER_DESTINATION_BUCKET_NAME, "dpr-destination-bucket" },
             { JobArguments.FILE_TRANSFER_RETENTION_DAYS, "2" },
             { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, "5" },
-            { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, "10" }
+            { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, "10" },
+            { JobArguments.MAX_S3_PAGE_SIZE, "100" }
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -101,7 +102,8 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.FILE_TRANSFER_DESTINATION_BUCKET_NAME, validArguments.getTransferDestinationBucket() },
                 { JobArguments.FILE_TRANSFER_RETENTION_DAYS, validArguments.getFileTransferRetentionDays() },
                 { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, validArguments.glueOrchestrationWaitIntervalSeconds() },
-                { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, validArguments.glueOrchestrationMaxAttempts() }
+                { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, validArguments.glueOrchestrationMaxAttempts() },
+                { JobArguments.MAX_S3_PAGE_SIZE, validArguments.getMaxObjectsPerPage() }
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -306,6 +308,23 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(20, jobArguments.glueOrchestrationMaxAttempts());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1", "1001"})
+    public void shouldReturnErrorWhenMaxObjectsPerPageIsInvalid(String value) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.MAX_S3_PAGE_SIZE, value);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertThrows(IllegalArgumentException.class, jobArguments::getMaxObjectsPerPage);
+    }
+
+    @Test
+    public void shouldDefaultMaxObjectsPerPageWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.MAX_S3_PAGE_SIZE);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(1000, jobArguments.getMaxObjectsPerPage());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -107,6 +107,8 @@ public class JobArguments {
     static final String GLUE_ORCHESTRATION_MAX_ATTEMPTS = "dpr.glue.orchestration.max.attempts";
     static final int DEFAULT_GLUE_ORCHESTRATION_MAX_ATTEMPTS = 20;
     static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";
+    static final String MAX_S3_PAGE_SIZE = "dpr.s3.max.page.size";
+    static final Integer DEFAULT_MAX_S3_PAGE_SIZE = 1000;
 
     private final Map<String, String> config;
 
@@ -361,6 +363,15 @@ public class JobArguments {
 
     public int glueOrchestrationMaxAttempts() {
         return getArgument(GLUE_ORCHESTRATION_MAX_ATTEMPTS, DEFAULT_GLUE_ORCHESTRATION_MAX_ATTEMPTS);
+    }
+
+    public Integer getMaxObjectsPerPage() {
+        int argument = getArgument(MAX_S3_PAGE_SIZE, DEFAULT_MAX_S3_PAGE_SIZE);
+        if (argument > DEFAULT_MAX_S3_PAGE_SIZE || argument <= 0) {
+            throw new IllegalArgumentException(MAX_S3_PAGE_SIZE + " can only be positive integer less than " + DEFAULT_MAX_S3_PAGE_SIZE);
+        } else {
+            return argument;
+        }
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/service/S3FileService.java
+++ b/src/main/java/uk/gov/justice/digital/service/S3FileService.java
@@ -59,7 +59,7 @@ public class S3FileService {
                 s3Client.copyObject(objectKey, sourceBucket, destinationBucket);
                 if (deleteCopiedFiles) s3Client.deleteObject(objectKey, sourceBucket);
             } catch (AmazonServiceException e) {
-                logger.warn("Failed to move S3 object {}: {}", objectKey, e.getErrorMessage());
+                logger.warn("Failed to move S3 object {}", objectKey, e);
                 failedObjects.add(objectKey);
             }
         }


### PR DESCRIPTION
This PR fixes a bug in the pagination when listing objects in S3.
To make the pagination work, the nextMarker of the current page is used to retrieve the next page.
This PR also exposed an argument `dpr.s3.max.page.size` which can be used to override the page size.