### PR TITLE
DPR2-46: Add optional flag to delete checkpoint

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -16,8 +16,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -59,7 +58,8 @@ class JobArgumentsIntegrationTest {
             { JobArguments.FILE_TRANSFER_RETENTION_DAYS, "2" },
             { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, "5" },
             { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, "10" },
-            { JobArguments.MAX_S3_PAGE_SIZE, "100" }
+            { JobArguments.MAX_S3_PAGE_SIZE, "100" },
+            { JobArguments.CLEAN_CDC_CHECKPOINT, "false" }
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -103,7 +103,8 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.FILE_TRANSFER_RETENTION_DAYS, validArguments.getFileTransferRetentionDays() },
                 { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, validArguments.glueOrchestrationWaitIntervalSeconds() },
                 { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, validArguments.glueOrchestrationMaxAttempts() },
-                { JobArguments.MAX_S3_PAGE_SIZE, validArguments.getMaxObjectsPerPage() }
+                { JobArguments.MAX_S3_PAGE_SIZE, validArguments.getMaxObjectsPerPage() },
+                { JobArguments.CLEAN_CDC_CHECKPOINT, validArguments.cleanCdcCheckpoint() }
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -325,6 +326,14 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.MAX_S3_PAGE_SIZE);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(1000, jobArguments.getMaxObjectsPerPage());
+    }
+
+    @Test
+    public void cleanCdcCheckpointShouldDefaultToFalseWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.CLEAN_CDC_CHECKPOINT);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertFalse(jobArguments.cleanCdcCheckpoint());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -109,6 +109,7 @@ public class JobArguments {
     static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";
     static final String MAX_S3_PAGE_SIZE = "dpr.s3.max.page.size";
     static final Integer DEFAULT_MAX_S3_PAGE_SIZE = 1000;
+    static final String CLEAN_CDC_CHECKPOINT = "dpr.clean.cdc.checkpoint";
 
     private final Map<String, String> config;
 
@@ -372,6 +373,10 @@ public class JobArguments {
         } else {
             return argument;
         }
+    }
+
+    public boolean cleanCdcCheckpoint() {
+        return getArgument(CLEAN_CDC_CHECKPOINT, false);
     }
 
     private String getArgument(String argumentName) {


### PR DESCRIPTION
This PR adds an optional boolean flag `--dpr.clean.cdc.checkpoint` which when `true` deletes the checkpoint thereby allowing already processed files to be reprocessed. When omitted the flag defaults to `false`.

This is added to support the replay pipeline and enables reprocessing of already processed files.