### PR TITLE
DPR2-351 Validate time field using ValidationType metadata in contract

### DIFF
--- a/src/it/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterIntegrationTest.java
@@ -49,7 +49,7 @@ class AvroToSparkSchemaConverterIntegrationTest {
                 new SimpleEntry<>("timestamp-micros", DataTypes.TimestampType),
                 // Note - spark does not support these types so the schema converter retains the original avro type.
                 new SimpleEntry<>("time-micros",      DataTypes.LongType),
-                new SimpleEntry<>("time-millis",      DataTypes.IntegerType)
+                new SimpleEntry<>("time-millis",      DataTypes.TimestampType)
         ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         typeMappings.forEach((avroType, sparkType) -> {

--- a/src/it/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterIntegrationTest.java
@@ -49,7 +49,7 @@ class AvroToSparkSchemaConverterIntegrationTest {
                 new SimpleEntry<>("timestamp-micros", DataTypes.TimestampType),
                 // Note - spark does not support these types so the schema converter retains the original avro type.
                 new SimpleEntry<>("time-micros",      DataTypes.LongType),
-                new SimpleEntry<>("time-millis",      DataTypes.TimestampType)
+                new SimpleEntry<>("time-millis",      DataTypes.IntegerType)
         ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         typeMappings.forEach((avroType, sparkType) -> {

--- a/src/it/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverterIntegrationTest.java
@@ -3,9 +3,7 @@ package uk.gov.justice.digital.converter.avro;
 import lombok.val;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -15,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AvroToSparkSchemaConverterIntegrationTest {
 
@@ -108,6 +107,27 @@ class AvroToSparkSchemaConverterIntegrationTest {
                 .add("aField", DataTypes.DateType, nullable);
 
         assertEquals(sparkSchema, underTest.convert(avroSchema));
+    }
+
+    @Test
+    public void shouldIncludeMetadataAfterConversion() {
+        val avroSchemaString = "{" +
+                "  \"type\": \"record\"," +
+                "  \"name\": \"test\"," +
+                "  \"fields\": [" +
+                "    {" +
+                "      \"name\": \"aField\"," +
+                "      \"type\": \"string\"," +
+                "      \"metadata\": {" +
+                "        \"validationType\": \"time\"" +
+                "      }" +
+                "    }" +
+                "  ]" +
+                "}";
+        
+        val result = underTest.convert(avroSchemaString);
+        
+        assertTrue(result.fields()[0].metadata().contains("validationType"));
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3ConfigReaderClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3ConfigReaderClient.java
@@ -49,7 +49,7 @@ public class S3ConfigReaderClient {
             val config = new ObjectMapper().readValue(configString, HashMap.class);
             return ImmutableSet.copyOf(convertToImmutablePairs((ArrayList<String>) config.get("tables")));
         } catch (Exception e) {
-            throw new ConfigReaderClientException("Exception when loading config", e);
+            throw new ConfigReaderClientException("Exception when loading config " + configFileKey, e);
         }
     }
 

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -12,6 +12,8 @@ public class CommonDataFields {
     // The error column is added to the schema by the app when writing violations to give error details.
     public static final String ERROR = "error";
     public static final String ERROR_RAW = "raw";
+    public static final String METADATA_KEY = "metadata";
+    public static final String VALIDATION_TYPE_KEY = "validationType";
 
     /**
      * The possible entries in the operation column

--- a/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
+++ b/src/main/java/uk/gov/justice/digital/converter/avro/AvroToSparkSchemaConverter.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static uk.gov.justice.digital.common.CommonDataFields.METADATA_KEY;
+
 /**
  * Avro Schema to Spark Schema (StructType) converter.
  * <p>
@@ -40,8 +42,8 @@ public class AvroToSparkSchemaConverter implements Converter<String, StructType>
         val avroSchema = toAvroSchema(avroSchemaString);
         val metadata = avroSchema.getFields()
                 .stream()
-                .filter(field -> field.getObjectProp("metadata") != null)
-                .collect(Collectors.toMap(Schema.Field::name, field -> field.getObjectProp("metadata")));
+                .filter(field -> field.getObjectProp(METADATA_KEY) != null)
+                .collect(Collectors.toMap(Schema.Field::name, field -> field.getObjectProp(METADATA_KEY)));
 
         val fields = Arrays.stream(castToStructType(toSparkDataType(avroSchema)).fields())
                 .map(updateMetadataField(metadata))
@@ -117,19 +119,19 @@ public class AvroToSparkSchemaConverter implements Converter<String, StructType>
                 (avroField.hasDefaultValue()) ? avroField.defaultVal() : null
         );
 
-        addMetadata(avroField.getObjectProp("metadata"), nullableField);
+        addMetadata(avroField.getObjectProp(METADATA_KEY), nullableField);
         return nullableField;
     }
 
     @NotNull
     private static Schema.Field createNonNullableField(Schema.Field avroField) {
         Schema.Field nonNullableField = new Schema.Field(avroField.name(), avroField.schema());
-        addMetadata(avroField.getObjectProp("metadata"), nonNullableField);
+        addMetadata(avroField.getObjectProp(METADATA_KEY), nonNullableField);
         return nonNullableField;
     }
 
     private static void addMetadata(Object metadataObject, Schema.Field field) {
-        Optional.ofNullable(metadataObject).ifPresent(metadata -> field.addProp("metadata", metadata));
+        Optional.ofNullable(metadataObject).ifPresent(metadata -> field.addProp(METADATA_KEY, metadata));
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -8,23 +8,19 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.functions;
-import org.apache.spark.sql.types.ByteType;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.IntegerType;
-import org.apache.spark.sql.types.ShortType;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
 import javax.inject.Singleton;
 import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static org.apache.spark.sql.functions.col;
-import static org.apache.spark.sql.functions.lit;
-import static org.apache.spark.sql.functions.when;
+import static org.apache.spark.sql.functions.*;
 import static uk.gov.justice.digital.common.CommonDataFields.ERROR;
 import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 
@@ -33,6 +29,9 @@ public class ValidationService {
 
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
     private final ViolationService violationService;
+    
+    private final String validTimeFormat = "^(?:[01]\\d|2[0-3]):(?:[0-5]\\d|5[0-9]):(?:[0-5]\\d|5[0-9])$"; // HH:mm:ss
+
     @Inject
     public ValidationService(ViolationService violationService) {
         this.violationService = violationService;
@@ -42,7 +41,7 @@ public class ValidationService {
         val maybeValidRows = validateRows(dataFrame, sourceReference, inferredSchema);
         val validRows = maybeValidRows.filter(col(ERROR).isNull()).drop(ERROR);
         val invalidRows = maybeValidRows.filter(col(ERROR).isNotNull());
-        if(!invalidRows.isEmpty()) {
+        if (!invalidRows.isEmpty()) {
             violationService.handleViolation(spark, invalidRows, sourceReference.getSource(), sourceReference.getTable(), zoneName);
         }
         return validRows;
@@ -51,28 +50,28 @@ public class ValidationService {
     @VisibleForTesting
     Dataset<Row> validateRows(Dataset<Row> df, SourceReference sourceReference, StructType inferredSchema) {
         StructType schema = withMetadataFields(sourceReference.getSchema());
-
-        if(schemasMatch(inferredSchema, schema)) {
-            return df.withColumn(
+        val convertedDf = convertTimestampFields(df, sourceReference);
+        if (schemasMatch(inferredSchema, schema)) {
+            return convertedDf.withColumn(
                     ERROR,
                     // The order of the 'when' clauses determines the validation error message used - first wins.
                     // Null means there is no validation error.
-                    when(pkIsNull(sourceReference), lit("Record does not have a primary key"))
-                            .when(requiredColumnIsNull(schema.fields()), lit("Required column is null"))
-                            .otherwise(lit(null))
+                    when(pkIsNull(sourceReference), concatenateErrors("Record does not have a primary key"))
+                            .when(requiredColumnIsNull(schema.fields()), concatenateErrors("Required column is null"))
+                            .otherwise(col(ERROR))
             );
         } else {
             String msg = format("Record does not match schema version %s", sourceReference.getVersionId());
             logger.warn(msg + " Inferred schema:\n{}\nActual schema:\n{}\nFor {}.{}",
                     inferredSchema, schema, sourceReference.getSource(), sourceReference.getTable()
             );
-            return df.withColumn(ERROR, lit(msg));
+            return convertedDf.withColumn(ERROR, concatenateErrors(msg));
         }
     }
 
     @VisibleForTesting
     static boolean schemasMatch(StructType inferredSchema, StructType specifiedSchema) {
-        if(inferredSchema.fields().length != specifiedSchema.fields().length) {
+        if (inferredSchema.fields().length != specifiedSchema.fields().length) {
             return false;
         }
         for (StructField inferredField : inferredSchema.fields()) {
@@ -82,11 +81,11 @@ public class ValidationService {
                 DataType specifiedDataType = specifiedField.dataType();
                 boolean sameType = specifiedDataType.getClass().equals(inferredDataType.getClass());
 
-                if(!sameType && !isAllowedDifference(inferredDataType, specifiedDataType)) {
+                if (!sameType && !isAllowedDifference(inferredDataType, specifiedDataType)) {
                     return false;
                 }
                 // If it is a struct then recurse to check the nested types
-                if(inferredDataType instanceof StructType &&
+                if (inferredDataType instanceof StructType &&
                         !schemasMatch((StructType) inferredDataType, (StructType) specifiedDataType)) {
                     // The struct schemas don't recursively match so the overall schema doesn't match
                     return false;
@@ -99,11 +98,48 @@ public class ValidationService {
         return true;
     }
 
+    private Dataset<Row> convertTimestampFields(Dataset<Row> df, SourceReference sourceReference) {
+        val timeFields = Arrays.stream(sourceReference.getSchema().fields())
+                .filter(field -> field.dataType() instanceof TimestampType)
+                .distinct()
+                .map(StructField::name)
+                .collect(Collectors.toList());
+
+        df.show(false);
+
+        val otherFields = Arrays.stream(df.columns())
+                .filter(field -> !timeFields.contains(field))
+                .map(ValidationService::backtickHyphenatedFields)
+                .collect(Collectors.toList());
+
+        otherFields.add(ERROR);
+
+        val timeFormatValidation = Stream
+                .concat(Stream.of(lit(null)), timeFields.stream().map(this::validateTimeField))
+                .toArray(Column[]::new);
+        // Convert string field of format "HH:mm:ss" to timestamp "yyyy-MM-dd HH:mm:ss.SSSS"
+        val timeFieldSelectExpressions = timeFields
+                .stream()
+                .map(ValidationService::backtickHyphenatedFields)
+                .map(fieldName -> convertFieldToTimestamp(fieldName).as(fieldName).expr().sql())
+                .collect(Collectors.toList());
+
+            return df
+                    .withColumn(ERROR, coalesce(timeFormatValidation))
+                    .selectExpr(Stream.concat(otherFields.stream(), timeFieldSelectExpressions.stream()).toArray(String[]::new));
+    }
+
+    @NotNull
+    private static String backtickHyphenatedFields(String field) {
+        return field.contains("-") ? "`" + field + "`" : field;
+    }
+
     // Handles special cases, e.g. due to minor differences in data types used in Parquet/Spark and Avro schemas
     private static boolean isAllowedDifference(DataType inferredDataType, DataType specifiedDataType) {
         // We represent 8 and 16 bit ints as 32 bit ints in avro so this difference is allowed
         return (inferredDataType instanceof ShortType && specifiedDataType instanceof IntegerType) ||
-                (inferredDataType instanceof ByteType && specifiedDataType instanceof IntegerType);
+                (inferredDataType instanceof ByteType && specifiedDataType instanceof IntegerType) ||
+                (inferredDataType instanceof StringType && specifiedDataType instanceof TimestampType);
     }
 
     private static Column pkIsNull(SourceReference sourceReference) {
@@ -124,5 +160,24 @@ public class ValidationService {
                 .map(Column::isNull)
                 .reduce(Column::or)
                 .orElse(lit(false));
+    }
+
+    private Column convertFieldToTimestamp(String fieldName) {
+        val timestampFormat = "yyyy-MM-dd HH:mm:ss.SSSS";
+        return when(
+                col(fieldName).isNotNull().and(col(fieldName).rlike(validTimeFormat)),
+                to_timestamp(concat(lit("1970-01-01 "), col(fieldName), lit(".0000")), timestampFormat)
+        ).otherwise(col(fieldName));
+    }
+
+    private Column validateTimeField(String fieldName) {
+        return when(
+                col(fieldName).isNotNull().and(not(col(fieldName).rlike(validTimeFormat))), 
+                lit(fieldName + " must have format HH:mm:ss")
+        );
+    }
+
+    private static Column concatenateErrors(String errorMsg) {
+        return when(col(ERROR).isNull(), lit(errorMsg)).otherwise(concat(col(ERROR), lit("; "), lit(errorMsg)));
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -21,8 +21,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.apache.spark.sql.functions.*;
-import static uk.gov.justice.digital.common.CommonDataFields.ERROR;
-import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
+import static uk.gov.justice.digital.common.CommonDataFields.*;
 
 @Singleton
 public class ValidationService {
@@ -30,11 +29,8 @@ public class ValidationService {
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
     private final ViolationService violationService;
 
-    private final String VALIDATION_TYPE_KEY = "validationType";
-    private final String TIME_FORMAT = "^(?:[01]\\d|2[0-3]):(?:[0-5]\\d|5[0-9]):(?:[0-5]\\d|5[0-9])$"; // HH:mm:ss
-
     private final ImmutableMap<String, String> validationFormats = ImmutableMap.<String, String>builder()
-            .put("time", TIME_FORMAT)
+            .put("time", "^(?:[01]\\d|2[0-3]):(?:[0-5]\\d|5[0-9]):(?:[0-5]\\d|5[0-9])$") // HH:mm:ss
             .build();
 
     @Inject

--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -29,6 +29,7 @@ public class ValidationService {
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
     private final ViolationService violationService;
 
+    // This contains a mapping of regex strings used for validating string fields annotated with the validationType metadata
     private final ImmutableMap<String, String> validationFormats = ImmutableMap.<String, String>builder()
             .put("time", "^(?:[01]\\d|2[0-3]):(?:[0-5]\\d|5[0-9]):(?:[0-5]\\d|5[0-9])$") // HH:mm:ss
             .build();

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -55,7 +55,7 @@ class ValidationServiceTest extends BaseSparkTest {
     private static final String noPkMsg = "Record does not have a primary key";
     private static final String VERSION_ID = UUID.randomUUID().toString();
     private static final String schemaMisMatchMsg = "Record does not match schema version " + VERSION_ID;
-    private static final String METADATA_STRING = "{\"metadata\": {\"validationType\": \"time\"}}";
+    private static final String VALIDATION_TYPE = "{\"validationType\": \"time\"}";
 
     private static Dataset<Row> inputDf;
     @Mock
@@ -199,14 +199,14 @@ class ValidationServiceTest extends BaseSparkTest {
         
         val providedSchema = new StructType()
                 .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
-                .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(METADATA_STRING)))
-                .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(METADATA_STRING)));
+                .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
+                .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)));
 
         val inferredSchema = withMetadataFields(
                 new StructType()
                         .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
-                        .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(METADATA_STRING)))
-                        .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(METADATA_STRING)))
+                        .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
+                        .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)))
         );
 
         when(sourceReference.getSchema()).thenReturn(providedSchema);
@@ -259,14 +259,14 @@ class ValidationServiceTest extends BaseSparkTest {
 
         val providedSchema = new StructType()
                 .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
-                .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(METADATA_STRING)))
-                .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(METADATA_STRING)));
+                .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
+                .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)));
 
         val inferredSchema = withMetadataFields(
                 new StructType()
                         .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
-                        .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(METADATA_STRING)))
-                        .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(METADATA_STRING)))
+                        .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
+                        .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)))
         );
 
         when(sourceReference.getSchema()).thenReturn(providedSchema);

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -194,7 +194,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void validateRowsShouldValidateTimeFields() {
+    void validateRowsShouldValidateTimeFields() {
         val timestamp = "2023-11-13 10:49:28.000000";
         
         val providedSchema = new StructType()
@@ -253,7 +253,7 @@ class ValidationServiceTest extends BaseSparkTest {
             "AB:CD:EF",
             " "
     })
-    public void validateRowsShouldRecordErrorWhenGivenInvalidTimeFields(String invalidTime) {
+    void validateRowsShouldRecordErrorWhenGivenInvalidTimeFields(String invalidTime) {
         val timestamp = "2023-11-13 10:49:28.000000";
         val validTime = "09:30:00";
 


### PR DESCRIPTION
This PR:
- Uses the type specified in the metadata field validationType to validate string fields where the original datatype is not supported by spark
- The validation type metadata is configured on a field contract like below:
```
{
    "name": "start_time",
    "type": "string",
    "nullable": false,
    "metadata": {
        "validationType": "time"
     }
}
```

- The validationType maps to a regex validation
- Errors from invalid fields are concatenated e.g. `field_1 must have format HH:mm:ss; field_2 must have format HH:mm:ss`
- Invalid records are written as violations