### PR TITLE
DPR2-662: Infer schema from raw-zone with fallback to raw-archive

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -8,7 +8,9 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.streaming.DataStreamReader;
 import org.apache.spark.sql.types.StructType;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.collection.JavaConverters;
@@ -17,7 +19,9 @@ import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.DataProviderFailedMergingSchemasException;
 import uk.gov.justice.digital.exception.NoSchemaNoDataException;
 
+import java.io.FileNotFoundException;
 import java.util.List;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
@@ -109,24 +113,65 @@ public class S3DataProvider {
     }
 
     public StructType inferSchema(SparkSession sparkSession, String sourceName, String tableName) {
+        // Attempt to infer schema from files in the raw zone.
+        // If there is a failure due to FileNotFoundException which occurs when a file gets archived then the schema inference is done using data already in the raw archive
+        // When spark structured streaming archiving is enabled, an attempt is made to infer the schema from the processed files folder before falling back to the archive
         String tablePath = tablePath(arguments.getRawS3Path(), sourceName, tableName);
-        return sparkSession.read().parquet(tablePath).schema();
+        try {
+            return sparkSession.read().parquet(tablePath).schema();
+        } catch (Exception ex) {
+            String failureMessage = format("Failed to infer schema from %s", tablePath);
+            logger.info(failureMessage);
+            if (rootCauseIsFileNotFound(ex)) {
+                String archiveTablePath = tablePath(arguments.getRawArchiveS3Path(), sourceName, tableName);
+                if (arguments.enableStreamingSourceArchiving()) {
+                    return inferSchemaWhenStreamingArchiveIsEnabled(sparkSession, sourceName, tableName, archiveTablePath);
+                } else {
+                    return sparkSession.read().parquet(archiveTablePath).schema();
+                }
+            } else {
+                throw ex;
+            }
+        }
     }
 
     private Dataset<Row> getStreamingDataset(SparkSession sparkSession, String fileGlobPath, StructType schema) {
+        DataStreamReader streamReader = sparkSession.readStream().schema(schema);
+
         if (arguments.enableStreamingSourceArchiving()) {
             String processedRawFilesLocation = ensureEndsWithSlash(arguments.getRawS3Path()) + arguments.getProcessedRawFilesPath();
-            return sparkSession
-                    .readStream()
-                    .schema(schema)
+            return streamReader
                     .option("cleanSource", "archive")
                     .option("sourceArchiveDir", processedRawFilesLocation)
                     .parquet(fileGlobPath);
         } else {
-            return sparkSession
-                    .readStream()
-                    .schema(schema)
-                    .parquet(fileGlobPath);
+            return streamReader.parquet(fileGlobPath);
         }
+    }
+
+    private StructType inferSchemaWhenStreamingArchiveIsEnabled(SparkSession sparkSession, String sourceName, String tableName, String archiveTablePath) {
+        try {
+            String processedFilesPath = ensureEndsWithSlash(arguments.getRawS3Path()) + arguments.getProcessedRawFilesPath();
+            String processedTableFilesPath = tablePath(processedFilesPath, sourceName, tableName);
+            String fallbackMessage = format("Failed to infer schema from %s. Falling back to %s", processedTableFilesPath, archiveTablePath);
+            logger.info(fallbackMessage);
+            return sparkSession.read().parquet(processedTableFilesPath).schema();
+        } catch (Exception ex) {
+            if (rootCauseIsFileNotFound(ex)) {
+                return sparkSession.read().parquet(archiveTablePath).schema();
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    @NotNull
+    private static Boolean rootCauseIsFileNotFound(Exception ex) {
+        // The FileNotFoundException is nested as a root cause of a AnalysisException.
+        // Where AnalysisException isCausedBy SparkException isCausedBy FileNotFoundException
+        val optionalInnerThrowable = Optional.ofNullable(ex.getCause())
+                .flatMap(throwable -> Optional.ofNullable(throwable.getCause()));
+
+        return optionalInnerThrowable.isPresent() && optionalInnerThrowable.get() instanceof FileNotFoundException;
     }
 }

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.stream.Collectors;
@@ -103,8 +105,11 @@ public class JobArguments {
     public static final String FILE_SOURCE_PREFIX = "dpr.file.source.prefix";
     public static final String FILE_TRANSFER_DESTINATION_BUCKET_NAME = "dpr.file.transfer.destination.bucket";
     public static final String FILE_TRANSFER_DESTINATION_PREFIX = "dpr.file.transfer.destination.prefix";
-    public static final String FILE_TRANSFER_RETENTION_DAYS = "dpr.file.transfer.retention.days";
-    static final Long DEFAULT_FILE_TRANSFER_RETENTION_DAYS = 0L;
+    public static final String FILE_TRANSFER_RETENTION_PERIOD_AMOUNT = "dpr.file.transfer.retention.period.amount";
+    static final Long DEFAULT_FILE_TRANSFER_RETENTION_PERIOD_AMOUNT = 0L;
+
+    public static final String FILE_TRANSFER_RETENTION_PERIOD_UNIT = "dpr.file.transfer.retention.period.unit";
+    static final String DEFAULT_FILE_TRANSFER_RETENTION_PERIOD_UNIT = "days";
 
     public static final String FILE_TRANSFER_DELETE_COPIED_FILES_FLAG = "dpr.file.transfer.delete.copied.files";
 
@@ -351,8 +356,21 @@ public class JobArguments {
         return removeLeadingAndTrailingSlashes(getArgument(FILE_TRANSFER_DESTINATION_PREFIX, ""));
     }
 
-    public Long getFileTransferRetentionDays() {
-        return getArgument(FILE_TRANSFER_RETENTION_DAYS, DEFAULT_FILE_TRANSFER_RETENTION_DAYS);
+    public Duration getFileTransferRetentionPeriod() {
+        long retentionAmount = getArgument(FILE_TRANSFER_RETENTION_PERIOD_AMOUNT, DEFAULT_FILE_TRANSFER_RETENTION_PERIOD_AMOUNT);
+        String retentionUnit = getArgument(FILE_TRANSFER_RETENTION_PERIOD_UNIT, DEFAULT_FILE_TRANSFER_RETENTION_PERIOD_UNIT);
+
+        switch (retentionUnit.toLowerCase()) {
+            case "minutes":
+                return Duration.of(retentionAmount, ChronoUnit.MINUTES);
+            case "hours":
+                return Duration.of(retentionAmount, ChronoUnit.HOURS);
+            case "days":
+                return Duration.of(retentionAmount, ChronoUnit.DAYS);
+            default:
+                String error = String.format("Unsupported %s=%s. Allowed values are: minutes, hours, days", FILE_TRANSFER_RETENTION_PERIOD_UNIT, retentionUnit);
+                throw new IllegalArgumentException(error);
+        }
     }
 
     public boolean getFileTransferDeleteCopiedFilesFlag() {

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.service.S3FileService;
 
 import javax.inject.Inject;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.*;
 
 /**
@@ -68,7 +69,7 @@ public class S3DataDeletionJob implements Runnable {
 
         for (String bucketToDeleteFilesFrom : bucketsToDeleteFilesFrom) {
             List<String> listedFiles = s3FileService
-                    .listFilesForConfig(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedExtensions, 0L);
+                    .listFilesForConfig(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedExtensions, Duration.ZERO);
 
             logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
             failedObjects = s3FileService.deleteObjects(listedFiles, bucketToDeleteFilesFrom);

--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -45,6 +45,8 @@ public class SparkSessionProvider {
                 .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
                 .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
                 .set("spark.sql.legacy.charVarcharAsString", "true")
+                // Do not fail when a file gets deleted/archived after it has been read and converted into a dataframe
+                .set("spark.sql.files.ignoreMissingFiles", "true")
                 // We can write dates as is since we will always be using Spark 3+. See SQLConf for context.
                 .set("spark.sql.parquet.datetimeRebaseModeInWrite", "CORRECTED")
                 .set("spark.sql.parquet.datetimeRebaseModeInRead", "CORRECTED")

--- a/src/main/java/uk/gov/justice/digital/service/S3FileService.java
+++ b/src/main/java/uk/gov/justice/digital/service/S3FileService.java
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.client.s3.S3FileTransferClient;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,8 +32,8 @@ public class S3FileService {
         this.clock = clock;
     }
 
-    public List<String> listFiles(String bucket, String sourcePrefix, ImmutableSet<String> allowedExtensions, Long retentionDays) {
-        return s3Client.getObjectsOlderThan(bucket, sourcePrefix, allowedExtensions, retentionDays, clock);
+    public List<String> listFiles(String bucket, String sourcePrefix, ImmutableSet<String> allowedExtensions, Duration retentionPeriod) {
+        return s3Client.getObjectsOlderThan(bucket, sourcePrefix, allowedExtensions, retentionPeriod, clock);
     }
 
     public List<String> listFilesForConfig(
@@ -40,10 +41,10 @@ public class S3FileService {
             String sourcePrefix,
             ImmutableSet<ImmutablePair<String, String>> configuredTables,
             ImmutableSet<String> allowedExtensions,
-            Long retentionDays
+            Duration retentionPeriod
     ) {
         return configuredTables.stream()
-                .flatMap(configuredTable -> listFilesForTable(sourceBucket, sourcePrefix, allowedExtensions, retentionDays, configuredTable).stream())
+                .flatMap(configuredTable -> listFilesForTable(sourceBucket, sourcePrefix, allowedExtensions, retentionPeriod, configuredTable).stream())
                 .collect(Collectors.toList());
     }
 
@@ -100,7 +101,7 @@ public class S3FileService {
             String sourceBucket,
             String sourcePrefix,
             ImmutableSet<String> allowedExtensions,
-            Long retentionDays,
+            Duration retentionPeriod,
             ImmutablePair<String, String> configuredTable
     ) {
         String tableKey = sourcePrefix.isEmpty() ?
@@ -111,7 +112,7 @@ public class S3FileService {
                 sourceBucket,
                 tableKey,
                 allowedExtensions,
-                retentionDays,
+                retentionPeriod,
                 clock
         );
     }

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3FileTransferClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3FileTransferClientTest.java
@@ -16,7 +16,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.JobArguments;
 
+import java.time.Duration;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -52,6 +54,7 @@ public class S3FileTransferClientTest {
     private static final String DESTINATION_BUCKET = "test-destination-bucket";
     private static final ImmutableSet<String> allowedExtensions = ImmutableSet.of(".parquet", ".json");
     private static final Integer MAX_OBJECTS_PER_PAGE = 10;
+    private static final Duration zeroDayRetentionPeriod = Duration.of(0L, ChronoUnit.DAYS);
 
     private S3FileTransferClient underTest;
     @BeforeEach
@@ -112,7 +115,7 @@ public class S3FileTransferClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, allowedExtensions, 0L, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, allowedExtensions, zeroDayRetentionPeriod, fixedClock);
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
@@ -147,7 +150,7 @@ public class S3FileTransferClientTest {
 
         givenMultiPageObjectListingSucceeds(firstPageSummaries, secondPageSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, ImmutableSet.of(".parquet"), 0L, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, ImmutableSet.of(".parquet"), zeroDayRetentionPeriod, fixedClock);
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
@@ -178,7 +181,7 @@ public class S3FileTransferClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, ImmutableSet.of("*"), 0L, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, ImmutableSet.of("*"), zeroDayRetentionPeriod, fixedClock);
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
@@ -213,7 +216,7 @@ public class S3FileTransferClientTest {
 
         givenObjectListingSucceeds(allObjectSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, allowedExtensions, 0L, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, allowedExtensions, zeroDayRetentionPeriod, fixedClock);
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
@@ -233,7 +236,7 @@ public class S3FileTransferClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        underTest.getObjectsOlderThan(SOURCE_BUCKET, folder, allowedExtensions, 0L, fixedClock);
+        underTest.getObjectsOlderThan(SOURCE_BUCKET, folder, allowedExtensions, zeroDayRetentionPeriod, fixedClock);
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(listObjectsRequestCaptor.getValue().getPrefix(), is(equalTo(folder)));

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.exception.ConfigServiceException;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
+import java.time.Duration;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -81,7 +82,7 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
                 eq(SOURCE_PREFIX),
                 eq(configuredTables),
                 eq(parquetFileExtension),
-                eq(0L)
+                eq(Duration.ZERO)
         )).thenReturn(objectsToDelete);
 
         when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture()))
@@ -126,7 +127,7 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
                 eq(SOURCE_PREFIX),
                 eq(configuredTables),
                 eq(parquetFileExtension),
-                eq(0L)
+                eq(Duration.ZERO)
         )).thenReturn(objectsToDelete);
 
         when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture())).thenReturn(failedFiles);

--- a/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
@@ -14,6 +14,8 @@ import uk.gov.justice.digital.exception.ConfigServiceException;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -35,7 +37,8 @@ public class S3FileTransferJobTest extends BaseSparkTest {
     private final static String DESTINATION_BUCKET = "destination-bucket";
     private final static String DESTINATION_PREFIX = "destination-prefix";
 
-    private static final long RETENTION_DAYS = 2L;
+    private static final long RETENTION_AMOUNT = 2L;
+    private static final Duration retentionPeriod = Duration.of(RETENTION_AMOUNT, ChronoUnit.DAYS);
 
     private static final ImmutableSet<String> parquetFileExtension = ImmutableSet.of(".parquet");
 
@@ -69,13 +72,13 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getSourcePrefix()).thenReturn(SOURCE_PREFIX);
         when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
         when(mockJobArguments.getTransferDestinationPrefix()).thenReturn(DESTINATION_PREFIX);
-        when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
+        when(mockJobArguments.getFileTransferRetentionPeriod()).thenReturn(retentionPeriod);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
         when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileExtension, RETENTION_DAYS))
+        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileExtension, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
@@ -96,11 +99,11 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getSourcePrefix()).thenReturn(SOURCE_PREFIX);
         when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
         when(mockJobArguments.getTransferDestinationPrefix()).thenReturn(DESTINATION_PREFIX);
-        when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
+        when(mockJobArguments.getFileTransferRetentionPeriod()).thenReturn(retentionPeriod);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
         when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
-        when(mockS3FileService.listFiles(SOURCE_BUCKET, SOURCE_PREFIX, parquetFileExtension, RETENTION_DAYS))
+        when(mockS3FileService.listFiles(SOURCE_BUCKET, SOURCE_PREFIX, parquetFileExtension, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
@@ -129,13 +132,13 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getSourcePrefix()).thenReturn(SOURCE_PREFIX);
         when(mockJobArguments.getTransferDestinationBucket()).thenReturn(DESTINATION_BUCKET);
         when(mockJobArguments.getTransferDestinationPrefix()).thenReturn(DESTINATION_PREFIX);
-        when(mockJobArguments.getFileTransferRetentionDays()).thenReturn(RETENTION_DAYS);
+        when(mockJobArguments.getFileTransferRetentionPeriod()).thenReturn(retentionPeriod);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
         when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileExtension, RETENTION_DAYS))
+        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileExtension, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -49,6 +49,13 @@ public class MinimalTestData {
     });
     public static Encoder<Row> encoder = RowEncoder.apply(TEST_DATA_SCHEMA);
 
+    public static Encoder<Row> encoderWithExtraColumn = RowEncoder.apply(
+            SCHEMA_WITHOUT_METADATA_FIELDS
+                    .add(new StructField(TIMESTAMP, DataTypes.StringType, true, Metadata.empty()))
+                    .add(new StructField(OPERATION, DataTypes.StringType, true, Metadata.empty()))
+                    .add(new StructField("extra_column", DataTypes.StringType, true, Metadata.empty()))
+    );
+
     public static Dataset<Row> inserts(SparkSession spark) {
         return spark.createDataFrame(Arrays.asList(
                 createRow(1, "2023-11-13 10:50:00.123456", Insert, "1"),


### PR DESCRIPTION
This PR:
- Maintains existing behaviour by attempting to infer the schema used for the CDC batch from the raw zone 
- In case a `FileNotFoundException` occurs as a result of CDC files getting archived, it infers the schema from the raw-archive
- Increase the granularity of the duration after which a raw file is archived to allow minutes, hours or days