### PR TITLE
DPR2-712: Annotate primary_key and handle checkpoint_col and update_type columns during validation

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
@@ -13,7 +13,11 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.GlueClientException;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Singleton

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -14,6 +14,8 @@ public class CommonDataFields {
     public static final String ERROR_RAW = "raw";
     public static final String METADATA_KEY = "metadata";
     public static final String VALIDATION_TYPE_KEY = "validationType";
+    public static final String CHECKPOINT_COL = "checkpoint_col";
+    public static final String UPDATE_TYPE = "update_type";
 
     /**
      * The possible entries in the operation column
@@ -41,5 +43,14 @@ public class CommonDataFields {
         return schema
                 .add(DataTypes.createStructField(OPERATION, DataTypes.StringType, false))
                 .add(DataTypes.createStructField(TIMESTAMP, DataTypes.StringType, false));
+    }
+
+    /**
+     * Add the SCD fields to the provided schema
+     */
+    public static StructType withScdFields(StructType schema) {
+        return schema
+                .add(DataTypes.createStructField(CHECKPOINT_COL, DataTypes.StringType, true))
+                .add(DataTypes.createStructField(UPDATE_TYPE, DataTypes.StringType, true));
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -51,7 +51,7 @@ public class ValidationService {
 
     @VisibleForTesting
     Dataset<Row> validateRows(Dataset<Row> df, SourceReference sourceReference, StructType inferredSchema) {
-        StructType schema = withMetadataFields(sourceReference.getSchema());
+        StructType schema = withScdFields(withMetadataFields(sourceReference.getSchema()));
         val validatedDf = validateStringFields(df, sourceReference);
         if (schemasMatch(inferredSchema, schema)) {
             return validatedDf.withColumn(

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -37,11 +37,10 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.common.CommonDataFields.*;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
-import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
-import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 import static uk.gov.justice.digital.service.ViolationService.ZoneName.STRUCTURED_LOAD;
 import static uk.gov.justice.digital.test.MinimalTestData.*;
 
@@ -99,20 +98,20 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(inputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", null),
-                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, null),
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", requiredColumnIsNullMsg),
-                RowFactory.create(4, null, "I", "data", requiredColumnIsNullMsg),
-                RowFactory.create(5, null, null, "data", requiredColumnIsNullMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, requiredColumnIsNullMsg),
-                RowFactory.create(7, null, null, null, requiredColumnIsNullMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", noPkMsg),
-                RowFactory.create(null, null, "U", "data", noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, noPkMsg),
-                RowFactory.create(null, null, "U", null, noPkMsg),
-                RowFactory.create(null, null, null, "data", noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
+                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -136,10 +135,10 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", null),
-                RowFactory.create(2, null, "U", null, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", noPkMsg),
-                RowFactory.create(null, null, "U", "data", noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
+                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -164,8 +163,8 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, misMatchingSchema).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", schemaMisMatchMsg),
-                RowFactory.create(2, null, "U", null, schemaMisMatchMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -186,7 +185,7 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Collections.singletonList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -202,21 +201,21 @@ class ValidationServiceTest extends BaseSparkTest {
                 .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
                 .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)));
 
-        val inferredSchema = withMetadataFields(
+        val inferredSchema = withScdFields(withMetadataFields(
                 new StructType()
                         .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
                         .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
                         .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)))
-        );
+        ));
 
         when(sourceReference.getSchema()).thenReturn(providedSchema);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
 
         val input = Arrays.asList(
-                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp),
-                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp),
-                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp)
+                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE),
+                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE),
+                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE)
         );
 
         val thisInputDf = spark.createDataFrame(input, inferredSchema);
@@ -224,9 +223,9 @@ class ValidationServiceTest extends BaseSparkTest {
         val result = underTest.validateRows(thisInputDf, sourceReference, inferredSchema).collectAsList();
 
         val expected = Arrays.asList(
-                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, null),
-                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, null),
-                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, null)
+                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
+                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
+                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null)
         );
 
         assertEquals(expected.size(), result.size());
@@ -262,20 +261,20 @@ class ValidationServiceTest extends BaseSparkTest {
                 .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
                 .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)));
 
-        val inferredSchema = withMetadataFields(
+        val inferredSchema = withScdFields(withMetadataFields(
                 new StructType()
                         .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
                         .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
                         .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)))
-        );
+        ));
 
         when(sourceReference.getSchema()).thenReturn(providedSchema);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
 
         List<Row> input = Arrays.asList(
-                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp),
-                RowFactory.create(2, validTime, null, Update.getName(), timestamp)
+                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE),
+                RowFactory.create(2, validTime, null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE)
         );
         
         Dataset<Row> thisInputDf = spark.createDataFrame(input, inferredSchema);
@@ -284,8 +283,8 @@ class ValidationServiceTest extends BaseSparkTest {
 
         String validationErrors = "hyphenated-col must have format HH:mm:ss; underscored_col must have format HH:mm:ss";
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, validationErrors),
-                RowFactory.create(2, validTime, null, Update.getName(), timestamp, null)
+                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, validationErrors),
+                RowFactory.create(2, validTime, null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null)
         );
 
         assertEquals(expected.size(), result.size());
@@ -323,18 +322,18 @@ class ValidationServiceTest extends BaseSparkTest {
         underTest.handleValidation(spark, inputDf, sourceReference, TEST_DATA_SCHEMA, STRUCTURED_LOAD).collectAsList();
 
         List<Row> expectedInvalid = Arrays.asList(
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", requiredColumnIsNullMsg),
-                RowFactory.create(4, null, "I", "data", requiredColumnIsNullMsg),
-                RowFactory.create(5, null, null, "data", requiredColumnIsNullMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, requiredColumnIsNullMsg),
-                RowFactory.create(7, null, null, null, requiredColumnIsNullMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", noPkMsg),
-                RowFactory.create(null, null, "U", "data", noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, noPkMsg),
-                RowFactory.create(null, null, "U", null, noPkMsg),
-                RowFactory.create(null, null, null, "data", noPkMsg)
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
         );
 
         verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(source), eq(table), eq(STRUCTURED_LOAD));
@@ -357,20 +356,20 @@ class ValidationServiceTest extends BaseSparkTest {
         underTest.handleValidation(spark, inputDf, sourceReference, misMatchingSchema, STRUCTURED_LOAD).collectAsList();
 
         List<Row> expectedInvalid = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", schemaMisMatchMsg),
-                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, schemaMisMatchMsg),
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", schemaMisMatchMsg),
-                RowFactory.create(4, null, "I", "data", schemaMisMatchMsg),
-                RowFactory.create(5, null, null, "data", schemaMisMatchMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, schemaMisMatchMsg),
-                RowFactory.create(7, null, null, null, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", schemaMisMatchMsg),
-                RowFactory.create(null, null, "U", "data", schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, schemaMisMatchMsg),
-                RowFactory.create(null, null, "U", null, schemaMisMatchMsg),
-                RowFactory.create(null, null, null, "data", schemaMisMatchMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg)
         );
 
         verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(source), eq(table), eq(STRUCTURED_LOAD));

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -16,15 +16,16 @@ import uk.gov.justice.digital.datahub.model.SourceReference;
 import java.util.Arrays;
 import java.util.List;
 
-import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.*;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
-import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
 
 public class MinimalTestData {
     public static final String PRIMARY_KEY_COLUMN = "pk";
     public static final String DATA_COLUMN = "data";
+    public static final String CHECKPOINT_COL_VALUE = "scn";
+    public static final String UPDATE_TYPE_VALUE = "incremental";
 
     public static final SourceReference.PrimaryKey PRIMARY_KEY = new SourceReference.PrimaryKey(PRIMARY_KEY_COLUMN);
 
@@ -34,6 +35,8 @@ public class MinimalTestData {
             new StructField(TIMESTAMP, DataTypes.StringType, true, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, true, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
+            new StructField(CHECKPOINT_COL, DataTypes.StringType, true, Metadata.empty()),
+            new StructField(UPDATE_TYPE, DataTypes.StringType, true, Metadata.empty())
     });
 
     public static final StructType SCHEMA_WITHOUT_METADATA_FIELDS = new StructType(new StructField[]{
@@ -46,15 +49,10 @@ public class MinimalTestData {
             new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
+            new StructField(CHECKPOINT_COL, DataTypes.StringType, false, Metadata.empty()),
+            new StructField(UPDATE_TYPE, DataTypes.StringType, false, Metadata.empty())
     });
     public static Encoder<Row> encoder = RowEncoder.apply(TEST_DATA_SCHEMA);
-
-    public static Encoder<Row> encoderWithExtraColumn = RowEncoder.apply(
-            SCHEMA_WITHOUT_METADATA_FIELDS
-                    .add(new StructField(TIMESTAMP, DataTypes.StringType, true, Metadata.empty()))
-                    .add(new StructField(OPERATION, DataTypes.StringType, true, Metadata.empty()))
-                    .add(new StructField("extra_column", DataTypes.StringType, true, Metadata.empty()))
-    );
 
     public static Dataset<Row> inserts(SparkSession spark) {
         return spark.createDataFrame(Arrays.asList(
@@ -125,7 +123,7 @@ public class MinimalTestData {
         } else {
             operationName = null;
         }
-        return RowFactory.create(pk, timestamp, operationName, data);
+        return RowFactory.create(pk, timestamp, operationName, data, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE);
      }
 
      private MinimalTestData() {}


### PR DESCRIPTION
This PR
- Annotates the primary key(s) with the text `primary_key` when creating the Hive tables
- Adds the columns `checkpoint_col` and `update_type` to the in-memory schema to allow successful schema validation. This is required because the raw data being validated now contains both columns

![raw-archive-hive-table-update](https://github.com/ministryofjustice/digital-prison-reporting-jobs/assets/136330532/ad8426b4-92ae-4851-910f-f47c58ea5324)

[link to Hive table in dev](https://eu-west-2.console.aws.amazon.com/glue/home?region=eu-west-2#/v2/data-catalog/tables/view/nomis_staff_user_accounts?database=raw_archive&catalogId=771283872747&versionId=latest)
