### PR TITLE
DPR2-713: Add job to stop DMS task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     compileOnly "com.amazonaws:AWSGlueETL:$glueApiVersion"
 
     implementation "com.amazonaws:aws-java-sdk-glue:$awsSdkVersion"
+    implementation "com.amazonaws:aws-java-sdk-dms:$awsSdkVersion"
     implementation "org.apache.spark:spark-avro_2.12:$sparkVersion"
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -61,8 +61,10 @@ class JobArgumentsIntegrationTest {
             { JobArguments.FILE_TRANSFER_SOURCE_BUCKET_NAME, "dpr-source-bucket" },
             { JobArguments.FILE_TRANSFER_DESTINATION_BUCKET_NAME, "dpr-destination-bucket" },
             { JobArguments.FILE_SOURCE_PREFIX, "dpr-source-prefix" },
-            { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, "5" },
-            { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, "10" },
+            { JobArguments.STOP_GLUE_INSTANCE_JOB_NAME, "dpr-glue-job-name" },
+            { JobArguments.DMS_REPLICATION_TASK_ID, "dpr-dms-task-id" },
+            { JobArguments.ORCHESTRATION_WAIT_INTERVAL_SECONDS, "5" },
+            { JobArguments.ORCHESTRATION_MAX_ATTEMPTS, "10" },
             { JobArguments.MAX_S3_PAGE_SIZE, "100" },
             { JobArguments.CLEAN_CDC_CHECKPOINT, "false" },
             { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, "60" },
@@ -110,8 +112,10 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.FILE_TRANSFER_SOURCE_BUCKET_NAME, validArguments.getTransferSourceBucket() },
                 { JobArguments.FILE_TRANSFER_DESTINATION_BUCKET_NAME, validArguments.getTransferDestinationBucket() },
                 { JobArguments.FILE_SOURCE_PREFIX, validArguments.getSourcePrefix() },
-                { JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, validArguments.glueOrchestrationWaitIntervalSeconds() },
-                { JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS, validArguments.glueOrchestrationMaxAttempts() },
+                { JobArguments.STOP_GLUE_INSTANCE_JOB_NAME, validArguments.getStopGlueInstanceJobName() },
+                { JobArguments.DMS_REPLICATION_TASK_ID, validArguments.getDmsTaskId() },
+                { JobArguments.ORCHESTRATION_WAIT_INTERVAL_SECONDS, validArguments.orchestrationWaitIntervalSeconds() },
+                { JobArguments.ORCHESTRATION_MAX_ATTEMPTS, validArguments.orchestrationMaxAttempts() },
                 { JobArguments.MAX_S3_PAGE_SIZE, validArguments.getMaxObjectsPerPage() },
                 { JobArguments.CLEAN_CDC_CHECKPOINT, validArguments.cleanCdcCheckpoint() },
                 { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, validArguments.getBroadcastTimeoutSeconds() },
@@ -343,19 +347,19 @@ class JobArgumentsIntegrationTest {
     }
 
     @Test
-    public void shouldDefaultGlueOrchestrationWaitIntervalSecondsWhenMissing() {
+    public void shouldDefaultOrchestrationWaitIntervalSecondsWhenMissing() {
         HashMap<String, String> args = cloneTestArguments();
-        args.remove(JobArguments.GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS);
+        args.remove(JobArguments.ORCHESTRATION_WAIT_INTERVAL_SECONDS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(10, jobArguments.glueOrchestrationWaitIntervalSeconds());
+        assertEquals(10, jobArguments.orchestrationWaitIntervalSeconds());
     }
 
     @Test
-    public void shouldDefaultGlueOrchestrationMaxAttemptsWhenMissing() {
+    public void shouldDefaultOrchestrationMaxAttemptsWhenMissing() {
         HashMap<String, String> args = cloneTestArguments();
-        args.remove(JobArguments.GLUE_ORCHESTRATION_MAX_ATTEMPTS);
+        args.remove(JobArguments.ORCHESTRATION_MAX_ATTEMPTS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(20, jobArguments.glueOrchestrationMaxAttempts());
+        assertEquals(20, jobArguments.orchestrationMaxAttempts());
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/justice/digital/client/dms/DmsClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/dms/DmsClient.java
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.client.dms;
+
+import com.amazonaws.services.databasemigrationservice.AWSDatabaseMigrationService;
+import com.amazonaws.services.databasemigrationservice.model.DescribeReplicationTasksRequest;
+import com.amazonaws.services.databasemigrationservice.model.Filter;
+import com.amazonaws.services.databasemigrationservice.model.ReplicationTask;
+import com.amazonaws.services.databasemigrationservice.model.StopReplicationTaskRequest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.exception.DmsClientException;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class DmsClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(DmsClient.class);
+
+    private final AWSDatabaseMigrationService awsDms;
+
+    @Inject
+    public DmsClient(DmsClientProvider dmsClientProvider) {
+        this.awsDms = dmsClientProvider.getClient();
+    }
+
+    public void stopTask(String taskId, int waitIntervalSeconds, int maxAttempts) {
+        Optional<ReplicationTask> optionalTask = getTask(taskId);
+        optionalTask.ifPresent(task -> {
+                    StopReplicationTaskRequest stopReplicationTaskRequest = new StopReplicationTaskRequest()
+                            .withReplicationTaskArn(task.getReplicationTaskArn());
+
+                    if (task.getStatus().equalsIgnoreCase("running")) {
+                        logger.info("Stopping replication task {}", taskId);
+                        awsDms.stopReplicationTask(stopReplicationTaskRequest);
+
+                        try {
+                            ensureState(taskId, "stopped", waitIntervalSeconds, maxAttempts);
+                        } catch (InterruptedException e) {
+                            logger.error("Error while ensuring task {} has stopped", taskId, e);
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        logger.info("Replication task {} is not running", taskId);
+                    }
+                }
+        );
+    }
+
+    private void ensureState(String taskId, String state, int waitIntervalSeconds, int maxAttempts) throws InterruptedException {
+        for (int attempts = 0; attempts < maxAttempts; attempts++) {
+            logger.info("Ensuring replication task {} is in {} state. Attempt {}", taskId, state, attempts);
+            Optional<ReplicationTask> optionalTask = getTask(taskId);
+            if (optionalTask.isPresent() && optionalTask.get().getStatus().equalsIgnoreCase(state)) {
+                return;
+            }
+
+            TimeUnit.SECONDS.sleep(waitIntervalSeconds);
+        }
+
+        String errorMessage = String.format("Exhausted attempts waiting for replication task %s to be %s", taskId, state);
+        throw new DmsClientException(errorMessage);
+    }
+
+    @NotNull
+    private Optional<ReplicationTask> getTask(String taskId) {
+        logger.info("Retrieving replication task {}", taskId);
+        val describeReplicationTasksRequest = new DescribeReplicationTasksRequest()
+                .withFilters(new Filter().withName("replication-task-id").withValues(taskId))
+                .withWithoutSettings(true);
+
+        return awsDms.describeReplicationTasks(describeReplicationTasksRequest)
+                .getReplicationTasks()
+                .stream()
+                .findFirst();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/client/dms/DmsClientProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/dms/DmsClientProvider.java
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.client.dms;
+
+import com.amazonaws.services.databasemigrationservice.AWSDatabaseMigrationService;
+import com.amazonaws.services.databasemigrationservice.AWSDatabaseMigrationServiceClientBuilder;
+import jakarta.inject.Singleton;
+import uk.gov.justice.digital.client.ClientProvider;
+
+@Singleton
+public class DmsClientProvider implements ClientProvider<AWSDatabaseMigrationService> {
+
+    @Override
+    public AWSDatabaseMigrationService getClient() {
+        return AWSDatabaseMigrationServiceClientBuilder.defaultClient();
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3ObjectClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3ObjectClient.java
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.client.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.config.JobArguments;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
+
+@Singleton
+public class S3ObjectClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3ObjectClient.class);
+
+    private final AmazonS3 s3;
+    private final Integer maxObjectsPerPage;
+    public static final String DELIMITER = "/";
+
+    @Inject
+    public S3ObjectClient(S3ClientProvider s3ClientProvider, JobArguments jobArguments) {
+        this.s3 = s3ClientProvider.getClient();
+        this.maxObjectsPerPage = jobArguments.getMaxObjectsPerPage();
+    }
+
+    public List<String> getObjectsOlderThan(String bucket, ImmutableSet<String> allowedExtensions, Duration retentionPeriod, Clock clock) {
+        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withMaxKeys(maxObjectsPerPage);
+        return listObjects(allowedExtensions, retentionPeriod, clock, request);
+    }
+
+    public List<String> getObjectsOlderThan(
+            String bucket,
+            String folder,
+            ImmutableSet<String> allowedExtensions,
+            Duration retentionPeriod,
+            Clock clock
+    ) {
+        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withPrefix(folder).withMaxKeys(maxObjectsPerPage);
+        return listObjects(allowedExtensions, retentionPeriod, clock, request);
+    }
+
+    private List<String> listObjects(ImmutableSet<String> allowedExtensions, Duration retentionPeriod, Clock clock, ListObjectsRequest request) {
+        LocalDateTime currentDate = LocalDateTime.now(clock);
+        List<String> objectPaths = new LinkedList<>();
+        ObjectListing objectList;
+        do {
+            objectList = s3.listObjects(request);
+            List<S3ObjectSummary> objectSummaries = objectList.getObjectSummaries();
+            logger.info("Listed a total of {} objects", objectSummaries.size());
+            for (S3ObjectSummary summary : objectSummaries) {
+
+                LocalDateTime lastModifiedDate = summary.getLastModified().toInstant().atZone(clock.getZone()).toLocalDateTime();
+                boolean isBeforeRetentionPeriod = lastModifiedDate.isBefore(currentDate.minus(retentionPeriod));
+
+                String summaryKey = summary.getKey();
+                logger.debug("Listed {}", summaryKey);
+
+                boolean extensionAllowed = allowedExtensions.contains("*") || allowedExtensions.contains(getFileExtension(summaryKey));
+
+                if (!summaryKey.endsWith(DELIMITER) && extensionAllowed && isBeforeRetentionPeriod) {
+                    logger.debug("Adding {}", summaryKey);
+                    objectPaths.add(summaryKey);
+                }
+            }
+            request.setMarker(objectList.getNextMarker());
+        } while (objectList.isTruncated());
+
+        return objectPaths;
+    }
+
+    public void copyObject(String sourceKey, String destinationKey, String sourceBucket, String destinationBucket) {
+        logger.info("Copying {}", sourceKey);
+        s3.copyObject(sourceBucket, sourceKey, destinationBucket, destinationKey);
+    }
+
+    public void deleteObject(String objectKey, String sourceBucket) {
+        logger.info("Deleting {}", objectKey);
+        s3.deleteObject(sourceBucket, objectKey);
+    }
+
+    private static String getFileExtension(String summaryKey) {
+        String[] splits = summaryKey.split("\\.");
+        return "." + splits[splits.length - 1].toLowerCase();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -18,7 +18,7 @@ import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.stream.Collectors;
 
-import static uk.gov.justice.digital.client.s3.S3FileTransferClient.DELIMITER;
+import static uk.gov.justice.digital.client.s3.S3ObjectClient.DELIMITER;
 
 /**
  * Class that defines and provides access to the job arguments that we support.
@@ -117,11 +117,12 @@ public class JobArguments {
     static final String FILE_DELETION_BUCKETS = "dpr.file.deletion.buckets";
     // A comma separated list of s3 file extensions. The wildcard '*' includes all extensions.
     static final String ALLOWED_S3_FILE_EXTENSIONS = "dpr.allowed.s3.file.extensions";
-    static final String GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.glue.orchestration.wait.interval.seconds";
-    static final int DEFAULT_GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 10;
-    static final String GLUE_ORCHESTRATION_MAX_ATTEMPTS = "dpr.glue.orchestration.max.attempts";
-    static final int DEFAULT_GLUE_ORCHESTRATION_MAX_ATTEMPTS = 20;
+    static final String ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.orchestration.wait.interval.seconds";
+    static final int DEFAULT_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 10;
+    static final String ORCHESTRATION_MAX_ATTEMPTS = "dpr.orchestration.max.attempts";
+    static final int DEFAULT_ORCHESTRATION_MAX_ATTEMPTS = 20;
     static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";
+    static final String DMS_REPLICATION_TASK_ID = "dpr.dms.replication.task.id";
     static final String MAX_S3_PAGE_SIZE = "dpr.s3.max.page.size";
     static final Integer DEFAULT_MAX_S3_PAGE_SIZE = 1000;
     static final String CLEAN_CDC_CHECKPOINT = "dpr.clean.cdc.checkpoint";
@@ -405,12 +406,16 @@ public class JobArguments {
         return getArgument(STOP_GLUE_INSTANCE_JOB_NAME);
     }
 
-    public int glueOrchestrationWaitIntervalSeconds() {
-        return getArgument(GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS, DEFAULT_GLUE_ORCHESTRATION_WAIT_INTERVAL_SECONDS);
+    public String getDmsTaskId() {
+        return getArgument(DMS_REPLICATION_TASK_ID);
     }
 
-    public int glueOrchestrationMaxAttempts() {
-        return getArgument(GLUE_ORCHESTRATION_MAX_ATTEMPTS, DEFAULT_GLUE_ORCHESTRATION_MAX_ATTEMPTS);
+    public int orchestrationWaitIntervalSeconds() {
+        return getArgument(ORCHESTRATION_WAIT_INTERVAL_SECONDS, DEFAULT_ORCHESTRATION_WAIT_INTERVAL_SECONDS);
+    }
+
+    public int orchestrationMaxAttempts() {
+        return getArgument(ORCHESTRATION_MAX_ATTEMPTS, DEFAULT_ORCHESTRATION_MAX_ATTEMPTS);
     }
 
     public Integer getMaxObjectsPerPage() {

--- a/src/main/java/uk/gov/justice/digital/exception/DmsClientException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/DmsClientException.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.exception;
+
+public class DmsClientException extends RuntimeException {
+
+    private static final long serialVersionUID = -6423158118665870705L;
+
+    public DmsClientException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public DmsClientException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/job/StopDmsTaskJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/StopDmsTaskJob.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.job;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.job.context.MicronautContext;
+import uk.gov.justice.digital.service.DmsOrchestrationService;
+
+import javax.inject.Inject;
+
+/**
+ * Job stops a DMS task.
+ */
+@CommandLine.Command(name = "StopDmsTaskJob")
+public class StopDmsTaskJob implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(StopDmsTaskJob.class);
+    private final DmsOrchestrationService dmsOrchestrationService;
+    private final JobArguments jobArguments;
+
+    @Inject
+    public StopDmsTaskJob(
+            DmsOrchestrationService dmsOrchestrationService,
+            JobArguments jobArguments
+    ) {
+        this.dmsOrchestrationService = dmsOrchestrationService;
+        this.jobArguments = jobArguments;
+    }
+
+    public static void main(String[] args) {
+        logger.info("Job starting");
+        PicocliRunner.run(StopDmsTaskJob.class, MicronautContext.withArgs(args));
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("StopDmsTaskJob running");
+
+            dmsOrchestrationService.stopTask(jobArguments.getDmsTaskId());
+
+            logger.info("StopDmsTaskJob finished");
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/DmsOrchestrationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DmsOrchestrationService.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.client.dms.DmsClient;
+import uk.gov.justice.digital.config.JobArguments;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class DmsOrchestrationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DmsOrchestrationService.class);
+
+    private final JobArguments jobArguments;
+
+    private final DmsClient dmsClient;
+
+    @Inject
+    public DmsOrchestrationService(JobArguments jobArguments, DmsClient dmsClient) {
+        this.jobArguments = jobArguments;
+        this.dmsClient = dmsClient;
+    }
+
+    public void stopTask(String taskId) {
+        int waitIntervalSeconds = jobArguments.orchestrationWaitIntervalSeconds();
+        int maxAttempts = jobArguments.orchestrationMaxAttempts();
+
+        logger.info("Stopping DMS task {}", taskId);
+        dmsClient.stopTask(taskId, waitIntervalSeconds, maxAttempts);
+        logger.info("Stopped DMS task {}", taskId);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/GlueOrchestrationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/GlueOrchestrationService.java
@@ -24,8 +24,8 @@ public class GlueOrchestrationService {
     }
 
     public void stopJob(String jobName) {
-        int waitIntervalSeconds = jobArguments.glueOrchestrationWaitIntervalSeconds();
-        int maxAttempts = jobArguments.glueOrchestrationMaxAttempts();
+        int waitIntervalSeconds = jobArguments.orchestrationWaitIntervalSeconds();
+        int maxAttempts = jobArguments.orchestrationMaxAttempts();
 
         logger.info("Stopping Glue job {}", jobName);
         glueClient.stopJob(jobName, waitIntervalSeconds, maxAttempts);

--- a/src/test/java/uk/gov/justice/digital/client/dms/DmsClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/dms/DmsClientTest.java
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.client.dms;
+
+import com.amazonaws.services.databasemigrationservice.AWSDatabaseMigrationService;
+import com.amazonaws.services.databasemigrationservice.model.DescribeReplicationTasksResult;
+import com.amazonaws.services.databasemigrationservice.model.DescribeReplicationTasksRequest;
+import com.amazonaws.services.databasemigrationservice.model.Filter;
+import com.amazonaws.services.databasemigrationservice.model.ReplicationTask;
+import com.amazonaws.services.databasemigrationservice.model.StopReplicationTaskResult;
+import com.amazonaws.services.databasemigrationservice.model.StopReplicationTaskRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DmsClientTest {
+
+    @Mock
+    private DmsClientProvider mockClientProvider;
+    @Mock
+    private AWSDatabaseMigrationService mockDmsClient;
+    @Mock
+    private DescribeReplicationTasksResult mockDescribeReplicationTasksResult;
+    @Mock
+    private StopReplicationTaskResult mockStopReplicationTaskResult;
+    @Captor
+    private ArgumentCaptor<DescribeReplicationTasksRequest> describeReplicationTasksRequestCaptor;
+    @Captor
+    private ArgumentCaptor<StopReplicationTaskRequest> stopReplicationTaskRequestCaptor;
+
+    private static final String TEST_TASK_ID = "test_task_id";
+    private static final int WAIT_INTERVAL_SECONDS = 1;
+    private static final int MAX_ATTEMPTS = 1;
+
+    private DmsClient underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockClientProvider, mockDmsClient, mockDescribeReplicationTasksResult, mockStopReplicationTaskResult);
+
+        when(mockClientProvider.getClient()).thenReturn(mockDmsClient);
+        underTest = new DmsClient(mockClientProvider);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void stopTaskShouldStopRunningDmsTaskWhenThereIsOne() {
+        List<ReplicationTask> runningTasks = new ArrayList<>();
+        runningTasks.add(createReplicationTask("running").withReplicationTaskArn("replication-task-arn"));
+
+        List<ReplicationTask> stoppedTasks = new ArrayList<>();
+        stoppedTasks.add(createReplicationTask("stopped").withReplicationTaskArn("replication-task-arn"));
+
+        when(mockDescribeReplicationTasksResult.getReplicationTasks()).thenReturn(runningTasks, stoppedTasks);
+        when(mockDmsClient.describeReplicationTasks(describeReplicationTasksRequestCaptor.capture()))
+                .thenReturn(mockDescribeReplicationTasksResult);
+        when(mockDmsClient.stopReplicationTask(stopReplicationTaskRequestCaptor.capture()))
+                .thenReturn(mockStopReplicationTaskResult);
+
+        underTest.stopTask(TEST_TASK_ID, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+
+        StopReplicationTaskRequest stopReplicationTaskRequest = stopReplicationTaskRequestCaptor.getValue();
+        assertThat(stopReplicationTaskRequest.getReplicationTaskArn(), equalTo("replication-task-arn"));
+        verifyDescribeReplicationTasksRequestParams(describeReplicationTasksRequestCaptor.getValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void stopTaskShouldNotFailWhenTaskIsAlreadyStopped() {
+        List<ReplicationTask> stoppedTasks = new ArrayList<>();
+        stoppedTasks.add(createReplicationTask("stopped").withReplicationTaskArn("replication-task-arn"));
+
+        when(mockDescribeReplicationTasksResult.getReplicationTasks()).thenReturn(stoppedTasks);
+        when(mockDmsClient.describeReplicationTasks(describeReplicationTasksRequestCaptor.capture()))
+                .thenReturn(mockDescribeReplicationTasksResult);
+
+        underTest.stopTask(TEST_TASK_ID, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+
+        verifyDescribeReplicationTasksRequestParams(describeReplicationTasksRequestCaptor.getValue());
+        verifyNoMoreInteractions(mockDmsClient);
+    }
+
+    @Test
+    void stopTaskShouldNotFailWhenThereIsNoRunningReplicationTask() {
+        List<ReplicationTask> tasks = Collections.emptyList();
+
+        when(mockDescribeReplicationTasksResult.getReplicationTasks()).thenReturn(tasks);
+        when(mockDmsClient.describeReplicationTasks(describeReplicationTasksRequestCaptor.capture())).thenReturn(mockDescribeReplicationTasksResult);
+
+        underTest.stopTask(TEST_TASK_ID, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+
+        verifyDescribeReplicationTasksRequestParams(describeReplicationTasksRequestCaptor.getValue());
+        verifyNoMoreInteractions(mockDescribeReplicationTasksResult);
+    }
+
+    private static void verifyDescribeReplicationTasksRequestParams(DescribeReplicationTasksRequest describeReplicationTasksRequest) {
+        assertThat(
+                new HashSet<>(describeReplicationTasksRequest.getFilters()),
+                containsInAnyOrder(new Filter().withName("replication-task-id").withValues(TEST_TASK_ID))
+        );
+        assertTrue(describeReplicationTasksRequest.getWithoutSettings());
+    }
+
+    private static ReplicationTask createReplicationTask(String state) {
+        return new ReplicationTask().withStatus(state);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/StopDmsTaskJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/StopDmsTaskJobTest.java
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.job;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.DmsClientException;
+import uk.gov.justice.digital.service.DmsOrchestrationService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StopDmsTaskJobTest extends BaseSparkTest {
+
+    @Mock
+    DmsOrchestrationService mockDmsOrchestrationService;
+    @Mock
+    JobArguments mockJobArguments;
+
+    private static final String TEST_TASK_ID = "test_task_id";
+
+    private StopDmsTaskJob underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockDmsOrchestrationService, mockJobArguments);
+
+        underTest = new StopDmsTaskJob(mockDmsOrchestrationService, mockJobArguments);
+    }
+
+    @Test
+    void shouldStopDmsTaskWithGivenDomain() {
+        when(mockJobArguments.getDmsTaskId()).thenReturn(TEST_TASK_ID);
+
+        underTest.run();
+
+        verify(mockDmsOrchestrationService, times(1)).stopTask(TEST_TASK_ID);
+    }
+
+    @Test
+    void shouldFailWhenAnExceptionOccursInService() throws Exception {
+        when(mockJobArguments.getDmsTaskId()).thenReturn(TEST_TASK_ID);
+        doThrow(new DmsClientException("error")).when(mockDmsOrchestrationService).stopTask(any());
+
+        assertEquals(1, SystemLambda.catchSystemExit(() -> underTest.run()));
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/DmsOrchestrationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DmsOrchestrationServiceTest.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.dms.DmsClient;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.exception.DmsClientException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DmsOrchestrationServiceTest {
+
+    @Mock
+    private JobArguments mockJobArguments;
+    @Mock
+    private DmsClient mockDmsClient;
+
+    private static final String TEST_TASK_ID = "test_task_id";
+    private static final int WAIT_INTERVAL_SECONDS = 2;
+    private static final int MAX_ATTEMPTS = 10;
+
+    private DmsOrchestrationService underTest;
+
+    @BeforeEach
+    public void setup() {
+        reset(mockJobArguments, mockDmsClient);
+
+        underTest = new DmsOrchestrationService(mockJobArguments, mockDmsClient);
+    }
+
+    @Test
+    void stopJobShouldStopDmsTaskWithGivenDomainName() {
+        when(mockJobArguments.orchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
+        when(mockJobArguments.orchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+
+        underTest.stopTask(TEST_TASK_ID);
+
+        verify(mockDmsClient, times(1)).stopTask(TEST_TASK_ID, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+    }
+
+    @Test
+    void stopJobShouldFailWhenDmsClientThrowsAnException() {
+        when(mockJobArguments.orchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
+        when(mockJobArguments.orchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+
+        doThrow(new DmsClientException("Client error")).when(mockDmsClient)
+                .stopTask(TEST_TASK_ID, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);
+
+        assertThrows(DmsClientException.class, () -> underTest.stopTask(TEST_TASK_ID));
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/GlueOrchestrationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/GlueOrchestrationServiceTest.java
@@ -35,8 +35,8 @@ public class GlueOrchestrationServiceTest {
 
     @Test
     public void stopJobShouldStopGlueJobWithGivenName() {
-        when(mockJobArguments.glueOrchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
-        when(mockJobArguments.glueOrchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+        when(mockJobArguments.orchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
+        when(mockJobArguments.orchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
 
         underTest.stopJob(TEST_JOB_NAME);
 
@@ -45,8 +45,8 @@ public class GlueOrchestrationServiceTest {
 
     @Test
     public void stopJobShouldFailWhenGlueClientThrowsAnException() {
-        when(mockJobArguments.glueOrchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
-        when(mockJobArguments.glueOrchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+        when(mockJobArguments.orchestrationWaitIntervalSeconds()).thenReturn(WAIT_INTERVAL_SECONDS);
+        when(mockJobArguments.orchestrationMaxAttempts()).thenReturn(MAX_ATTEMPTS);
 
         doThrow(new GlueClientException("Client error")).when(mockGlueClient)
                 .stopJob(TEST_JOB_NAME, WAIT_INTERVAL_SECONDS, MAX_ATTEMPTS);


### PR DESCRIPTION
This PR adds a Glue job to enable stopping a DMS task.
This job will be invoked during the reload and replay pipelines.