### PR TITLE
DPR2-712: Update AP integration fields

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/glue/GlueClient.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
 import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.CHECKPOINT_COL;
 
 @Singleton
 public class GlueClient {
@@ -71,7 +72,7 @@ public class GlueClient {
                 .map(col -> "'" + col.toLowerCase() + "'")
                 .collect(Collectors.joining(",", "[", "]"));
 
-        String extractionKeyFormatted = String.join(",", Stream.of(TIMESTAMP, OPERATION).map(String::toLowerCase)
+        String extractionKeyFormatted = String.join(",", Stream.of(TIMESTAMP, CHECKPOINT_COL).map(String::toLowerCase)
                 .collect(Collectors.toCollection(HashSet::new)));
 
         String primaryKeysFormatted = primaryKey.getKeyColumnNames()

--- a/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
+++ b/src/main/java/uk/gov/justice/digital/common/CommonDataFields.java
@@ -16,7 +16,6 @@ public class CommonDataFields {
     public static final String VALIDATION_TYPE_KEY = "validationType";
     public static final String SENSITIVE_COLUMN_LABEL_KEY = "sensitive";
     public static final String CHECKPOINT_COL = "checkpoint_col";
-    public static final String UPDATE_TYPE = "update_type";
 
     /**
      * The possible entries in the operation column
@@ -47,11 +46,9 @@ public class CommonDataFields {
     }
 
     /**
-     * Add the SCD fields to the provided schema
+     * Add the checkpoint required for AP integration
      */
-    public static StructType withScdFields(StructType schema) {
-        return schema
-                .add(DataTypes.createStructField(CHECKPOINT_COL, DataTypes.StringType, true))
-                .add(DataTypes.createStructField(UPDATE_TYPE, DataTypes.StringType, true));
+    public static StructType withCheckpointField(StructType schema) {
+        return schema.add(DataTypes.createStructField(CHECKPOINT_COL, DataTypes.StringType, true));
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/HiveTableService.java
+++ b/src/main/java/uk/gov/justice/digital/service/HiveTableService.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
-import static uk.gov.justice.digital.common.CommonDataFields.withScdFields;
+import static uk.gov.justice.digital.common.CommonDataFields.withCheckpointField;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 
 @Singleton
@@ -68,7 +68,7 @@ public class HiveTableService {
                 SourceReference.SensitiveColumns sensitiveColumns = sourceReference.getSensitiveColumns();
 
                 String rawArchivePath = createValidatedPath(jobArguments.getRawArchiveS3Path(), sourceName, tableName);
-                StructType rawSchema = withScdFields(withMetadataFields(schema));
+                StructType rawSchema = withCheckpointField(withMetadataFields(schema));
                 replaceParquetInputTables(jobArguments.getRawArchiveDatabase(), hiveTableName, rawArchivePath, rawSchema, primaryKey, sensitiveColumns);
 
                 String structuredPath = createValidatedPath(jobArguments.getStructuredS3Path(), sourceName, tableName);

--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -51,7 +51,7 @@ public class ValidationService {
 
     @VisibleForTesting
     Dataset<Row> validateRows(Dataset<Row> df, SourceReference sourceReference, StructType inferredSchema) {
-        StructType schema = withScdFields(withMetadataFields(sourceReference.getSchema()));
+        StructType schema = withCheckpointField(withMetadataFields(sourceReference.getSchema()));
         val validatedDf = validateStringFields(df, sourceReference);
         if (schemasMatch(inferredSchema, schema)) {
             return validatedDf.withColumn(

--- a/src/test/java/uk/gov/justice/digital/client/glue/GlueClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/glue/GlueClientTest.java
@@ -48,8 +48,9 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.justice.digital.client.glue.GlueClient.MAPRED_PARQUET_INPUT_FORMAT;
 import static uk.gov.justice.digital.client.glue.GlueClient.SYMLINK_INPUT_FORMAT;
-import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
 import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
+import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.CHECKPOINT_COL;
 import static uk.gov.justice.digital.test.Fixtures.PRIMARY_KEY_FIELD;
 import static uk.gov.justice.digital.test.Fixtures.SENSITIVE_FIELD_1;
 import static uk.gov.justice.digital.test.Fixtures.SENSITIVE_FIELD_2;
@@ -131,7 +132,7 @@ class GlueClientTest {
         assertThat(parameters.get("extraction_timestamp_column_name"), is(equalTo(TIMESTAMP.toLowerCase())));
         assertThat(parameters.get("extraction_operation_column_name"), is(equalTo(OPERATION.toLowerCase())));
         assertThat(parameters.get("sensitive_columns"), is(equalTo("['" + SENSITIVE_FIELD_1.toLowerCase() + "','" + SENSITIVE_FIELD_2.toLowerCase() + "']")));
-        assertThat(parameters.get("extraction_key"), is(equalTo(OPERATION.toLowerCase() + "," + TIMESTAMP.toLowerCase())));
+        assertThat(parameters.get("extraction_key"), is(equalTo(CHECKPOINT_COL.toLowerCase() + "," + TIMESTAMP.toLowerCase())));
         assertThat(parameters.get("source_primary_key"), is(equalTo(PRIMARY_KEY_FIELD.toLowerCase())));
     }
 

--- a/src/test/java/uk/gov/justice/digital/service/HiveTableServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/HiveTableServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
-import static uk.gov.justice.digital.common.CommonDataFields.withScdFields;
+import static uk.gov.justice.digital.common.CommonDataFields.withCheckpointField;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.test.Fixtures.JSON_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.Fixtures.TABLE_NAME;
@@ -184,7 +184,7 @@ public class HiveTableServiceTest extends BaseSparkTest {
                         createArchiveDatabaseArgCaptor.capture(),
                         createArchiveTableArgCaptor.capture(),
                         createArchivePathArgCaptor.capture(),
-                        eq(withScdFields(withMetadataFields(JSON_DATA_SCHEMA))),
+                        eq(withCheckpointField(withMetadataFields(JSON_DATA_SCHEMA))),
                         createArchivePrimaryKeyCaptor.capture(),
                         createArchiveSensitiveColumnsCaptor.capture()
                 );

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -98,20 +98,20 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(inputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
-                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, null),
+                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, null),
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, noPkMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -135,10 +135,10 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
-                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, null),
+                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, noPkMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -163,8 +163,8 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, misMatchingSchema).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -185,7 +185,7 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Collections.singletonList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg)
         );
 
         assertEquals(expected.size(), result.size());
@@ -201,7 +201,7 @@ class ValidationServiceTest extends BaseSparkTest {
                 .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
                 .add(new StructField("nullable_time", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)));
 
-        val inferredSchema = withScdFields(withMetadataFields(
+        val inferredSchema = withCheckpointField(withMetadataFields(
                 new StructType()
                         .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
                         .add(new StructField("time", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
@@ -213,9 +213,9 @@ class ValidationServiceTest extends BaseSparkTest {
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
 
         val input = Arrays.asList(
-                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE),
-                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE),
-                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE)
+                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, CHECKPOINT_COL_VALUE),
+                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE),
+                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, CHECKPOINT_COL_VALUE)
         );
 
         val thisInputDf = spark.createDataFrame(input, inferredSchema);
@@ -223,9 +223,9 @@ class ValidationServiceTest extends BaseSparkTest {
         val result = underTest.validateRows(thisInputDf, sourceReference, inferredSchema).collectAsList();
 
         val expected = Arrays.asList(
-                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
-                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null),
-                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null)
+                RowFactory.create(1, "09:00:00", "12:30:00", Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, null),
+                RowFactory.create(2, "23:59:59", null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, null),
+                RowFactory.create(3, "00:00:00", "08:30:30", Delete.getName(), timestamp, CHECKPOINT_COL_VALUE, null)
         );
 
         assertEquals(expected.size(), result.size());
@@ -261,7 +261,7 @@ class ValidationServiceTest extends BaseSparkTest {
                 .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
                 .add(new StructField("hyphenated-col", DataTypes.StringType, true, Metadata.fromJson(VALIDATION_TYPE)));
 
-        val inferredSchema = withScdFields(withMetadataFields(
+        val inferredSchema = withCheckpointField(withMetadataFields(
                 new StructType()
                         .add(new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()))
                         .add(new StructField("underscored_col", DataTypes.StringType, false, Metadata.fromJson(VALIDATION_TYPE)))
@@ -273,8 +273,8 @@ class ValidationServiceTest extends BaseSparkTest {
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
 
         List<Row> input = Arrays.asList(
-                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE),
-                RowFactory.create(2, validTime, null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE)
+                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, CHECKPOINT_COL_VALUE),
+                RowFactory.create(2, validTime, null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE)
         );
         
         Dataset<Row> thisInputDf = spark.createDataFrame(input, inferredSchema);
@@ -283,8 +283,8 @@ class ValidationServiceTest extends BaseSparkTest {
 
         String validationErrors = "hyphenated-col must have format HH:mm:ss; underscored_col must have format HH:mm:ss";
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, validationErrors),
-                RowFactory.create(2, validTime, null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, null)
+                RowFactory.create(1, invalidTime, invalidTime, Insert.getName(), timestamp, CHECKPOINT_COL_VALUE, validationErrors),
+                RowFactory.create(2, validTime, null, Update.getName(), timestamp, CHECKPOINT_COL_VALUE, null)
         );
 
         assertEquals(expected.size(), result.size());
@@ -322,18 +322,18 @@ class ValidationServiceTest extends BaseSparkTest {
         underTest.handleValidation(spark, inputDf, sourceReference, TEST_DATA_SCHEMA, STRUCTURED_LOAD).collectAsList();
 
         List<Row> expectedInvalid = Arrays.asList(
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg),
-                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, noPkMsg)
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, noPkMsg)
         );
 
         verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(source), eq(table), eq(STRUCTURED_LOAD));
@@ -356,20 +356,20 @@ class ValidationServiceTest extends BaseSparkTest {
         underTest.handleValidation(spark, inputDf, sourceReference, misMatchingSchema, STRUCTURED_LOAD).collectAsList();
 
         List<Row> expectedInvalid = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE, schemaMisMatchMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg)
         );
 
         verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(source), eq(table), eq(STRUCTURED_LOAD));

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -24,8 +24,7 @@ import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.
 public class MinimalTestData {
     public static final String PRIMARY_KEY_COLUMN = "pk";
     public static final String DATA_COLUMN = "data";
-    public static final String CHECKPOINT_COL_VALUE = "scn";
-    public static final String UPDATE_TYPE_VALUE = "incremental";
+    public static final String CHECKPOINT_COL_VALUE = "some-database-sequence-number";
 
     public static final SourceReference.PrimaryKey PRIMARY_KEY = new SourceReference.PrimaryKey(PRIMARY_KEY_COLUMN);
 
@@ -35,8 +34,7 @@ public class MinimalTestData {
             new StructField(TIMESTAMP, DataTypes.StringType, true, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, true, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
-            new StructField(CHECKPOINT_COL, DataTypes.StringType, true, Metadata.empty()),
-            new StructField(UPDATE_TYPE, DataTypes.StringType, true, Metadata.empty())
+            new StructField(CHECKPOINT_COL, DataTypes.StringType, true, Metadata.empty())
     });
 
     public static final StructType SCHEMA_WITHOUT_METADATA_FIELDS = new StructType(new StructField[]{
@@ -49,8 +47,7 @@ public class MinimalTestData {
             new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
-            new StructField(CHECKPOINT_COL, DataTypes.StringType, false, Metadata.empty()),
-            new StructField(UPDATE_TYPE, DataTypes.StringType, false, Metadata.empty())
+            new StructField(CHECKPOINT_COL, DataTypes.StringType, false, Metadata.empty())
     });
     public static Encoder<Row> encoder = RowEncoder.apply(TEST_DATA_SCHEMA);
 
@@ -123,7 +120,7 @@ public class MinimalTestData {
         } else {
             operationName = null;
         }
-        return RowFactory.create(pk, timestamp, operationName, data, CHECKPOINT_COL_VALUE, UPDATE_TYPE_VALUE);
+        return RowFactory.create(pk, timestamp, operationName, data, CHECKPOINT_COL_VALUE);
      }
 
      private MinimalTestData() {}


### PR DESCRIPTION
This PR
- Removes the `update_type` column as it is no longer required for the AP integration
- Adds the `checkpoint_col` to the extraction key when creating the hive tables