### PR TITLE
DPR2-895: Use micronaut to enable or disable operational datastore functionality

### DIFF
--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
@@ -120,7 +121,7 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         OperationalDataStoreDataAccess operationalDataStoreDataAccess = new OperationalDataStoreDataAccess(connectionDetailsService);
-        OperationalDataStoreServiceImpl operationalDataStoreService =
+        OperationalDataStoreService operationalDataStoreService =
                 new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
         BatchProcessor batchProcessor = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
         underTest = new DataHubBatchJob(

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
-import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
 import uk.gov.justice.digital.zone.structured.StructuredZoneLoad;
 
@@ -57,7 +57,6 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
 
     @BeforeEach
     public void setUp() throws SQLException {
-        givenOperationalDataStoreWriteIsEnabled();
         givenDatastoreCredentials();
         givenPathsAreConfigured(arguments);
         givenTableConfigIsConfigured(arguments, configService);
@@ -121,8 +120,8 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         OperationalDataStoreDataAccess operationalDataStoreDataAccess = new OperationalDataStoreDataAccess(connectionDetailsService);
-        OperationalDataStoreService operationalDataStoreService =
-                new OperationalDataStoreService(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
+        OperationalDataStoreServiceImpl operationalDataStoreService =
+                new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
         BatchProcessor batchProcessor = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
         underTest = new DataHubBatchJob(
                 arguments,
@@ -139,10 +138,6 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
     private void givenGlobPatternIsConfigured() {
         // Pattern for data written by Spark as input in tests instead of by DMS
         when(arguments.getBatchLoadFileGlobPattern()).thenReturn("part-*parquet");
-    }
-
-    private void givenOperationalDataStoreWriteIsEnabled() {
-        when(arguments.isOperationalDataStoreWriteEnabled()).thenReturn(true);
     }
 
     private void givenDatastoreCredentials() {

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
-import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
 import uk.gov.justice.digital.test.BaseMinimalDataIntegrationTest;
 import uk.gov.justice.digital.test.InMemoryOperationalDataStore;
@@ -81,7 +81,6 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        givenOperationalDataStoreWriteIsEnabled();
         givenDatastoreCredentials();
         givenPathsAreConfigured();
         givenRetrySettingsAreConfigured(arguments);
@@ -253,8 +252,8 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         OperationalDataStoreDataAccess operationalDataStoreDataAccess = new OperationalDataStoreDataAccess(connectionDetailsService);
-        OperationalDataStoreService operationalDataStoreService =
-                new OperationalDataStoreService(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
+        OperationalDataStoreServiceImpl operationalDataStoreService =
+                new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
         underTest = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
     }
 
@@ -288,10 +287,6 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                         credentials
                 )
         );
-    }
-
-    private void givenOperationalDataStoreWriteIsEnabled() {
-        when(arguments.isOperationalDataStoreWriteEnabled()).thenReturn(true);
     }
 
     private void thenStructuredCuratedAndOperationalDataStoreContainForPK(String data, int primaryKey) throws SQLException {

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.service.ViolationService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
 import uk.gov.justice.digital.test.BaseMinimalDataIntegrationTest;
@@ -252,7 +253,7 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         OperationalDataStoreDataAccess operationalDataStoreDataAccess = new OperationalDataStoreDataAccess(connectionDetailsService);
-        OperationalDataStoreServiceImpl operationalDataStoreService =
+        OperationalDataStoreService operationalDataStoreService =
                 new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
         underTest = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
     }

--- a/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
@@ -53,7 +53,7 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
     @Mock
     private JobArguments jobArguments;
 
-    private OperationalDataStoreService underTest;
+    private OperationalDataStoreServiceImpl underTest;
 
     private String tableName;
 
@@ -87,10 +87,7 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
         tableName = "public._" + UUID.randomUUID().toString().replaceAll("-", "_");
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(tableName);
 
-        when(jobArguments.isOperationalDataStoreWriteEnabled()).thenReturn(true);
-
-        underTest = new OperationalDataStoreService(
-                jobArguments,
+        underTest = new OperationalDataStoreServiceImpl(
                 new OperationalDataStoreTransformation(),
                 new OperationalDataStoreDataAccess(mockConnectionDetailsService)
         );

--- a/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
@@ -53,7 +53,7 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
     @Mock
     private JobArguments jobArguments;
 
-    private OperationalDataStoreServiceImpl underTest;
+    private OperationalDataStoreService underTest;
 
     private String tableName;
 

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/DisabledOperationalDataStoreService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/DisabledOperationalDataStoreService.java
@@ -12,6 +12,11 @@ import uk.gov.justice.digital.datahub.model.SourceReference;
 @Requires(missingProperty = "dpr.operational.data.store.write.enabled")
 public class DisabledOperationalDataStoreService implements OperationalDataStoreService {
     private static final Logger logger = LoggerFactory.getLogger(DisabledOperationalDataStoreService.class);
+
+    public DisabledOperationalDataStoreService() {
+        logger.info("Operational DataStore functionality is disabled");
+    }
+
     @Override
     public void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference) {
         logger.info("Operational DataStore functionality is disabled, skipping table {}.{}", sourceReference.getSource(), sourceReference.getTable());

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/DisabledOperationalDataStoreService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/DisabledOperationalDataStoreService.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.service.operationaldatastore;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+
+@Singleton
+@Requires(missingProperty = "dpr.operational.data.store.write.enabled")
+public class DisabledOperationalDataStoreService implements OperationalDataStoreService {
+    private static final Logger logger = LoggerFactory.getLogger(DisabledOperationalDataStoreService.class);
+    @Override
+    public void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference) {
+        logger.info("Operational DataStore functionality is disabled, skipping table {}.{}", sourceReference.getSource(), sourceReference.getTable());
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreService.java
@@ -1,51 +1,9 @@
 package uk.gov.justice.digital.service.operationaldatastore;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
-import lombok.val;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
-/**
- * Entrypoint for access to the Operational DataStore.
- */
-@Singleton
-public class OperationalDataStoreService {
-
-    private static final Logger logger = LoggerFactory.getLogger(OperationalDataStoreService.class);
-
-    private final JobArguments jobArguments;
-    private final OperationalDataStoreTransformation transformer;
-    private final OperationalDataStoreDataAccess operationalDataStoreDataAccess;
-
-    @Inject
-    public OperationalDataStoreService(
-            JobArguments jobArguments,
-            OperationalDataStoreTransformation transformer,
-            OperationalDataStoreDataAccess operationalDataStoreDataAccess
-    ) {
-        this.jobArguments = jobArguments;
-        this.transformer = transformer;
-        this.operationalDataStoreDataAccess = operationalDataStoreDataAccess;
-    }
-
-    public void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference) {
-        String destinationTableName = sourceReference.getFullyQualifiedTableName();
-        if(jobArguments.isOperationalDataStoreWriteEnabled()) {
-            val startTime = System.currentTimeMillis();
-            logger.info("Processing records for Operational Data Store table {}", destinationTableName);
-
-            Dataset<Row> transformedDf = transformer.transform(dataFrame);
-            operationalDataStoreDataAccess.overwriteTable(transformedDf, destinationTableName);
-
-            logger.info("Finished processing records for Operational Data Store table {} in {}ms",
-                    destinationTableName, System.currentTimeMillis() - startTime);
-        } else {
-            logger.info("Operational Data Store write is disabled so skipping write for table {}", destinationTableName);
-        }
-    }
+public interface OperationalDataStoreService {
+    void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference);
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceImpl.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceImpl.java
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.service.operationaldatastore;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.val;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+
+/**
+ * Entrypoint for access to the Operational DataStore.
+ */
+@Singleton
+@Requires(property = "dpr.operational.data.store.write.enabled")
+public class OperationalDataStoreServiceImpl implements OperationalDataStoreService {
+
+    private static final Logger logger = LoggerFactory.getLogger(OperationalDataStoreServiceImpl.class);
+
+    private final OperationalDataStoreTransformation transformer;
+    private final OperationalDataStoreDataAccess operationalDataStoreDataAccess;
+
+    @Inject
+    public OperationalDataStoreServiceImpl(
+            OperationalDataStoreTransformation transformer,
+            OperationalDataStoreDataAccess operationalDataStoreDataAccess
+    ) {
+        this.transformer = transformer;
+        this.operationalDataStoreDataAccess = operationalDataStoreDataAccess;
+    }
+
+    public void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference) {
+        String destinationTableName = sourceReference.getFullyQualifiedTableName();
+        val startTime = System.currentTimeMillis();
+        logger.info("Processing records for Operational Data Store table {}", destinationTableName);
+
+        Dataset<Row> transformedDf = transformer.transform(dataFrame);
+        operationalDataStoreDataAccess.overwriteTable(transformedDf, destinationTableName);
+
+        logger.info("Finished processing records for Operational Data Store table {} in {}ms",
+                destinationTableName, System.currentTimeMillis() - startTime);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ValidationService;
-import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
 import uk.gov.justice.digital.zone.structured.StructuredZoneLoad;
 
@@ -65,7 +65,7 @@ class BatchProcessorTest extends BaseSparkTest {
     @Mock
     private ValidationService validationService;
     @Mock
-    private OperationalDataStoreServiceImpl operationalDataStoreService;
+    private OperationalDataStoreService operationalDataStoreService;
     @Captor
     private ArgumentCaptor<Dataset<Row>> argumentCaptor;
 

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ValidationService;
-import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
 import uk.gov.justice.digital.zone.structured.StructuredZoneLoad;
 
@@ -65,7 +65,7 @@ class BatchProcessorTest extends BaseSparkTest {
     @Mock
     private ValidationService validationService;
     @Mock
-    private OperationalDataStoreService operationalDataStoreService;
+    private OperationalDataStoreServiceImpl operationalDataStoreService;
     @Captor
     private ArgumentCaptor<Dataset<Row>> argumentCaptor;
 

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreConnectionDetailsServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreConnectionDetailsServiceTest.java
@@ -41,7 +41,7 @@ class OperationalDataStoreConnectionDetailsServiceTest {
     }
 
     @Test
-    void shouldReturnConnectionDetailsWhenEnabled() {
+    void shouldReturnConnectionDetails() {
         String expectedUrl = "jdbc:postgresql://localhost/test";
         String expectedDriver = "org.postgresql.Driver";
         String expectedUsername = "user";
@@ -58,7 +58,6 @@ class OperationalDataStoreConnectionDetailsServiceTest {
         credentials.setUsername(expectedUsername);
         credentials.setPassword(expectedPassword);
 
-        when(mockJobArguments.isOperationalDataStoreWriteEnabled()).thenReturn(true);
         when(mockJobArguments.getOperationalDataStoreGlueConnectionName()).thenReturn(connectionName);
         when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
         when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
@@ -73,19 +72,4 @@ class OperationalDataStoreConnectionDetailsServiceTest {
         verify(mockGlueClient, times(1)).getConnection(connectionName);
         verify(mockSecretsManagerClient, times(1)).getSecret(secretId, OperationalDataStoreCredentials.class);
     }
-
-    @Test
-    void shouldReturnBlankConnectionDetailsWhenDisabled() {
-        when(mockJobArguments.isOperationalDataStoreWriteEnabled()).thenReturn(false);
-
-        OperationalDataStoreConnectionDetails result = underTest.getConnectionDetails();
-        assertEquals("", result.getUrl());
-        assertEquals("", result.getJdbcDriverClassName());
-        assertEquals("", result.getCredentials().getUsername());
-        assertEquals("", result.getCredentials().getPassword());
-
-        verify(mockGlueClient, times(0)).getConnection(any());
-        verify(mockSecretsManagerClient, times(0)).getSecret(any(), any());
-    }
-
 }

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
@@ -30,7 +30,7 @@ class OperationalDataStoreServiceTest {
     @Mock
     private SourceReference sourceReference;
 
-    private OperationalDataStoreServiceImpl underTest;
+    private OperationalDataStoreService underTest;
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
@@ -29,19 +29,16 @@ class OperationalDataStoreServiceTest {
     private Dataset<Row> transformedDataframe;
     @Mock
     private SourceReference sourceReference;
-    @Mock
-    private JobArguments jobArguments;
 
-    private OperationalDataStoreService underTest;
+    private OperationalDataStoreServiceImpl underTest;
 
     @BeforeEach
     public void setup() {
-        underTest = new OperationalDataStoreService(jobArguments, mockDataTransformation, mockDataAccess);
+        underTest = new OperationalDataStoreServiceImpl(mockDataTransformation, mockDataAccess);
     }
 
     @Test
     void shouldTransformInputDataframe() {
-        when(jobArguments.isOperationalDataStoreWriteEnabled()).thenReturn(true);
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
         when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
 
@@ -52,22 +49,11 @@ class OperationalDataStoreServiceTest {
 
     @Test
     void shouldWriteTransformedDataframeToDestinationTable() {
-        when(jobArguments.isOperationalDataStoreWriteEnabled()).thenReturn(true);
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
         when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
 
         underTest.storeBatchData(inputDataframe, sourceReference);
 
         verify(mockDataAccess, times(1)).overwriteTable(transformedDataframe, destinationTableName);
-    }
-
-    @Test
-    void shouldNotTransformOrWriteWhenDisabled() {
-        when(jobArguments.isOperationalDataStoreWriteEnabled()).thenReturn(false);
-        when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
-        underTest.storeBatchData(inputDataframe, sourceReference);
-
-        verify(mockDataTransformation, times(0)).transform(any());
-        verify(mockDataAccess, times(0)).overwriteTable(any(), any());
     }
 }


### PR DESCRIPTION
- Simplify operational datastore feature flag by using micronaut conditional DI instead of conditional
- Inject either a OperationalDataStoreServiceImpl or a DisabledOperationalDataStoreService implementation of OperationalDataStoreService depending on presence or absence of property "dpr.operational.data.store.write.enabled"
- This will be simpler, especially as CDC functionality uses the operational data store