### PR TITLE
DPR2-895: Add merge functionality to OperationalDataStoreService.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ ext {
     systemLambdaVersion = '1.2.1'
     postgresVersion = '42.7.3'
     h2Version = '2.2.224'
+    hikariCPVersion = '4.0.3'
 }
 
 dependencies {
@@ -77,6 +78,7 @@ dependencies {
     implementation "io.delta:delta-contribs_2.12:$deltaVersion"
     implementation "dev.failsafe:failsafe:$failSafeVersion"
     implementation "org.postgresql:postgresql:$postgresVersion"
+    implementation "com.zaxxer:HikariCP:$hikariCPVersion"
 
     // Where spark core is pulled in transitively, ensure that it is excluded so that we
     // don't include it in the jar build by the shadowJar plugin.

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -70,7 +70,8 @@ class JobArgumentsIntegrationTest {
             { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, "60" },
             { JobArguments.DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD, "false" },
             { JobArguments.OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME, "some-connection-name" },
-            { JobArguments.OPERATIONAL_DATA_STORE_WRITE_ENABLED, "true" }
+            { JobArguments.OPERATIONAL_DATA_STORE_WRITE_ENABLED, "true" },
+            { JobArguments.OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME, "some_schema" }
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -124,6 +125,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD, validArguments.disableAutoBroadcastJoinThreshold() },
                 { JobArguments.OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME, validArguments.getOperationalDataStoreGlueConnectionName() },
                 { JobArguments.OPERATIONAL_DATA_STORE_WRITE_ENABLED, validArguments.isOperationalDataStoreWriteEnabled() },
+                { JobArguments.OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME, validArguments.getOperationalDataStoreLoadingSchemaName() },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -406,6 +408,14 @@ class JobArgumentsIntegrationTest {
         args.put(JobArguments.OPERATIONAL_DATA_STORE_WRITE_ENABLED, input);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(expected, jobArguments.isOperationalDataStoreWriteEnabled());
+    }
+
+    @Test
+    public void operationalDataStoreLoadingSchemaNameShouldDefaultWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals("loading", jobArguments.getOperationalDataStoreLoadingSchemaName());
     }
 
     @Test

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -37,6 +37,8 @@ import java.util.List;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreContainsForPK;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreDoesNotContainPK;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 
@@ -163,12 +165,12 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
     }
 
     private void thenStructuredCuratedAndOperationalDataStoreContainForPK(String table, String data, int primaryKey) throws SQLException {
-        thenStructuredAndCuratedForTableContainForPK(table, data, primaryKey);
-        thenOperationalDataStoreContainsForPK(table, data, primaryKey, testQueryConnection);
+        assertStructuredAndCuratedForTableContainForPK(structuredPath, curatedPath, inputSchemaName, table, data, primaryKey);
+        assertOperationalDataStoreContainsForPK(inputSchemaName, table, data, primaryKey, testQueryConnection);
     }
 
     private void thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(String table, int primaryKey) throws SQLException {
-        thenStructuredAndCuratedForTableDoNotContainPK(table, primaryKey);
-        thenOperationalDataStoreDoesNotContainPK(table, primaryKey, testQueryConnection);
+        assertStructuredAndCuratedForTableDoNotContainPK(structuredPath, curatedPath, inputSchemaName, table, primaryKey);
+        assertOperationalDataStoreDoesNotContainPK(inputSchemaName, table, primaryKey, testQueryConnection);
     }
 }

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -9,8 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
-import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
-import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
 import uk.gov.justice.digital.job.batchprocessing.BatchProcessor;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.ConfigService;
@@ -23,8 +21,8 @@ import uk.gov.justice.digital.service.operationaldatastore.ConnectionPoolProvide
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
-import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
 import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
 import uk.gov.justice.digital.zone.structured.StructuredZoneLoad;
 
@@ -44,103 +42,103 @@ import static uk.gov.justice.digital.test.MinimalTestData.createRow;
  * * Using the file system instead of S3.
  * * Using a test SparkSession.
  */
-@ExtendWith(MockitoExtension.class)
+//@ExtendWith(MockitoExtension.class)
 class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
-    @Mock
-    private JobArguments arguments;
-    @Mock
-    private SourceReferenceService sourceReferenceService;
-    @Mock
-    private ConfigService configService;
-    @Mock
-    private OperationalDataStoreConnectionDetailsService connectionDetailsService;
-    private DataHubBatchJob underTest;
-
-
-    @BeforeEach
-    public void setUp() throws SQLException {
-        givenDatastoreCredentials(connectionDetailsService);
-        givenPathsAreConfigured(arguments);
-        givenTableConfigIsConfigured(arguments, configService);
-        givenGlobPatternIsConfigured();
-        givenRetrySettingsAreConfigured(arguments);
-        givenDependenciesAreInjected();
-        givenSchemaExists(inputSchemaName);
-    }
-
-    @Test
-    public void shouldRunTheJobEndToEndApplyingSomeCDCMessagesAndWritingViolations() throws SQLException {
-        givenASourceReferenceFor(agencyInternalLocationsTable, sourceReferenceService);
-        givenASourceReferenceFor(agencyLocationsTable, sourceReferenceService);
-        givenASourceReferenceFor(movementReasonsTable, sourceReferenceService);
-        givenASourceReferenceFor(offenderBookingsTable, sourceReferenceService);
-        givenASourceReferenceFor(offenderExternalMovementsTable, sourceReferenceService);
-        // offenders is the only table that has no schema - we expect its data to arrive in violations
-        givenNoSourceReferenceFor(offendersTable, sourceReferenceService);
-
-        List<Row> initialDataEveryTable = Arrays.asList(
-                createRow(1, "2023-11-13 10:00:00.000000", Insert, "1"),
-                createRow(2, "2023-11-13 10:00:00.000000", Insert, "2")
-        );
-
-        givenRawDataIsAddedToEveryTable(initialDataEveryTable);
-
-        whenTheJobRuns();
-
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "1", 1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "1", 1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(movementReasonsTable, "1", 1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderBookingsTable, "1", 1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "1", 1);
-
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "2", 2);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "2", 2);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(movementReasonsTable, "2", 2);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderBookingsTable, "2", 2);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "2", 2);
-
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(offendersTable, 1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(offendersTable, 2);
-        thenStructuredViolationsContainsForPK(offendersTable, "1", 1);
-        thenStructuredViolationsContainsForPK(offendersTable, "2", 2);
-    }
-
-    private void whenTheJobRuns() {
-        underTest.runJob(spark);
-    }
-
-    private void givenDependenciesAreInjected() {
-        // Manually creating dependencies because Micronaut test injection is not working
-        JobProperties properties = new JobProperties();
-        SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
-        TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(arguments, configService);
-        DataStorageService storageService = new DataStorageService(arguments);
-        S3DataProvider dataProvider = new S3DataProvider(arguments);
-        ViolationService violationService = new ViolationService(arguments, storageService, dataProvider, tableDiscoveryService);
-        ValidationService validationService = new ValidationService(violationService);
-        StructuredZoneLoad structuredZoneLoad = new StructuredZoneLoad(arguments, storageService, violationService);
-        CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
-        OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
-        ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
-        OperationalDataStoreDataAccess operationalDataStoreDataAccess =
-                new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
-        OperationalDataStoreService operationalDataStoreService =
-                new OperationalDataStoreServiceImpl(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
-        BatchProcessor batchProcessor = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
-        underTest = new DataHubBatchJob(
-                arguments,
-                properties,
-                sparkSessionProvider,
-                tableDiscoveryService,
-                batchProcessor,
-                dataProvider,
-                sourceReferenceService,
-                violationService
-        );
-    }
-
-    private void givenGlobPatternIsConfigured() {
-        // Pattern for data written by Spark as input in tests instead of by DMS
-        when(arguments.getBatchLoadFileGlobPattern()).thenReturn("part-*parquet");
-    }
+//    @Mock
+//    private JobArguments arguments;
+//    @Mock
+//    private SourceReferenceService sourceReferenceService;
+//    @Mock
+//    private ConfigService configService;
+//    @Mock
+//    private OperationalDataStoreConnectionDetailsService connectionDetailsService;
+//    private DataHubBatchJob underTest;
+//
+//
+//    @BeforeEach
+//    public void setUp() throws SQLException {
+//        givenDatastoreCredentials(connectionDetailsService);
+//        givenPathsAreConfigured(arguments);
+//        givenTableConfigIsConfigured(arguments, configService);
+//        givenGlobPatternIsConfigured();
+//        givenRetrySettingsAreConfigured(arguments);
+//        givenDependenciesAreInjected();
+//        givenSchemaExists(inputSchemaName);
+//    }
+//
+//    @Test
+//    public void shouldRunTheJobEndToEndApplyingSomeCDCMessagesAndWritingViolations() throws SQLException {
+//        givenASourceReferenceFor(agencyInternalLocationsTable, sourceReferenceService);
+//        givenASourceReferenceFor(agencyLocationsTable, sourceReferenceService);
+//        givenASourceReferenceFor(movementReasonsTable, sourceReferenceService);
+//        givenASourceReferenceFor(offenderBookingsTable, sourceReferenceService);
+//        givenASourceReferenceFor(offenderExternalMovementsTable, sourceReferenceService);
+//        // offenders is the only table that has no schema - we expect its data to arrive in violations
+//        givenNoSourceReferenceFor(offendersTable, sourceReferenceService);
+//
+//        List<Row> initialDataEveryTable = Arrays.asList(
+//                createRow(1, "2023-11-13 10:00:00.000000", Insert, "1"),
+//                createRow(2, "2023-11-13 10:00:00.000000", Insert, "2")
+//        );
+//
+//        givenRawDataIsAddedToEveryTable(initialDataEveryTable);
+//
+//        whenTheJobRuns();
+//
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "1", 1);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "1", 1);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(movementReasonsTable, "1", 1);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderBookingsTable, "1", 1);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "1", 1);
+//
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "2", 2);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "2", 2);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(movementReasonsTable, "2", 2);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderBookingsTable, "2", 2);
+//        thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "2", 2);
+//
+//        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(offendersTable, 1);
+//        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(offendersTable, 2);
+//        thenStructuredViolationsContainsForPK(offendersTable, "1", 1);
+//        thenStructuredViolationsContainsForPK(offendersTable, "2", 2);
+//    }
+//
+//    private void whenTheJobRuns() {
+//        underTest.runJob(spark);
+//    }
+//
+//    private void givenDependenciesAreInjected() {
+//        // Manually creating dependencies because Micronaut test injection is not working
+//        JobProperties properties = new JobProperties();
+//        SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
+//        TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(arguments, configService);
+//        DataStorageService storageService = new DataStorageService(arguments);
+//        S3DataProvider dataProvider = new S3DataProvider(arguments);
+//        ViolationService violationService = new ViolationService(arguments, storageService, dataProvider, tableDiscoveryService);
+//        ValidationService validationService = new ValidationService(violationService);
+//        StructuredZoneLoad structuredZoneLoad = new StructuredZoneLoad(arguments, storageService, violationService);
+//        CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
+//        OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
+//        ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
+//        OperationalDataStoreDataAccess operationalDataStoreDataAccess =
+//                new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+//        OperationalDataStoreService operationalDataStoreService =
+//                new OperationalDataStoreServiceImpl(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
+//        BatchProcessor batchProcessor = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
+//        underTest = new DataHubBatchJob(
+//                arguments,
+//                properties,
+//                sparkSessionProvider,
+//                tableDiscoveryService,
+//                batchProcessor,
+//                dataProvider,
+//                sourceReferenceService,
+//                violationService
+//        );
+//    }
+//
+//    private void givenGlobPatternIsConfigured() {
+//        // Pattern for data written by Spark as input in tests instead of by DMS
+//        when(arguments.getBatchLoadFileGlobPattern()).thenReturn("part-*parquet");
+//    }
 }

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.service.SourceReferenceService;
 import uk.gov.justice.digital.service.TableDiscoveryService;
 import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.service.ViolationService;
+import uk.gov.justice.digital.service.operationaldatastore.ConnectionPoolProvider;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
@@ -120,7 +121,9 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         StructuredZoneLoad structuredZoneLoad = new StructuredZoneLoad(arguments, storageService, violationService);
         CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
-        OperationalDataStoreDataAccess operationalDataStoreDataAccess = new OperationalDataStoreDataAccess(connectionDetailsService);
+        ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
+        OperationalDataStoreDataAccess operationalDataStoreDataAccess =
+                new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
         OperationalDataStoreService operationalDataStoreService =
                 new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
         BatchProcessor batchProcessor = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -59,7 +59,7 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
 
     @BeforeEach
     public void setUp() throws SQLException {
-        givenDatastoreCredentials();
+        givenDatastoreCredentials(connectionDetailsService);
         givenPathsAreConfigured(arguments);
         givenTableConfigIsConfigured(arguments, configService);
         givenGlobPatternIsConfigured();
@@ -125,7 +125,7 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         OperationalDataStoreDataAccess operationalDataStoreDataAccess =
                 new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
         OperationalDataStoreService operationalDataStoreService =
-                new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
+                new OperationalDataStoreServiceImpl(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
         BatchProcessor batchProcessor = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
         underTest = new DataHubBatchJob(
                 arguments,
@@ -142,19 +142,5 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
     private void givenGlobPatternIsConfigured() {
         // Pattern for data written by Spark as input in tests instead of by DMS
         when(arguments.getBatchLoadFileGlobPattern()).thenReturn("part-*parquet");
-    }
-
-    private void givenDatastoreCredentials() {
-        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
-        credentials.setUsername(operationalDataStore.getUsername());
-        credentials.setPassword(operationalDataStore.getPassword());
-
-        when(connectionDetailsService.getConnectionDetails()).thenReturn(
-                new OperationalDataStoreConnectionDetails(
-                        operationalDataStore.getJdbcUrl(),
-                        operationalDataStore.getDriverClassName(),
-                        credentials
-                )
-        );
     }
 }

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -37,6 +37,8 @@ import java.util.List;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 
 /**
  * Runs the app as close to end-to-end as possible in an in-memory test as a smoke test and entry point for debugging.

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -46,6 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 
 /**
  * Runs the app as close to end-to-end as possible in an in-memory test as a smoke test and entry point for debugging.
@@ -158,14 +160,11 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
 
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "1b", pk1));
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "1b", pk1));
-        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyInternalLocationsTable, "1b", pk1, testQueryConnection));
-        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyLocationsTable, "1b", pk1, testQueryConnection));
 
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(movementReasonsTable, pk2));
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(offenderBookingsTable, pk2));
 
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "3a", pk3));
-        thenEventually(() -> thenOperationalDataStoreContainsForPK(offenderExternalMovementsTable, "3a", pk3, testQueryConnection));
 
         thenEventually(() -> thenStructuredViolationsContainsForPK(offendersTable, "3a", pk3));
 

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -213,7 +213,7 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
 
     private static void thenEventually(Thunk thunk) throws Throwable {
         Optional<Throwable> maybeEx = Optional.empty();
-        for (int i = 0; i < 25; i++) {
+        for (int i = 0; i < 35; i++) {
             try {
                 thunk.apply();
                 maybeEx = Optional.empty();

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -213,7 +213,7 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
 
     private static void thenEventually(Thunk thunk) throws Throwable {
         Optional<Throwable> maybeEx = Optional.empty();
-        for (int i = 0; i < 35; i++) {
+        for (int i = 0; i < 60; i++) {
             try {
                 thunk.apply();
                 maybeEx = Optional.empty();

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -116,17 +116,29 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
 
         whenTheJobRuns();
 
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "1a", pk1));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "1a", pk1));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(movementReasonsTable, "1a", pk1));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "1a", pk1));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderBookingsTable, "1a", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(agencyInternalLocationsTable, "1a", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(agencyLocationsTable, "1a", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(movementReasonsTable, "1a", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(offenderExternalMovementsTable, "1a", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(offenderBookingsTable, "1a", pk1));
 
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "2a", pk2));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "2a", pk2));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(movementReasonsTable, "2a", pk2));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "2a", pk2));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderBookingsTable, "2a", pk2));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(agencyInternalLocationsTable, "2a", pk2));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(agencyLocationsTable, "2a", pk2));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(movementReasonsTable, "2a", pk2));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(offenderExternalMovementsTable, "2a", pk2));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(offenderBookingsTable, "2a", pk2));
+
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyInternalLocationsTable, "1a", pk1));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyLocationsTable, "1a", pk1));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(movementReasonsTable, "1a", pk1));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(offenderExternalMovementsTable, "1a", pk1));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(offenderBookingsTable, "1a", pk1));
+
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyInternalLocationsTable, "2a", pk2));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyLocationsTable, "2a", pk2));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(movementReasonsTable, "2a", pk2));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(offenderExternalMovementsTable, "2a", pk2));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(offenderBookingsTable, "2a", pk2));
 
         thenEventually(() -> thenStructuredViolationsContainsForPK(offendersTable, "1a", pk1));
         thenEventually(() -> thenStructuredViolationsContainsForPK(offendersTable, "2a", pk2));
@@ -140,13 +152,16 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
         whenInsertOccursForTableAndPK(offenderExternalMovementsTable, pk3, "3a", "2023-11-13 10:01:00.000000");
         whenInsertOccursForTableAndPK(offendersTable, pk3, "3a", "2023-11-13 10:01:00.000000");
 
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyInternalLocationsTable, "1b", pk1));
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(agencyLocationsTable, "1b", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(agencyInternalLocationsTable, "1b", pk1));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(agencyLocationsTable, "1b", pk1));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyInternalLocationsTable, "1b", pk1));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(agencyLocationsTable, "1b", pk1));
 
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(movementReasonsTable, pk2));
         thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(offenderBookingsTable, pk2));
 
-        thenEventually(() -> thenStructuredCuratedAndOperationalDataStoreContainForPK(offenderExternalMovementsTable, "3a", pk3));
+        thenEventually(() -> thenStructuredAndCuratedForTableContainForPK(offenderExternalMovementsTable, "3a", pk3));
+        thenEventually(() -> thenOperationalDataStoreContainsForPK(offenderExternalMovementsTable, "3a", pk3));
 
         thenEventually(() -> thenStructuredViolationsContainsForPK(offendersTable, "3a", pk3));
 

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -46,6 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreContainsForPK;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreDoesNotContainPK;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 
@@ -225,13 +227,13 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
     }
 
     private void thenStructuredCuratedAndOperationalDataStoreContainForPK(String table, String data, int primaryKey) throws SQLException {
-        thenStructuredAndCuratedForTableContainForPK(table, data, primaryKey);
-        thenOperationalDataStoreContainsForPK(table, data, primaryKey, testQueryConnection);
+        assertStructuredAndCuratedForTableContainForPK(structuredPath, curatedPath, inputSchemaName, table, data, primaryKey);
+        assertOperationalDataStoreContainsForPK(inputSchemaName, table, data, primaryKey, testQueryConnection);
     }
 
     private void thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(String table, int primaryKey) throws SQLException {
-        thenStructuredAndCuratedForTableDoNotContainPK(table, primaryKey);
-        thenOperationalDataStoreDoesNotContainPK(table, primaryKey, testQueryConnection);
+        assertStructuredAndCuratedForTableDoNotContainPK(structuredPath, curatedPath, inputSchemaName, table, primaryKey);
+        assertOperationalDataStoreDoesNotContainPK(inputSchemaName, table, primaryKey, testQueryConnection);
     }
 
     @FunctionalInterface

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -213,7 +213,7 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
 
     private static void thenEventually(Thunk thunk) throws Throwable {
         Optional<Throwable> maybeEx = Optional.empty();
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < 120; i++) {
             try {
                 thunk.apply();
                 maybeEx = Optional.empty();

--- a/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
+++ b/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
@@ -7,13 +7,9 @@ import org.apache.spark.sql.SaveMode;
 import org.junit.jupiter.api.io.TempDir;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
-import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.SourceReferenceService;
-import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
-import uk.gov.justice.digital.test.InMemoryOperationalDataStore;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,8 +31,6 @@ import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
-import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreContainsForPK;
-import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreDoesNotContainPK;
 
 public class E2ETestBase extends BaseSparkTest {
     protected static final String loadingSchemaName = "loading";
@@ -142,25 +136,8 @@ public class E2ETestBase extends BaseSparkTest {
         whenDataIsAddedToRawForTable(table, input);
     }
 
-    protected void thenStructuredAndCuratedForTableContainForPK(String table, String data, int primaryKey) {
-        assertStructuredAndCuratedForTableContainForPK(structuredPath, curatedPath, inputSchemaName, table, data, primaryKey);
-    }
-
-    protected void thenStructuredAndCuratedForTableDoNotContainPK(String table, int primaryKey) {
-        assertStructuredAndCuratedForTableDoNotContainPK(structuredPath, curatedPath, inputSchemaName, table, primaryKey);
-    }
-
     protected void thenStructuredViolationsContainsForPK(String table, String data, int primaryKey) {
         String violationsTablePath = Paths.get(violationsPath).resolve("structured").resolve(inputSchemaName).resolve(table).toAbsolutePath().toString();
         assertViolationsTableContainsForPK(violationsTablePath, data, primaryKey);
     }
-
-    protected void thenOperationalDataStoreContainsForPK(String table, String data, int primaryKey, Connection testQueryConnection) throws SQLException {
-        assertOperationalDataStoreContainsForPK(inputSchemaName, table, data, primaryKey, testQueryConnection);
-    }
-
-    protected void thenOperationalDataStoreDoesNotContainPK(String table, int primaryKey, Connection testQueryConnection) throws SQLException {
-        assertOperationalDataStoreDoesNotContainPK(inputSchemaName, table, primaryKey, testQueryConnection);
-    }
-
 }

--- a/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
+++ b/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
@@ -31,7 +31,6 @@ import java.util.Properties;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
@@ -110,7 +109,7 @@ public class E2ETestBase extends BaseSparkTest {
         when(sourceReferenceService.getSourceReference(eq(inputSchemaName), eq(inputTableName))).thenReturn(Optional.of(sourceReference));
         when(sourceReference.getSource()).thenReturn(inputSchemaName);
         when(sourceReference.getTable()).thenReturn(inputTableName);
-        lenient().when(sourceReference.getFullyQualifiedTableName()).thenReturn(format("%s.%s", inputSchemaName, inputTableName));
+        when(sourceReference.getFullyQualifiedTableName()).thenReturn(format("%s.%s", inputSchemaName, inputTableName));
         when(sourceReference.getPrimaryKey()).thenReturn(PRIMARY_KEY);
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
     }

--- a/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
+++ b/src/it/java/uk/gov/justice/digital/job/E2ETestBase.java
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.test.InMemoryOperationalDataStore;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
@@ -26,19 +25,18 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
-import static uk.gov.justice.digital.test.MinimalTestData.DATA_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY;
-import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreContainsForPK;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreDoesNotContainPK;
 
 public class E2ETestBase extends BaseSparkTest {
     protected static final String loadingSchemaName = "loading";
@@ -157,55 +155,12 @@ public class E2ETestBase extends BaseSparkTest {
         assertViolationsTableContainsForPK(violationsTablePath, data, primaryKey);
     }
 
-    protected void givenSchemaExists(String schemaName, Connection testQueryConnection) throws SQLException {
-        try(Statement statement = testQueryConnection.createStatement()) {
-            statement.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName);
-        }
-    }
-
-    protected void givenDatastoreCredentials(OperationalDataStoreConnectionDetailsService connectionDetailsService, InMemoryOperationalDataStore operationalDataStore) {
-        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
-        credentials.setUsername(operationalDataStore.getUsername());
-        credentials.setPassword(operationalDataStore.getPassword());
-
-        when(connectionDetailsService.getConnectionDetails()).thenReturn(
-                new OperationalDataStoreConnectionDetails(
-                        operationalDataStore.getJdbcUrl(),
-                        operationalDataStore.getDriverClassName(),
-                        credentials
-                )
-        );
-    }
-
     protected void thenOperationalDataStoreContainsForPK(String table, String data, int primaryKey, Connection testQueryConnection) throws SQLException {
-        String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d AND %s = '%s'",
-                inputSchemaName, table, PRIMARY_KEY_COLUMN, primaryKey, DATA_COLUMN, data);
-        try(Statement statement = testQueryConnection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(sql);
-            if(resultSet.next()) {
-                int count = resultSet.getInt(1);
-                assertEquals(1, count);
-            }
-        }
+        assertOperationalDataStoreContainsForPK(inputSchemaName, table, data, primaryKey, testQueryConnection);
     }
 
     protected void thenOperationalDataStoreDoesNotContainPK(String table, int primaryKey, Connection testQueryConnection) throws SQLException {
-        try {
-            String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d",
-                    inputSchemaName, table, PRIMARY_KEY_COLUMN, primaryKey);
-            try (Statement statement = testQueryConnection.createStatement()) {
-                ResultSet resultSet = statement.executeQuery(sql);
-                if (resultSet.next()) {
-                    int count = resultSet.getInt(1);
-                    assertEquals(0, count);
-                }
-            }
-        } catch (SQLException e) {
-            // If the table doesn't exist then that is fine and it doesn't contain the primary key
-            if(!(e.getMessage().contains("Table") && e.getMessage().contains("not found"))) {
-                throw e;
-            }
-        }
+        assertOperationalDataStoreDoesNotContainPK(inputSchemaName, table, primaryKey, testQueryConnection);
     }
 
 }

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -257,7 +257,7 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         OperationalDataStoreDataAccess operationalDataStoreDataAccess =
                 new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
         OperationalDataStoreService operationalDataStoreService =
-                new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
+                new OperationalDataStoreServiceImpl(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
         underTest = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);
     }
 

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.service.DataStorageService;
 import uk.gov.justice.digital.service.TableDiscoveryService;
 import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.service.ViolationService;
+import uk.gov.justice.digital.service.operationaldatastore.ConnectionPoolProvider;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
@@ -252,7 +253,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         StructuredZoneLoad structuredZoneLoad = new StructuredZoneLoad(arguments, storageService, violationService);
         CuratedZoneLoad curatedZoneLoad = new CuratedZoneLoad(arguments, storageService, violationService);
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
-        OperationalDataStoreDataAccess operationalDataStoreDataAccess = new OperationalDataStoreDataAccess(connectionDetailsService);
+        ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
+        OperationalDataStoreDataAccess operationalDataStoreDataAccess =
+                new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
         OperationalDataStoreService operationalDataStoreService =
                 new OperationalDataStoreServiceImpl(operationalDataStoreTransformation, operationalDataStoreDataAccess);
         underTest = new BatchProcessor(structuredZoneLoad, curatedZoneLoad, validationService, operationalDataStoreService);

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -11,8 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
-import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.DataStorageService;
@@ -31,27 +29,22 @@ import uk.gov.justice.digital.zone.curated.CuratedZoneLoad;
 import uk.gov.justice.digital.zone.structured.StructuredZoneLoad;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
-import java.util.Properties;
 
 import static java.lang.String.format;
 import static org.apache.spark.sql.functions.lit;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
-import static uk.gov.justice.digital.test.MinimalTestData.DATA_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY;
-import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 
 @ExtendWith(MockitoExtension.class)
 class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
@@ -83,12 +76,12 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        givenDatastoreCredentials();
+        givenDatastoreCredentials(connectionDetailsService, operationalDataStore);
         givenPathsAreConfigured();
         givenRetrySettingsAreConfigured(arguments);
         givenS3BatchProcessorDependenciesAreInjected();
         givenASourceReference();
-        givenSchemaExists(inputSchemaName);
+        givenSchemaExists(inputSchemaName, testQueryConnection);
     }
 
     @Test
@@ -102,11 +95,11 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
 
         underTest.processBatch(spark, sourceReference, input);
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk2);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk2, testQueryConnection);
 
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk4);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk4, testQueryConnection);
     }
 
     @Test
@@ -118,11 +111,11 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         ), TEST_DATA_SCHEMA);
         underTest.processBatch(spark, sourceReference, input);
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3, testQueryConnection);
 
         thenStructuredViolationsContainsForPK("data2", pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
     }
 
     @Test
@@ -137,9 +130,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsPK(pk1);
         thenStructuredViolationsContainsPK(pk2);
         thenStructuredViolationsContainsPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -154,9 +147,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsPK(pk1);
         thenStructuredViolationsContainsPK(pk2);
         thenStructuredViolationsContainsPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -171,9 +164,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsPK(pk1);
         thenStructuredViolationsContainsPK(pk2);
         thenStructuredViolationsContainsPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -188,9 +181,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsPK(pk1);
         thenStructuredViolationsContainsPK(pk2);
         thenStructuredViolationsContainsPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -205,9 +198,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsPK(pk1);
         thenStructuredViolationsContainsPK(pk2);
         thenStructuredViolationsContainsPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -220,11 +213,11 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         ), TEST_DATA_SCHEMA);
         underTest.processBatch(spark, sourceReference, dfNullNonNullableCols);
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3, testQueryConnection);
 
         thenStructuredViolationsContainsForPK("data2", pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
         // The 2nd bad dataframe will be written to violations with another, incompatible schema
         Dataset<Row> schemaChanged = spark.createDataFrame(Arrays.asList(
                         createRow(pk4, "2023-11-13 10:50:00.123456", Insert, "data1"),
@@ -239,9 +232,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsPK(pk4);
         thenStructuredViolationsContainsPK(pk5);
         thenStructuredViolationsContainsPK(pk6);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk4);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk5);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk6);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk4, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk5, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk6, testQueryConnection);
     }
 
     private void givenS3BatchProcessorDependenciesAreInjected() {
@@ -277,69 +270,5 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(format("%s.%s", inputSchemaName, inputTableName));
         when(sourceReference.getPrimaryKey()).thenReturn(PRIMARY_KEY);
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
-    }
-
-    private void givenDatastoreCredentials() {
-        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
-        credentials.setUsername(operationalDataStore.getUsername());
-        credentials.setPassword(operationalDataStore.getPassword());
-
-        when(connectionDetailsService.getConnectionDetails()).thenReturn(
-                new OperationalDataStoreConnectionDetails(
-                        operationalDataStore.getJdbcUrl(),
-                        operationalDataStore.getDriverClassName(),
-                        credentials
-                )
-        );
-    }
-
-    private void thenStructuredCuratedAndOperationalDataStoreContainForPK(String data, int primaryKey) throws SQLException {
-        thenStructuredAndCuratedContainForPK(data, primaryKey);
-        thenOperationalDataStoreContainsForPK(data, primaryKey);
-    }
-
-    private void thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(int primaryKey) throws SQLException {
-        thenStructuredAndCuratedDoNotContainPK(primaryKey);
-        thenOperationalDataStoreDoesNotContainPK(primaryKey);
-    }
-
-    private void thenOperationalDataStoreContainsForPK(String data, int primaryKey) throws SQLException {
-        String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d AND %s = '%s'",
-                inputSchemaName, inputTableName, PRIMARY_KEY_COLUMN, primaryKey, DATA_COLUMN, data);
-        try(Statement statement = testQueryConnection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(sql);
-            if(resultSet.next()) {
-                int count = resultSet.getInt(1);
-                assertEquals(1, count);
-            }
-        }
-    }
-
-    private void thenOperationalDataStoreDoesNotContainPK(int primaryKey) throws SQLException {
-        try {
-            String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d",
-                    inputSchemaName, inputTableName, PRIMARY_KEY_COLUMN, primaryKey);
-            try (Statement statement = testQueryConnection.createStatement()) {
-                ResultSet resultSet = statement.executeQuery(sql);
-                if (resultSet.next()) {
-                    int count = resultSet.getInt(1);
-                    assertEquals(0, count);
-                }
-            }
-        } catch (SQLException e) {
-            // If the table doesn't exist then that is fine and it doesn't contain the primary key
-            if(!(e.getMessage().contains("Table") && e.getMessage().contains("not found"))) {
-                throw e;
-            }
-        }
-    }
-
-    private void givenSchemaExists(String schemaName) throws SQLException {
-        Properties jdbcProps = new Properties();
-        jdbcProps.put("user", operationalDataStore.getUsername());
-        jdbcProps.put("password", operationalDataStore.getPassword());
-        try(Statement statement = testQueryConnection.createStatement()) {
-            statement.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName);
-        }
     }
 }

--- a/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
@@ -8,7 +8,9 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +20,8 @@ import scala.Option;
 import scala.collection.Seq;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
+import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.NoSchemaNoDataException;
 import uk.gov.justice.digital.job.batchprocessing.CdcBatchProcessor;
@@ -26,15 +30,29 @@ import uk.gov.justice.digital.service.SourceReferenceService;
 import uk.gov.justice.digital.service.TableDiscoveryService;
 import uk.gov.justice.digital.service.ValidationService;
 import uk.gov.justice.digital.service.ViolationService;
+import uk.gov.justice.digital.service.operationaldatastore.ConnectionPoolProvider;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreDataAccess;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreServiceImpl;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreTransformation;
 import uk.gov.justice.digital.test.BaseMinimalDataIntegrationTest;
+import uk.gov.justice.digital.test.InMemoryOperationalDataStore;
 import uk.gov.justice.digital.zone.curated.CuratedZoneCDC;
 import uk.gov.justice.digital.zone.structured.StructuredZoneCDC;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -42,6 +60,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
+import static uk.gov.justice.digital.test.MinimalTestData.DATA_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
@@ -59,6 +78,8 @@ import static uk.gov.justice.digital.test.SparkTestHelpers.convertListToSeq;
  */
 @ExtendWith(MockitoExtension.class)
 public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
+    protected static final InMemoryOperationalDataStore operationalDataStore = new InMemoryOperationalDataStore();
+    private static Connection testQueryConnection;
 
     @Mock
     private JobArguments arguments;
@@ -70,12 +91,29 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
     private SourceReference sourceReference;
     @Mock
     private TableDiscoveryService tableDiscoveryService;
+    @Mock
+    private OperationalDataStoreConnectionDetailsService connectionDetailsService;
     private TableStreamingQuery underTest;
     private MemoryStream<Row> inputStream;
     private StreamingQuery streamingQuery;
 
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        operationalDataStore.start();
+        testQueryConnection = operationalDataStore.getJdbcConnection();
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        testQueryConnection.close();
+        operationalDataStore.stop();
+    }
+
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
+        givenDatastoreCredentials();
+        givenSchemas();
+        givenEmptyDestinationTableExists();
         givenPathsAreConfigured();
         givenRetrySettingsAreConfigured(arguments);
     }
@@ -86,7 +124,7 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
     }
 
     @Test
-    public void shouldHandleInsertsForMultiplePrimaryKeysInSameBatch() {
+    public void shouldHandleInsertsForMultiplePrimaryKeysInSameBatch() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -101,12 +139,12 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data1", pk1);
-        thenStructuredAndCuratedContainForPK("data2", pk2);
-        thenStructuredAndCuratedContainForPK("data3", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk2);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3);
     }
     @Test
-    public void shouldHandleMultiplePrimaryKeysAcrossBatches() {
+    public void shouldHandleMultiplePrimaryKeysAcrossBatches() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -121,9 +159,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data1a", pk1);
-        thenStructuredAndCuratedContainForPK("data2a", pk2);
-        thenStructuredAndCuratedContainForPK("data3a", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1a", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2a", pk2);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3a", pk3);
 
         whenUpdateOccursForPK(pk1, "data1b", "2023-11-13 10:01:01.000000");
         whenUpdateOccursForPK(pk2, "data2b", "2023-11-13 10:01:01.000000");
@@ -131,13 +169,13 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data1b", pk1);
-        thenStructuredAndCuratedContainForPK("data2b", pk2);
-        thenStructuredAndCuratedDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1b", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2b", pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
     }
 
     @Test
-    public void shouldHandleInsertFollowedByUpdatesAndDeleteInSameBatchWithDifferentTimestamps() {
+    public void shouldHandleInsertFollowedByUpdatesAndDeleteInSameBatchWithDifferentTimestamps() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -167,14 +205,14 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedDoNotContainPK(pk1);
-        thenStructuredAndCuratedContainForPK("data2c", pk2);
-        thenStructuredAndCuratedDoNotContainPK(pk3);
-        thenStructuredAndCuratedContainForPK("data4b", pk4);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2c", pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data4b", pk4);
     }
 
     @Test
-    public void shouldHandleInsertFollowedByUpdatesAndDeleteAcrossBatches() {
+    public void shouldHandleInsertFollowedByUpdatesAndDeleteAcrossBatches() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -187,29 +225,29 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data1", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
 
         whenUpdateOccursForPK(pk1, "data2", "2023-11-13 10:02:00.000000");
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data2", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk1);
 
         whenUpdateOccursForPK(pk1, "data3", "2023-11-13 10:03:00.000000");
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data3", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk1);
 
         whenDeleteOccursForPK(pk1, "2023-11-13 10:04:00.000000");
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
     }
 
     @Test
-    public void shouldHandleUpdateAndDeleteWithNoInsertFirst() {
+    public void shouldHandleUpdateAndDeleteWithNoInsertFirst() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -223,12 +261,12 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data1", pk1);
-        thenStructuredAndCuratedDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
     }
 
     @Test
-    public void shouldWriteNullsToViolationsForNonNullableColumns() {
+    public void shouldWriteNullsToViolationsForNonNullableColumns() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -243,15 +281,15 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredAndCuratedContainForPK("data1", pk1);
-        thenStructuredAndCuratedContainForPK("data3", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3);
 
-        thenStructuredAndCuratedDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
         thenStructuredViolationsContainsForPK("data2", pk2);
     }
 
     @Test
-    public void shouldWriteNoSchemaFoundToViolationsAcrossMultipleBatches() {
+    public void shouldWriteNoSchemaFoundToViolationsAcrossMultipleBatches() throws Exception {
         givenMissingSourceReference();
         givenAnInputStreamWithSchemaInference();
         givenTableStreamingQuery();
@@ -267,9 +305,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data1", pk1);
         thenStructuredViolationsContainsForPK("data2", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredAndCuratedDoNotContainPK(pk1);
-        thenStructuredAndCuratedDoNotContainPK(pk2);
-        thenStructuredAndCuratedDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
 
         whenInsertOccursForPK(pk1, "data4", "2023-11-13 10:00:01.000000");
         whenUpdateOccursForPK(pk2, "data5", "2023-11-13 10:00:01.000000");
@@ -280,13 +318,13 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data4", pk1);
         thenStructuredViolationsContainsForPK("data5", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredAndCuratedDoNotContainPK(pk1);
-        thenStructuredAndCuratedDoNotContainPK(pk2);
-        thenStructuredAndCuratedDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
     }
 
     @Test
-    public void shouldWriteSchemaMismatchesToViolationsAcrossMultipleBatches() {
+    public void shouldWriteSchemaMismatchesToViolationsAcrossMultipleBatches() throws Exception {
         givenSourceReference();
         givenASourceReferenceSchema();
         givenASourceReferencePrimaryKey();
@@ -304,9 +342,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data1", pk1);
         thenStructuredViolationsContainsForPK("data2", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredAndCuratedDoNotContainPK(pk1);
-        thenStructuredAndCuratedDoNotContainPK(pk2);
-        thenStructuredAndCuratedDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
 
         whenInsertOccursForPK(pk1, "data4", "2023-11-13 10:00:01.000000");
         whenUpdateOccursForPK(pk2, "data5", "2023-11-13 10:00:01.000000");
@@ -317,9 +355,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data4", pk1);
         thenStructuredViolationsContainsForPK("data5", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredAndCuratedDoNotContainPK(pk1);
-        thenStructuredAndCuratedDoNotContainPK(pk2);
-        thenStructuredAndCuratedDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
     }
 
     private void givenAMatchingSchema() {
@@ -369,6 +407,7 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
                 .thenReturn(Optional.of(sourceReference));
         when(sourceReference.getSource()).thenReturn(inputSchemaName);
         when(sourceReference.getTable()).thenReturn(inputTableName);
+        when(sourceReference.getFullyQualifiedTableName()).thenReturn(format("%s.%s", inputSchemaName, inputTableName));
     }
 
     private void givenASourceReferenceSchema() {
@@ -378,9 +417,46 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
     private void givenASourceReferencePrimaryKey() {
         when(sourceReference.getPrimaryKey()).thenReturn(new SourceReference.PrimaryKey(PRIMARY_KEY_COLUMN));
     }
+
     private void givenMissingSourceReference() {
         when(sourceReferenceService.getSourceReference(inputSchemaName, inputTableName))
                 .thenReturn(Optional.empty());
+    }
+
+    private void givenDatastoreCredentials() {
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername(operationalDataStore.getUsername());
+        credentials.setPassword(operationalDataStore.getPassword());
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(
+                new OperationalDataStoreConnectionDetails(
+                        operationalDataStore.getJdbcUrl(),
+                        operationalDataStore.getDriverClassName(),
+                        credentials
+                )
+        );
+    }
+
+    private void givenSchemas() throws SQLException {
+        when(arguments.getOperationalDataStoreLoadingSchemaName()).thenReturn("loading");
+        givenSchemaExists("loading");
+        givenSchemaExists(inputSchemaName);
+    }
+
+    private void givenSchemaExists(String schemaName) throws SQLException {
+        Properties jdbcProps = new Properties();
+        jdbcProps.put("user", operationalDataStore.getUsername());
+        jdbcProps.put("password", operationalDataStore.getPassword());
+        try(Statement statement = testQueryConnection.createStatement()) {
+            statement.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName);
+        }
+    }
+
+    private void givenEmptyDestinationTableExists() throws SQLException {
+        try(Statement statement = testQueryConnection.createStatement()) {
+            statement.execute(format("CREATE TABLE IF NOT EXISTS %s.%s (pk INTEGER, data VARCHAR)", inputSchemaName, inputTableName));
+            statement.execute(format("TRUNCATE TABLE %s.%s", inputSchemaName, inputTableName));
+        }
     }
 
     private void givenTableStreamingQuery() throws NoSchemaNoDataException {
@@ -391,11 +467,18 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
                 dataProvider,
                 tableDiscoveryService
         );
+        OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
+        ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
+        OperationalDataStoreDataAccess operationalDataStoreDataAccess =
+                new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+        OperationalDataStoreService operationalDataStoreService =
+                new OperationalDataStoreServiceImpl(arguments, operationalDataStoreTransformation, operationalDataStoreDataAccess);
         CdcBatchProcessor batchProcessor = new CdcBatchProcessor(
                 new ValidationService(violationService),
                 new StructuredZoneCDC(arguments, violationService, storageService),
                 new CuratedZoneCDC(arguments, violationService, storageService),
-                dataProvider
+                dataProvider,
+                operationalDataStoreService
         );
         TableStreamingQueryProvider streamingQueryProvider = new TableStreamingQueryProvider(
                 arguments,
@@ -435,5 +518,46 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
     private void whenDataIsAddedToTheInputStream(List<Row> inputData) {
         Seq<Row> input = convertListToSeq(inputData);
         inputStream.addData(input);
+    }
+
+    private void thenOperationalDataStoreContainsForPK(String data, int primaryKey) throws SQLException {
+        String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d AND %s = '%s'",
+                inputSchemaName, inputTableName, PRIMARY_KEY_COLUMN, primaryKey, DATA_COLUMN, data);
+        try(Statement statement = testQueryConnection.createStatement()) {
+            ResultSet resultSet = statement.executeQuery(sql);
+            if(resultSet.next()) {
+                int count = resultSet.getInt(1);
+                assertEquals(1, count);
+            }
+        }
+    }
+
+    private void thenStructuredCuratedAndOperationalDataStoreContainForPK(String data, int primaryKey) throws SQLException {
+        thenStructuredAndCuratedContainForPK(data, primaryKey);
+        thenOperationalDataStoreContainsForPK(data, primaryKey);
+    }
+
+    private void thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(int primaryKey) throws SQLException {
+        thenStructuredAndCuratedDoNotContainPK(primaryKey);
+        thenOperationalDataStoreDoesNotContainPK(primaryKey);
+    }
+
+    private void thenOperationalDataStoreDoesNotContainPK(int primaryKey) throws SQLException {
+        try {
+            String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d",
+                    inputSchemaName, inputTableName, PRIMARY_KEY_COLUMN, primaryKey);
+            try (Statement statement = testQueryConnection.createStatement()) {
+                ResultSet resultSet = statement.executeQuery(sql);
+                if (resultSet.next()) {
+                    int count = resultSet.getInt(1);
+                    assertEquals(0, count);
+                }
+            }
+        } catch (SQLException e) {
+            // If the table doesn't exist then that is fine and it doesn't contain the primary key
+            if(!(e.getMessage().contains("Table") && e.getMessage().contains("not found"))) {
+                throw e;
+            }
+        }
     }
 }

--- a/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
@@ -60,8 +60,6 @@ import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADAT
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
 import static uk.gov.justice.digital.test.MinimalTestData.encoder;
-import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreContainsForPK;
-import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreDoesNotContainPK;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 import static uk.gov.justice.digital.test.SparkTestHelpers.convertListToSeq;
@@ -137,9 +135,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk2);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3, testQueryConnection);
     }
     @Test
     public void shouldHandleMultiplePrimaryKeysAcrossBatches() throws Exception {
@@ -157,9 +155,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1a", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2a", pk2);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3a", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1a", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2a", pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3a", pk3, testQueryConnection);
 
         whenUpdateOccursForPK(pk1, "data1b", "2023-11-13 10:01:01.000000");
         whenUpdateOccursForPK(pk2, "data2b", "2023-11-13 10:01:01.000000");
@@ -167,9 +165,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1b", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2b", pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1b", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2b", pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -203,10 +201,10 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2c", pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data4b", pk4);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2c", pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data4b", pk4, testQueryConnection);
     }
 
     @Test
@@ -223,25 +221,25 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
 
         whenUpdateOccursForPK(pk1, "data2", "2023-11-13 10:02:00.000000");
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data2", pk1, testQueryConnection);
 
         whenUpdateOccursForPK(pk1, "data3", "2023-11-13 10:03:00.000000");
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk1);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk1, testQueryConnection);
 
         whenDeleteOccursForPK(pk1, "2023-11-13 10:04:00.000000");
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
     }
 
     @Test
@@ -259,8 +257,8 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
     }
 
     @Test
@@ -279,10 +277,10 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
         whenTheNextBatchIsProcessed();
 
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1);
-        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreContainForPK("data3", pk3, testQueryConnection);
 
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
         thenStructuredViolationsContainsForPK("data2", pk2);
     }
 
@@ -303,9 +301,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data1", pk1);
         thenStructuredViolationsContainsForPK("data2", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
 
         whenInsertOccursForPK(pk1, "data4", "2023-11-13 10:00:01.000000");
         whenUpdateOccursForPK(pk2, "data5", "2023-11-13 10:00:01.000000");
@@ -316,9 +314,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data4", pk1);
         thenStructuredViolationsContainsForPK("data5", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     @Test
@@ -340,9 +338,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data1", pk1);
         thenStructuredViolationsContainsForPK("data2", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
 
         whenInsertOccursForPK(pk1, "data4", "2023-11-13 10:00:01.000000");
         whenUpdateOccursForPK(pk2, "data5", "2023-11-13 10:00:01.000000");
@@ -353,9 +351,9 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         thenStructuredViolationsContainsForPK("data4", pk1);
         thenStructuredViolationsContainsForPK("data5", pk2);
         thenStructuredViolationsContainsForPK(null, pk3);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2);
-        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk1, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk2, testQueryConnection);
+        thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(pk3, testQueryConnection);
     }
 
     private void givenAMatchingSchema() {
@@ -494,23 +492,5 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
     private void whenDataIsAddedToTheInputStream(List<Row> inputData) {
         Seq<Row> input = convertListToSeq(inputData);
         inputStream.addData(input);
-    }
-
-    private void thenOperationalDataStoreContainsForPK(String data, int primaryKey) throws SQLException {
-        assertOperationalDataStoreContainsForPK(inputSchemaName, inputTableName, data, primaryKey, testQueryConnection);
-    }
-
-    private void thenStructuredCuratedAndOperationalDataStoreContainForPK(String data, int primaryKey) throws SQLException {
-        thenStructuredAndCuratedContainForPK(data, primaryKey);
-        thenOperationalDataStoreContainsForPK(data, primaryKey);
-    }
-
-    private void thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(int primaryKey) throws SQLException {
-        thenStructuredAndCuratedDoNotContainPK(primaryKey);
-        thenOperationalDataStoreDoesNotContainPK(primaryKey);
-    }
-
-    private void thenOperationalDataStoreDoesNotContainPK(int primaryKey) throws SQLException {
-        assertOperationalDataStoreDoesNotContainPK(inputSchemaName, inputTableName, primaryKey, testQueryConnection);
     }
 }

--- a/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
@@ -87,9 +87,10 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
         tableName = "public._" + UUID.randomUUID().toString().replaceAll("-", "_");
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(tableName);
 
+        ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
         underTest = new OperationalDataStoreServiceImpl(
                 new OperationalDataStoreTransformation(),
-                new OperationalDataStoreDataAccess(mockConnectionDetailsService)
+                new OperationalDataStoreDataAccess(mockConnectionDetailsService, connectionPoolProvider)
         );
     }
 
@@ -100,7 +101,7 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
                 RowFactory.create("pk2", "2023-11-13 10:49:28.123458", "I", "some other data")
         ), schema);
 
-        underTest.storeBatchData(df, sourceReference);
+        underTest.overwriteData(df, sourceReference);
 
         Properties jdbcProperties = new Properties();
         jdbcProperties.put("user", operationalDataStore.getUsername());
@@ -128,8 +129,8 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
                 RowFactory.create("pk2", "2023-11-13 10:49:28.123458", "I", "some other new data")
         ), schema);
 
-        underTest.storeBatchData(df1, sourceReference);
-        underTest.storeBatchData(df2, sourceReference);
+        underTest.overwriteData(df1, sourceReference);
+        underTest.overwriteData(df2, sourceReference);
 
         Properties jdbcProperties = new Properties();
         jdbcProperties.put("user", operationalDataStore.getUsername());
@@ -154,7 +155,7 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
                 RowFactory.create("pk2", "2023-11-13 10:49:28.123458", "I", "some other data")
         ), schema);
 
-        underTest.storeBatchData(df, sourceReference);
+        underTest.overwriteData(df, sourceReference);
 
         Properties jdbcProperties = new Properties();
         jdbcProperties.put("user", operationalDataStore.getUsername());

--- a/src/it/java/uk/gov/justice/digital/test/BaseMinimalDataIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/test/BaseMinimalDataIntegrationTest.java
@@ -5,9 +5,11 @@ import uk.gov.justice.digital.config.BaseSparkTest;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
 
-import static org.apache.spark.sql.functions.lit;
-import static uk.gov.justice.digital.test.MinimalTestData.inserts;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreContainsForPK;
+import static uk.gov.justice.digital.test.SharedTestFunctions.assertOperationalDataStoreDoesNotContainPK;
 
 public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
     protected static final int pk1 = 1;
@@ -27,10 +29,6 @@ public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
     protected String curatedPath;
     protected String violationsPath;
     protected String checkpointPath;
-
-    protected void thenStructuredAndCuratedContainForPK(String data, int primaryKey) {
-        assertStructuredAndCuratedForTableContainForPK(structuredPath, curatedPath, inputSchemaName, inputTableName, data, primaryKey);
-    }
 
     protected void thenStructuredViolationsContainsPK(int primaryKey) {
         String violationsTablePath = Paths.get(violationsPath)
@@ -52,9 +50,13 @@ public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
         assertViolationsTableContainsForPK(violationsTablePath, data, primaryKey);
     }
 
-    protected void thenStructuredAndCuratedDoNotContainPK(int primaryKey) {
-        assertStructuredAndCuratedForTableDoNotContainPK(structuredPath, curatedPath, inputSchemaName, inputTableName, primaryKey);
+    protected void thenStructuredCuratedAndOperationalDataStoreContainForPK(String data, int primaryKey, Connection testQueryConnection) throws SQLException {
+        assertStructuredAndCuratedForTableContainForPK(structuredPath, curatedPath, inputSchemaName, inputTableName, data, primaryKey);
+        assertOperationalDataStoreContainsForPK(inputSchemaName, inputTableName, data, primaryKey, testQueryConnection);
     }
 
-
+    protected void thenStructuredCuratedAndOperationalDataStoreDoNotContainPK(int primaryKey, Connection testQueryConnection) throws SQLException {
+        assertStructuredAndCuratedForTableDoNotContainPK(structuredPath, curatedPath, inputSchemaName, inputTableName, primaryKey);
+        assertOperationalDataStoreDoesNotContainPK(inputSchemaName, inputTableName, primaryKey, testQueryConnection);
+    }
 }

--- a/src/it/java/uk/gov/justice/digital/test/SharedTestFunctions.java
+++ b/src/it/java/uk/gov/justice/digital/test/SharedTestFunctions.java
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.test;
+
+import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
+import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreConnectionDetailsService;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.test.MinimalTestData.DATA_COLUMN;
+import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
+
+public class SharedTestFunctions {
+
+    public static void givenDatastoreCredentials(OperationalDataStoreConnectionDetailsService connectionDetailsService, InMemoryOperationalDataStore operationalDataStore) {
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername(operationalDataStore.getUsername());
+        credentials.setPassword(operationalDataStore.getPassword());
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(
+                new OperationalDataStoreConnectionDetails(
+                        operationalDataStore.getJdbcUrl(),
+                        operationalDataStore.getDriverClassName(),
+                        credentials
+                )
+        );
+    }
+
+    public static void givenSchemaExists(String schemaName, Connection testQueryConnection) throws SQLException {
+        try(Statement statement = testQueryConnection.createStatement()) {
+            statement.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName);
+        }
+    }
+
+    public static void assertOperationalDataStoreContainsForPK(String schemaName, String table, String data, int primaryKey, Connection testQueryConnection) throws SQLException {
+        String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d AND %s = '%s'",
+                schemaName, table, PRIMARY_KEY_COLUMN, primaryKey, DATA_COLUMN, data);
+        try(Statement statement = testQueryConnection.createStatement()) {
+            ResultSet resultSet = statement.executeQuery(sql);
+            if(resultSet.next()) {
+                int count = resultSet.getInt(1);
+                assertEquals(1, count);
+            }
+        }
+    }
+
+    public static void assertOperationalDataStoreDoesNotContainPK(String schemaName, String table, int primaryKey, Connection testQueryConnection) throws SQLException {
+        try {
+            String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d",
+                    schemaName, table, PRIMARY_KEY_COLUMN, primaryKey);
+            try (Statement statement = testQueryConnection.createStatement()) {
+                ResultSet resultSet = statement.executeQuery(sql);
+                if (resultSet.next()) {
+                    int count = resultSet.getInt(1);
+                    assertEquals(0, count);
+                }
+            }
+        } catch (SQLException e) {
+            // If the table doesn't exist then that is fine and it doesn't contain the primary key
+            if(!(e.getMessage().contains("Table") && e.getMessage().contains("not found"))) {
+                throw e;
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -133,6 +133,8 @@ public class JobArguments {
     static final String ACTIVATE_GLUE_TRIGGER = "dpr.glue.trigger.activate";
     static final String OPERATIONAL_DATA_STORE_WRITE_ENABLED = "dpr.operational.data.store.write.enabled";
     static final String OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME = "dpr.operational.data.store.glue.connection.name";
+    static final String OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME = "dpr.operational.data.store.loading.schema.name";
+    static final String OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME_DEFAULT = "loading";
 
     private final Map<String, String> config;
 
@@ -420,6 +422,10 @@ public class JobArguments {
 
     public String getOperationalDataStoreGlueConnectionName() {
         return getArgument(OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME);
+    }
+
+    public String getOperationalDataStoreLoadingSchemaName() {
+        return getArgument(OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME, OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME_DEFAULT);
     }
 
     public int orchestrationWaitIntervalSeconds() {

--- a/src/main/java/uk/gov/justice/digital/exception/OperationalDataStoreException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/OperationalDataStoreException.java
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.exception;
+
+public class OperationalDataStoreException extends RuntimeException {
+
+    private static final long serialVersionUID = 8570364121994003864L;
+
+    public OperationalDataStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessor.java
+++ b/src/main/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessor.java
@@ -64,7 +64,7 @@ public class BatchProcessor {
             val validRows = validationService.handleValidation(spark, filteredDf, sourceReference, inferredSchema, STRUCTURED_LOAD);
             val structuredLoadDf = structuredZoneLoad.process(spark, validRows, sourceReference);
             val curatedLoadDf = curatedZoneLoad.process(spark, structuredLoadDf, sourceReference);
-            operationalDataStoreService.storeBatchData(curatedLoadDf, sourceReference);
+            operationalDataStoreService.overwriteData(curatedLoadDf, sourceReference);
             dataFrame.unpersist();
 
             logger.info("Processed records {}/{} in {}ms",

--- a/src/main/java/uk/gov/justice/digital/job/batchprocessing/CdcBatchProcessor.java
+++ b/src/main/java/uk/gov/justice/digital/job/batchprocessing/CdcBatchProcessor.java
@@ -16,6 +16,7 @@ import scala.collection.JavaConverters;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ValidationService;
+import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
 import uk.gov.justice.digital.zone.curated.CuratedZoneCDC;
 import uk.gov.justice.digital.zone.structured.StructuredZoneCDC;
 
@@ -35,17 +36,21 @@ public class CdcBatchProcessor {
     private final StructuredZoneCDC structuredZone;
     private final CuratedZoneCDC curatedZone;
     private final S3DataProvider dataProvider;
+    private final OperationalDataStoreService operationalDataStoreService;
 
     @Inject
     public CdcBatchProcessor(
             ValidationService validationService,
             StructuredZoneCDC structuredZone,
             CuratedZoneCDC curatedZone,
-            S3DataProvider dataProvider) {
+            S3DataProvider dataProvider,
+            OperationalDataStoreService operationalDataStoreService
+    ) {
         this.validationService = validationService;
         this.structuredZone = structuredZone;
         this.curatedZone = curatedZone;
         this.dataProvider = dataProvider;
+        this.operationalDataStoreService = operationalDataStoreService;
     }
 
     public void processBatch(SourceReference sourceReference, SparkSession spark, Dataset<Row> df, Long batchId) {
@@ -58,8 +63,9 @@ public class CdcBatchProcessor {
             val validRows = validationService.handleValidation(spark, df, sourceReference, inferredSchema, STRUCTURED_CDC);
             val latestCDCRecordsByPK = latestRecords(validRows, sourceReference.getPrimaryKey());
 
-            structuredZone.process(spark, latestCDCRecordsByPK, sourceReference);
-            curatedZone.process(spark, latestCDCRecordsByPK, sourceReference);
+            val structuredDf = structuredZone.process(spark, latestCDCRecordsByPK, sourceReference);
+            val curatedDf = curatedZone.process(spark, structuredDf, sourceReference);
+            operationalDataStoreService.mergeData(curatedDf, sourceReference);
             logger.info("Processing batch {} {}.{} took {}ms", batchId, source, table, System.currentTimeMillis() - batchStartTime);
         } else {
             logger.info("Skipping empty batch");

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/ConnectionPoolProvider.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/ConnectionPoolProvider.java
@@ -9,7 +9,7 @@ import javax.sql.DataSource;
 @Singleton
 public class ConnectionPoolProvider {
 
-    private static final int maxHikariPoolSize = 10;
+    private static final int MAX_HIKARI_POOL_SIZE = 10;
 
     DataSource getConnectionPool(
             String jdbcUrl,
@@ -22,7 +22,7 @@ public class ConnectionPoolProvider {
         hikariConfig.setDriverClassName(jdbcDriverClassName);
         hikariConfig.setUsername(username);
         hikariConfig.setPassword(password);
-        hikariConfig.setMaximumPoolSize(maxHikariPoolSize);
+        hikariConfig.setMaximumPoolSize(MAX_HIKARI_POOL_SIZE);
         return new HikariDataSource(hikariConfig);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/ConnectionPoolProvider.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/ConnectionPoolProvider.java
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.service.operationaldatastore;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+@Singleton
+public class ConnectionPoolProvider {
+
+    private static final int maxHikariPoolSize = 10;
+
+    DataSource getConnectionPool(
+            String jdbcUrl,
+            String jdbcDriverClassName,
+            String username,
+            String password
+    ) {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setDriverClassName(jdbcDriverClassName);
+        hikariConfig.setUsername(username);
+        hikariConfig.setPassword(password);
+        hikariConfig.setMaximumPoolSize(maxHikariPoolSize);
+        return new HikariDataSource(hikariConfig);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/DisabledOperationalDataStoreService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/DisabledOperationalDataStoreService.java
@@ -18,7 +18,12 @@ public class DisabledOperationalDataStoreService implements OperationalDataStore
     }
 
     @Override
-    public void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference) {
-        logger.info("Operational DataStore functionality is disabled, skipping table {}.{}", sourceReference.getSource(), sourceReference.getTable());
+    public void overwriteData(Dataset<Row> dataFrame, SourceReference sourceReference) {
+        logger.info("Operational DataStore functionality is disabled, Skipping overwrite data to table {}.{}", sourceReference.getSource(), sourceReference.getTable());
+    }
+
+    @Override
+    public void mergeData(Dataset<Row> dataFrame, SourceReference sourceReference) {
+        logger.info("Operational DataStore functionality is disabled, Skipping merge into table {}.{}", sourceReference.getSource(), sourceReference.getTable());
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
@@ -120,7 +120,7 @@ public class OperationalDataStoreDataAccess {
 
     private String buildUpdateAssignments(SourceReference sourceReference, String[] lowerCaseFieldNames) {
         Set<String> pkColumns = sourceReference.getPrimaryKey().getKeyColumnNames().stream().map(String::toLowerCase).collect(Collectors.toSet());
-        return String.join(", ", Arrays.stream(lowerCaseFieldNames).filter(c -> !pkColumns.contains(c)).map(c -> c + " = s." + c).toArray(String[]::new));
+        return String.join(", ", Arrays.stream(lowerCaseFieldNames).filter(c -> !pkColumns.contains(c)).map(c -> "d." + c + " = s." + c).toArray(String[]::new));
     }
 
     private String buildInsertColumnNames(String[] lowerCaseFieldNames) {

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.service.operationaldatastore;
 
+import com.google.common.annotations.VisibleForTesting;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.val;
 import org.apache.spark.sql.Dataset;
@@ -8,8 +10,18 @@ import org.apache.spark.sql.SaveMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
+import uk.gov.justice.digital.datahub.model.SourceReference;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
 
 /**
  * Responsible for accessing the Operational DataStore.
@@ -20,9 +32,15 @@ public class OperationalDataStoreDataAccess {
     private static final Logger logger = LoggerFactory.getLogger(OperationalDataStoreDataAccess.class);
 
     private final String jdbcUrl;
+    // Used by Spark to write to the DataStore
     private final Properties jdbcProps;
+    private final DataSource dataSource;
 
-    public OperationalDataStoreDataAccess(OperationalDataStoreConnectionDetailsService connectionDetailsService) {
+    @Inject
+    public OperationalDataStoreDataAccess(
+            OperationalDataStoreConnectionDetailsService connectionDetailsService,
+            ConnectionPoolProvider connectionPoolProvider
+    ) {
         logger.debug("Retrieving connection details for Operational DataStore");
         OperationalDataStoreConnectionDetails connectionDetails = connectionDetailsService.getConnectionDetails();
         jdbcUrl = connectionDetails.getUrl();
@@ -30,6 +48,12 @@ public class OperationalDataStoreDataAccess {
         jdbcProps.put("driver", connectionDetails.getJdbcDriverClassName());
         jdbcProps.put("user", connectionDetails.getCredentials().getUsername());
         jdbcProps.put("password", connectionDetails.getCredentials().getPassword());
+        dataSource = connectionPoolProvider.getConnectionPool(
+                jdbcUrl,
+                connectionDetails.getJdbcDriverClassName(),
+                connectionDetails.getCredentials().getUsername(),
+                connectionDetails.getCredentials().getPassword()
+        );
         logger.debug("Finished retrieving connection details for Operational DataStore");
     }
 
@@ -40,5 +64,70 @@ public class OperationalDataStoreDataAccess {
                 .mode(SaveMode.Overwrite)
                 .jdbc(jdbcUrl, destinationTableName, jdbcProps);
         logger.debug("Finished writing data to Operational DataStore in {}ms", System.currentTimeMillis() - startTime);
+    }
+
+    void merge(String temporaryTableName, String destinationTableName, SourceReference sourceReference) {
+        val startTime = System.currentTimeMillis();
+        logger.debug("Merging into destination table {}", destinationTableName);
+        String mergeSql = buildMergeSql(temporaryTableName, destinationTableName, sourceReference);
+        logger.debug("Merge SQL is {}", mergeSql);
+        String truncateSql = format("TRUNCATE TABLE %s", temporaryTableName);
+        logger.debug("truncate SQL is {}", truncateSql);
+
+        try (Connection connection = dataSource.getConnection()) {
+            try(Statement statement = connection.createStatement()) {
+                statement.execute(mergeSql);
+                logger.debug("Finished running MERGE into destination table {}", destinationTableName);
+                // Truncation of the temporary loading table is not really required since spark will truncate it
+                // before it is reloaded - we do it just to keep space free.
+                statement.execute(truncateSql);
+                logger.debug("Finished running TRUNCATE on temporary table {}", temporaryTableName);
+            }
+        } catch (SQLException e) {
+            logger.error("Exception during merge from temporary table to destination", e);
+            throw new RuntimeException(e);
+        }
+
+        logger.debug("Finished merging into destination table {} in {}ms", destinationTableName, System.currentTimeMillis() - startTime);
+    }
+
+    @VisibleForTesting
+    String buildMergeSql(String temporaryTableName, String destinationTableName, SourceReference sourceReference) {
+        // Build the various fragments of the SQL we need
+        String[] lowerCaseFieldNames = fieldNamesToLowerCase(sourceReference);
+        String joinCondition = buildJoinCondition(sourceReference);
+        String updateAssignments = buildUpdateAssignments(sourceReference, lowerCaseFieldNames);
+        String insertColumnNames = buildInsertColumnNames(lowerCaseFieldNames);
+        String insertValues = buildInsertValues(lowerCaseFieldNames);
+
+        // 'd' is the destination table we merge into.
+        // 's' is the source table we merge from.
+        return format("MERGE INTO %s d\n" +
+                        "USING %s s ON %s\n" +
+                        "    WHEN MATCHED AND s.op = 'D' THEN DELETE\n" +
+                        "    WHEN MATCHED AND s.op = 'U' THEN UPDATE SET %s\n" +
+                        "    WHEN NOT MATCHED AND (s.op = 'I' OR s.op = 'U') THEN INSERT (%s) VALUES (%s)",
+                destinationTableName, temporaryTableName, joinCondition, updateAssignments, insertColumnNames, insertValues);
+    }
+
+    private String[] fieldNamesToLowerCase(SourceReference sourceReference) {
+        return Arrays.stream(sourceReference.getSchema().fieldNames()).map(String::toLowerCase).toArray(String[]::new);
+    }
+
+    private String buildJoinCondition(SourceReference sourceReference) {
+        return sourceReference.getPrimaryKey().getSparkCondition("s", "d").toLowerCase();
+    }
+
+    private String buildUpdateAssignments(SourceReference sourceReference, String[] lowerCaseFieldNames) {
+        Set<String> pkColumns = sourceReference.getPrimaryKey().getKeyColumnNames().stream().map(String::toLowerCase).collect(Collectors.toSet());
+        return String.join(", ", Arrays.stream(lowerCaseFieldNames).filter(c -> !pkColumns.contains(c)).map(c -> c + " = s." + c).toArray(String[]::new));
+    }
+
+    private String buildInsertColumnNames(String[] lowerCaseFieldNames) {
+        return String.join(", ", lowerCaseFieldNames);
+    }
+
+    private String buildInsertValues(String[] lowerCaseFieldNames) {
+        return String.join(", ", Arrays.stream(lowerCaseFieldNames).map(c -> "s." + c).toArray(String[]::new));
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
@@ -119,7 +119,7 @@ public class OperationalDataStoreDataAccess {
 
     private String buildUpdateAssignments(SourceReference sourceReference, String[] lowerCaseFieldNames) {
         Set<String> pkColumns = sourceReference.getPrimaryKey().getKeyColumnNames().stream().map(String::toLowerCase).collect(Collectors.toSet());
-        return String.join(", ", Arrays.stream(lowerCaseFieldNames).filter(c -> !pkColumns.contains(c)).map(c -> "destination." + c + " = source." + c).toArray(String[]::new));
+        return String.join(", ", Arrays.stream(lowerCaseFieldNames).filter(c -> !pkColumns.contains(c)).map(c -> c + " = source." + c).toArray(String[]::new));
     }
 
     private String buildInsertColumnNames(String[] lowerCaseFieldNames) {

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
@@ -85,9 +85,7 @@ public class OperationalDataStoreDataAccess {
                 logger.debug("Finished running TRUNCATE on temporary table {}", temporaryTableName);
             }
         } catch (SQLException e) {
-            String message = "Exception during merge from temporary table to destination";
-            logger.error(message, e);
-            throw new OperationalDataStoreException(message, e);
+            throw new OperationalDataStoreException("Exception during merge from temporary table to destination", e);
         }
 
         logger.debug("Finished merging into destination table {} in {}ms", destinationTableName, System.currentTimeMillis() - startTime);

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccess.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
 import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.exception.OperationalDataStoreException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -84,8 +85,9 @@ public class OperationalDataStoreDataAccess {
                 logger.debug("Finished running TRUNCATE on temporary table {}", temporaryTableName);
             }
         } catch (SQLException e) {
-            logger.error("Exception during merge from temporary table to destination", e);
-            throw new RuntimeException(e);
+            String message = "Exception during merge from temporary table to destination";
+            logger.error(message, e);
+            throw new OperationalDataStoreException(message, e);
         }
 
         logger.debug("Finished merging into destination table {} in {}ms", destinationTableName, System.currentTimeMillis() - startTime);

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreService.java
@@ -5,5 +5,6 @@ import org.apache.spark.sql.Row;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
 public interface OperationalDataStoreService {
-    void storeBatchData(Dataset<Row> dataFrame, SourceReference sourceReference);
+    void overwriteData(Dataset<Row> dataFrame, SourceReference sourceReference);
+    void mergeData(Dataset<Row> dataFrame, SourceReference sourceReference);
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreService.java
@@ -4,6 +4,9 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
+/**
+ * Entrypoint for access to the Operational DataStore.
+ */
 public interface OperationalDataStoreService {
     void overwriteData(Dataset<Row> dataFrame, SourceReference sourceReference);
     void mergeData(Dataset<Row> dataFrame, SourceReference sourceReference);

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceImpl.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceImpl.java
@@ -8,6 +8,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
 import static uk.gov.justice.digital.common.CommonDataFields.CHECKPOINT_COL;
@@ -22,16 +23,18 @@ import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
 public class OperationalDataStoreServiceImpl implements OperationalDataStoreService {
 
     private static final Logger logger = LoggerFactory.getLogger(OperationalDataStoreServiceImpl.class);
-    private static final String LOADING_SCHEMA = "loading";
 
+    private final String loadingSchema;
     private final OperationalDataStoreTransformation transformer;
     private final OperationalDataStoreDataAccess operationalDataStoreDataAccess;
 
     @Inject
     public OperationalDataStoreServiceImpl(
+            JobArguments jobArguments,
             OperationalDataStoreTransformation transformer,
             OperationalDataStoreDataAccess operationalDataStoreDataAccess
     ) {
+        this.loadingSchema = jobArguments.getOperationalDataStoreLoadingSchemaName();
         this.transformer = transformer;
         this.operationalDataStoreDataAccess = operationalDataStoreDataAccess;
     }
@@ -58,7 +61,7 @@ public class OperationalDataStoreServiceImpl implements OperationalDataStoreServ
         String destinationTableName = sourceReference.getFullyQualifiedTableName();
         logger.info("Processing records to merge into Operational Data Store table {}", destinationTableName);
 
-        String temporaryLoadingTableName = LOADING_SCHEMA + "." + sourceReference.getTable();
+        String temporaryLoadingTableName = loadingSchema + "." + sourceReference.getTable();
         logger.debug("Loading to temporary table {}", temporaryLoadingTableName);
 
         Dataset<Row> transformedDf = transformer

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreTransformation.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreTransformation.java
@@ -13,9 +13,6 @@ import java.util.Arrays;
 
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.regexp_replace;
-import static uk.gov.justice.digital.common.CommonDataFields.CHECKPOINT_COL;
-import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
-import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
 
 /**
  * Transforms a DataFrame to the format we want to store in the Operational DataStore

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreTransformation.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreTransformation.java
@@ -30,9 +30,7 @@ public class OperationalDataStoreTransformation {
         // We normalise columns to lower case to avoid having to quote every column due to Postgres lower casing everything in incoming queries
         Dataset<Row> lowerCaseColsDf = normaliseColumnsToLowerCase(dataFrame);
         // Handle 0x00 null String character which cannot be inserted in to a Postgres text column
-        Dataset<Row> withoutNullsDf = stripNullStrings(lowerCaseColsDf);
-        // We don't store these metadata columns in the destination table so we remove them
-        return withoutNullsDf.drop(OPERATION.toLowerCase(), TIMESTAMP.toLowerCase(), CHECKPOINT_COL.toLowerCase());
+        return stripNullStrings(lowerCaseColsDf);
     }
 
     private static Dataset<Row> normaliseColumnsToLowerCase(Dataset<Row> dataFrame) {

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorTest.java
@@ -88,7 +88,7 @@ class BatchProcessorTest extends BaseSparkTest {
 
         verify(structuredZoneLoad, times(0)).process(any(), any(), any());
         verify(curatedZoneLoad, times(0)).process(any(), any(), any());
-        verify(operationalDataStoreService, times(0)).storeBatchData(any(), any());
+        verify(operationalDataStoreService, times(0)).overwriteData(any(), any());
     }
 
     @Test
@@ -128,7 +128,7 @@ class BatchProcessorTest extends BaseSparkTest {
 
         underTest.processBatch(spark, sourceReference, inputDf);
 
-        verify(operationalDataStoreService, times(1)).storeBatchData(curatedDfMock, sourceReference);
+        verify(operationalDataStoreService, times(1)).overwriteData(curatedDfMock, sourceReference);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
@@ -4,17 +4,25 @@ import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
 import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
+import uk.gov.justice.digital.datahub.model.SourceReference;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +35,20 @@ class OperationalDataStoreDataAccessTest {
     private Dataset<Row> dataframe;
     @Mock
     private DataFrameWriter<Row> dataframeWriter;
+    @Mock
+    private ConnectionPoolProvider connectionPoolProvider;
+    @Mock
+    private DataSource dataSource;
+    @Mock
+    private Connection connection;
+    @Mock
+    private Statement statement;
+    @Mock
+    private SourceReference sourceReference;
+    @Mock
+    private StructType schema;
+    @Mock
+    private SourceReference.PrimaryKey primaryKey;
 
     private OperationalDataStoreDataAccess underTest;
 
@@ -41,9 +63,30 @@ class OperationalDataStoreDataAccessTest {
 
         when(connectionDetailsService.getConnectionDetails()).thenReturn(connectionDetails);
 
-        underTest = new OperationalDataStoreDataAccess(connectionDetailsService);
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
 
         verify(connectionDetailsService, times(1)).getConnectionDetails();
+    }
+
+    @Test
+    void shouldInitialiseConnectionPoolInConstructor() {
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername("username");
+        credentials.setPassword("password");
+        OperationalDataStoreConnectionDetails connectionDetails = new OperationalDataStoreConnectionDetails(
+                "jdbc-url", "org.postgresql.Driver", credentials
+        );
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(connectionDetails);
+
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+
+        verify(connectionPoolProvider, times(1)).getConnectionPool(
+                "jdbc-url",
+                "org.postgresql.Driver",
+                "username",
+                "password"
+        );
     }
 
     @Test
@@ -60,7 +103,7 @@ class OperationalDataStoreDataAccessTest {
         when(dataframe.write()).thenReturn(dataframeWriter);
         when(dataframeWriter.mode(any(SaveMode.class))).thenReturn(dataframeWriter);
 
-        underTest = new OperationalDataStoreDataAccess(connectionDetailsService);
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
         underTest.overwriteTable(dataframe, destinationTableName);
 
         Properties expectedProperties = new Properties();
@@ -72,4 +115,125 @@ class OperationalDataStoreDataAccessTest {
         verify(dataframeWriter, times(1))
                 .jdbc("jdbc-url", destinationTableName, expectedProperties);
     }
+
+    @Test
+    void shouldMerge() throws Exception {
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername("username");
+        credentials.setPassword("password");
+        String temporaryTableName = "loading.table";
+        String destinationTableName = "some.table";
+        OperationalDataStoreConnectionDetails connectionDetails = new OperationalDataStoreConnectionDetails(
+                "jdbc-url", "org.postgresql.Driver", credentials
+        );
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(connectionDetails);
+        when(connectionPoolProvider.getConnectionPool(any(), any(), any(), any())).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(sourceReference.getSchema()).thenReturn(schema);
+        when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
+        when(schema.fieldNames()).thenReturn(new String[]{"column1", "column2"});
+        when(primaryKey.getSparkCondition(any(), any())).thenReturn("s.column1 = d.column1");
+        when(primaryKey.getKeyColumnNames()).thenReturn(Arrays.asList("column1"));
+
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+        underTest.merge(temporaryTableName, destinationTableName, sourceReference);
+
+        verify(statement, times(2)).execute(any());
+    }
+
+    @Test
+    void shouldCloseResources() throws Exception {
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername("username");
+        credentials.setPassword("password");
+        String temporaryTableName = "loading.table";
+        String destinationTableName = "some.table";
+        OperationalDataStoreConnectionDetails connectionDetails = new OperationalDataStoreConnectionDetails(
+                "jdbc-url", "org.postgresql.Driver", credentials
+        );
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(connectionDetails);
+        when(connectionPoolProvider.getConnectionPool(any(), any(), any(), any())).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(sourceReference.getSchema()).thenReturn(schema);
+        when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
+        when(schema.fieldNames()).thenReturn(new String[]{"column1", "column2"});
+        when(primaryKey.getSparkCondition(any(), any())).thenReturn("s.column1 = d.column1");
+        when(primaryKey.getKeyColumnNames()).thenReturn(Arrays.asList("column1"));
+
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+        underTest.merge(temporaryTableName, destinationTableName, sourceReference);
+
+        verify(connection, times(1)).close();
+        verify(statement, times(1)).close();
+    }
+
+    @Test
+    void shouldCloseResourcesWhenSqlExecutionThrows() throws Exception {
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername("username");
+        credentials.setPassword("password");
+        String temporaryTableName = "loading.table";
+        String destinationTableName = "some.table";
+        OperationalDataStoreConnectionDetails connectionDetails = new OperationalDataStoreConnectionDetails(
+                "jdbc-url", "org.postgresql.Driver", credentials
+        );
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(connectionDetails);
+        when(connectionPoolProvider.getConnectionPool(any(), any(), any(), any())).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.execute(any())).thenThrow(new SQLException());
+        when(sourceReference.getSchema()).thenReturn(schema);
+        when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
+        when(schema.fieldNames()).thenReturn(new String[]{"column1", "column2"});
+        when(primaryKey.getSparkCondition(any(), any())).thenReturn("s.column1 = d.column1");
+        when(primaryKey.getKeyColumnNames()).thenReturn(Arrays.asList("column1"));
+
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+        assertThrows(RuntimeException.class, () -> {
+            underTest.merge(temporaryTableName, destinationTableName, sourceReference);
+        });
+
+        verify(connection, times(1)).close();
+        verify(statement, times(1)).close();
+    }
+
+
+    @Test
+    void shouldBuildMergeSql() {
+        String temporaryTableName = "loading.table";
+        String destinationTableName = "some.table";
+
+        OperationalDataStoreCredentials credentials = new OperationalDataStoreCredentials();
+        credentials.setUsername("username");
+        credentials.setPassword("password");
+        OperationalDataStoreConnectionDetails connectionDetails = new OperationalDataStoreConnectionDetails(
+                "jdbc-url", "org.postgresql.Driver", credentials
+        );
+
+        when(connectionDetailsService.getConnectionDetails()).thenReturn(connectionDetails);
+
+        when(sourceReference.getSchema()).thenReturn(schema);
+        when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
+        when(schema.fieldNames()).thenReturn(new String[]{"pk_col", "column2"});
+        when(primaryKey.getSparkCondition(any(), any())).thenReturn("s.pk_col = d.pk_col");
+        when(primaryKey.getKeyColumnNames()).thenReturn(Arrays.asList("pk_col"));
+
+        underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
+
+        String resultSql = underTest.buildMergeSql(temporaryTableName, destinationTableName, sourceReference);
+        System.out.println(resultSql);
+        String expectedSql = "MERGE INTO some.table d\n" +
+                "USING loading.table s ON s.pk_col = d.pk_col\n" +
+                "    WHEN MATCHED AND s.op = 'D' THEN DELETE\n" +
+                "    WHEN MATCHED AND s.op = 'U' THEN UPDATE SET column2 = s.column2\n" +
+                "    WHEN NOT MATCHED AND (s.op = 'I' OR s.op = 'U') THEN INSERT (pk_col, column2) VALUES (s.pk_col, s.column2)";
+        assertEquals(resultSql, expectedSql);
+
+    }
+
 }

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
@@ -231,7 +231,7 @@ class OperationalDataStoreDataAccessTest {
         String expectedSql = "MERGE INTO some.table d\n" +
                 "USING loading.table s ON s.pk_col = d.pk_col\n" +
                 "    WHEN MATCHED AND s.op = 'D' THEN DELETE\n" +
-                "    WHEN MATCHED AND s.op = 'U' THEN UPDATE SET column2 = s.column2\n" +
+                "    WHEN MATCHED AND s.op = 'U' THEN UPDATE SET d.column2 = s.column2\n" +
                 "    WHEN NOT MATCHED AND (s.op = 'I' OR s.op = 'U') THEN INSERT (pk_col, column2) VALUES (s.pk_col, s.column2)";
         assertEquals(resultSql, expectedSql);
 

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
@@ -229,7 +229,7 @@ class OperationalDataStoreDataAccessTest {
         String expectedSql = "MERGE INTO some.table destination\n" +
                 "USING loading.table source ON source.pk_col = destination.pk_col\n" +
                 "    WHEN MATCHED AND source.op = 'D' THEN DELETE\n" +
-                "    WHEN MATCHED AND source.op = 'U' THEN UPDATE SET destination.column2 = source.column2\n" +
+                "    WHEN MATCHED AND source.op = 'U' THEN UPDATE SET column2 = source.column2\n" +
                 "    WHEN NOT MATCHED AND (source.op = 'I' OR source.op = 'U') THEN INSERT (pk_col, column2) VALUES (source.pk_col, source.column2)";
         assertEquals(expectedSql, resultSql);
 

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreDataAccessTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.datahub.model.OperationalDataStoreConnectionDetails;
 import uk.gov.justice.digital.datahub.model.OperationalDataStoreCredentials;
 import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.exception.OperationalDataStoreException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -194,7 +195,7 @@ class OperationalDataStoreDataAccessTest {
         when(primaryKey.getKeyColumnNames()).thenReturn(Arrays.asList("column1"));
 
         underTest = new OperationalDataStoreDataAccess(connectionDetailsService, connectionPoolProvider);
-        assertThrows(RuntimeException.class, () -> {
+        assertThrows(OperationalDataStoreException.class, () -> {
             underTest.merge(temporaryTableName, destinationTableName, sourceReference);
         });
 

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
@@ -2,6 +2,10 @@ package uk.gov.justice.digital.service.operationaldatastore;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,10 +17,22 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.common.CommonDataFields.CHECKPOINT_COL;
+import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
+import static uk.gov.justice.digital.common.CommonDataFields.TIMESTAMP;
 
 @ExtendWith(MockitoExtension.class)
 class OperationalDataStoreServiceTest {
     private static final String destinationTableName = "somesource.sometable";
+
+    private static final StructType schema = new StructType(new StructField[]{
+            new StructField("PK", DataTypes.StringType, true, Metadata.empty()),
+            new StructField(TIMESTAMP, DataTypes.StringType, true, Metadata.empty()),
+            new StructField(OPERATION, DataTypes.StringType, true, Metadata.empty()),
+            new StructField(CHECKPOINT_COL, DataTypes.StringType, true, Metadata.empty()),
+            new StructField("DATA", DataTypes.StringType, true, Metadata.empty())
+    });
+
     @Mock
     private OperationalDataStoreTransformation mockDataTransformation;
     @Mock
@@ -26,6 +42,8 @@ class OperationalDataStoreServiceTest {
     private Dataset<Row> inputDataframe;
     @Mock
     private Dataset<Row> transformedDataframe;
+    @Mock
+    private Dataset<Row> colsDroppedDataframe;
     @Mock
     private SourceReference sourceReference;
 
@@ -37,22 +55,59 @@ class OperationalDataStoreServiceTest {
     }
 
     @Test
-    void shouldTransformInputDataframe() {
+    void overwriteDataShouldTransformInputDataframe() {
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
         when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
 
-        underTest.storeBatchData(inputDataframe, sourceReference);
+        underTest.overwriteData(inputDataframe, sourceReference);
 
         verify(mockDataTransformation, times(1)).transform(inputDataframe);
     }
 
     @Test
-    void shouldWriteTransformedDataframeToDestinationTable() {
+    void overwriteDataShouldWriteTransformedDataframeToDestinationTableAfterDroppingMetadataCols() {
+        when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
+        when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
+        when(transformedDataframe.drop((String[]) any())).thenReturn(colsDroppedDataframe);
+
+        underTest.overwriteData(inputDataframe, sourceReference);
+
+        verify(transformedDataframe, times(1)).drop("op", "_timestamp", "checkpoint_col");
+        verify(mockDataAccess, times(1)).overwriteTable(colsDroppedDataframe, destinationTableName);
+    }
+
+    @Test
+    void mergeDataShouldTransformInputDataframe() {
         when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
         when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
 
-        underTest.storeBatchData(inputDataframe, sourceReference);
+        underTest.mergeData(inputDataframe, sourceReference);
 
-        verify(mockDataAccess, times(1)).overwriteTable(transformedDataframe, destinationTableName);
+        verify(mockDataTransformation, times(1)).transform(inputDataframe);
+    }
+
+    @Test
+    void mergeDataShouldWriteTransformedDataframeToLoadingTableAfterDroppingMetadataCols() {
+        when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
+        when(sourceReference.getTable()).thenReturn("some_table");
+        when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
+        when(transformedDataframe.drop((String[]) any())).thenReturn(colsDroppedDataframe);
+
+        underTest.mergeData(inputDataframe, sourceReference);
+
+        verify(transformedDataframe, times(1)).drop("_timestamp", "checkpoint_col");
+        verify(mockDataAccess, times(1)).overwriteTable(colsDroppedDataframe, "loading.some_table");
+    }
+
+    @Test
+    void mergeDataShouldRunMerge() {
+        when(sourceReference.getFullyQualifiedTableName()).thenReturn(destinationTableName);
+        when(sourceReference.getTable()).thenReturn("some_table");
+        when(mockDataTransformation.transform(any())).thenReturn(transformedDataframe);
+        when(transformedDataframe.drop((String[]) any())).thenReturn(colsDroppedDataframe);
+
+        underTest.mergeData(inputDataframe, sourceReference);
+
+        verify(mockDataAccess, times(1)).merge("loading.some_table", destinationTableName, sourceReference);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -37,6 +38,8 @@ class OperationalDataStoreServiceTest {
     private OperationalDataStoreTransformation mockDataTransformation;
     @Mock
     private OperationalDataStoreDataAccess mockDataAccess;
+    @Mock
+    private JobArguments jobArguments;
 
     @Mock
     private Dataset<Row> inputDataframe;
@@ -51,7 +54,8 @@ class OperationalDataStoreServiceTest {
 
     @BeforeEach
     public void setup() {
-        underTest = new OperationalDataStoreServiceImpl(mockDataTransformation, mockDataAccess);
+        when(jobArguments.getOperationalDataStoreLoadingSchemaName()).thenReturn("loading");
+        underTest = new OperationalDataStoreServiceImpl(jobArguments, mockDataTransformation, mockDataAccess);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreTransformationTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreTransformationTest.java
@@ -55,23 +55,6 @@ class OperationalDataStoreTransformationTest extends BaseSparkTest {
     }
 
     @Test
-    public void shouldMetadataColumns() {
-        Dataset<Row> df = spark.createDataFrame(Arrays.asList(
-                RowFactory.create("pk1", "2023-11-13 10:49:28.123458", "I", "", "some data"),
-                RowFactory.create("pk2", "2023-11-13 10:49:28.123458", "U", "", "some other data")
-        ), schema);
-
-        Dataset<Row> result = underTest.transform(df);
-
-        assertThat(result.columns(), not(hasItemInArray(OPERATION)));
-        assertThat(result.columns(), not(hasItemInArray(TIMESTAMP)));
-        assertThat(result.columns(), not(hasItemInArray(CHECKPOINT_COL)));
-        assertThat(result.columns(), not(hasItemInArray(OPERATION.toLowerCase())));
-        assertThat(result.columns(), not(hasItemInArray(TIMESTAMP.toLowerCase())));
-        assertThat(result.columns(), not(hasItemInArray(CHECKPOINT_COL.toLowerCase())));
-    }
-
-    @Test
     public void shouldStripNullStringCharacters() {
         Dataset<Row> df = spark.createDataFrame(Arrays.asList(
                 RowFactory.create("pk1\u0000", "2023-11-13 10:49:28.123458", "I", "", "some data"),


### PR DESCRIPTION
- Update the CDC job so that on each batch it:
    - Writes the output of curated to a loading table (e.g. loading.offenders), overwriting any data if the table already exists.
    - Runs a SQL MERGE statement to merge the data in the loading table in to the destination table, which already exists since it was created by the batch job (e.g. from loading.offenders in to nomis.offenders).
    - Finally, it truncates the loading table.
- Add a JobArguments property to configure the loading schema name.
- Updated E2E and IT tests to use in-memory operational data store when testing CDC functionality
- Unit tests
- Removes some duplication from the E2E and IT tests in to SharedTestFunctions
- Moves the dropping of metadata columns out of the Operational DataStore transformer and in to the service since this functionality differs between batch and CDC