### PR TITLE
DPR2-986: Load the database driver explicitly each time we start a test database.

### DIFF
--- a/src/it/java/uk/gov/justice/digital/test/InMemoryOperationalDataStore.java
+++ b/src/it/java/uk/gov/justice/digital/test/InMemoryOperationalDataStore.java
@@ -28,8 +28,8 @@ public class InMemoryOperationalDataStore {
             }
         }));
         try {
-            // We shouldn't need to explicitly load the class like this, but we get intermittent test failures
-            // due to "java.sql.SQLException: No suitable driver found" if we don't.
+            // We shouldn't need to explicitly load the class like this, but we get intermittent test failures when
+            // running integration tests in parallel due to "java.sql.SQLException: No suitable driver found" if we don't
             Class.forName(DRIVER_CLASS_NAME);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/src/it/java/uk/gov/justice/digital/test/InMemoryOperationalDataStore.java
+++ b/src/it/java/uk/gov/justice/digital/test/InMemoryOperationalDataStore.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import static java.lang.String.format;
 
 public class InMemoryOperationalDataStore {
+    private static final String DRIVER_CLASS_NAME = "org.h2.Driver";
 
     private Server h2Server;
 
@@ -26,6 +27,13 @@ public class InMemoryOperationalDataStore {
                 // Squash on purpose since this is a best effort attempt to not leave around orphaned resources
             }
         }));
+        try {
+            // We shouldn't need to explicitly load the class like this, but we get intermittent test failures
+            // due to "java.sql.SQLException: No suitable driver found" if we don't.
+            Class.forName(DRIVER_CLASS_NAME);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void stop() {
@@ -47,7 +55,7 @@ public class InMemoryOperationalDataStore {
     }
 
     public String getDriverClassName() {
-        return "org.h2.Driver";
+        return DRIVER_CLASS_NAME;
     }
 
     public Connection getJdbcConnection() throws SQLException {


### PR DESCRIPTION
- One of the integration tests fails in the release repo but not in the jobs repo.
- This seems to be because the release repo runs the tests in parallel using gradle and this causes some strangeness in class loading.
- I can reproduce the issue locally with `./gradlew --parallel --max-workers=4 clean build -x test`
- The changes in this PR fix the issue when run locally
- It loads the JDBC database driver explicitly for each test that uses the in memory database using Class.forName
- This shouldn't be necessary as it is the legacy way of ensuring the class is loaded but seems to fix the weird class loading issue