### PR TITLE
DPR2-904 truncate instead of drop

### DIFF
--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -45,6 +45,7 @@ import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
+import static uk.gov.justice.digital.test.SharedTestFunctions.givenEmptyTableExists;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenTablesToWriteToOperationalDataStore;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenTablesToWriteToOperationalDataStoreTableNameIsConfigured;
@@ -99,6 +100,8 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk4, "2023-11-13 10:50:00.123456", Delete, "data4")
         ), TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS);
 
+        givenEmptyTableExists(inputFullTableName, input, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, input);
 
         thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
@@ -115,6 +118,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA);
+
+        givenEmptyTableExists(inputFullTableName, input, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, input);
 
         thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);
@@ -131,6 +137,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA).withColumn("extra-column", lit(1));
+
+        givenEmptyTableExists(inputFullTableName, dfWithMisMatchingSchema, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, dfWithMisMatchingSchema);
 
         thenStructuredViolationsContainsPK(pk1);
@@ -148,6 +157,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA).drop("data");
+
+        givenEmptyTableExists(inputFullTableName, dfWithMisMatchingSchema, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, dfWithMisMatchingSchema);
 
         thenStructuredViolationsContainsPK(pk1);
@@ -165,6 +177,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA).withColumn("data", lit(1));
+
+        givenEmptyTableExists(inputFullTableName, dfWithMisMatchingSchema, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, dfWithMisMatchingSchema);
 
         thenStructuredViolationsContainsPK(pk1);
@@ -182,6 +197,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA).withColumn("data", lit(1));
+
+        givenEmptyTableExists(inputFullTableName, dfWithMisMatchingSchema, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, dfWithMisMatchingSchema);
 
         thenStructuredViolationsContainsPK(pk1);
@@ -199,6 +217,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA).withColumn("data", lit(1L));
+
+        givenEmptyTableExists(inputFullTableName, dfWithMisMatchingSchema, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, dfWithMisMatchingSchema);
 
         thenStructuredViolationsContainsPK(pk1);
@@ -217,6 +238,9 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
                 createRow(pk2, null, Insert, "data2"),
                 createRow(pk3, "2023-11-13 10:50:00.123456", Insert, "data3")
         ), TEST_DATA_SCHEMA);
+
+        givenEmptyTableExists(inputFullTableName, dfNullNonNullableCols, testQueryConnection, operationalDataStore);
+
         underTest.processBatch(spark, sourceReference, dfNullNonNullableCols);
 
         thenStructuredCuratedAndOperationalDataStoreContainForPK("data1", pk1, testQueryConnection);

--- a/src/it/java/uk/gov/justice/digital/test/BaseMinimalDataIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/test/BaseMinimalDataIntegrationTest.java
@@ -23,6 +23,7 @@ public class BaseMinimalDataIntegrationTest extends BaseSparkTest {
     protected static final String configurationTableName = "datahub_managed_tables";
     protected static final String inputSchemaName = "my_schema";
     protected static final String inputTableName = "my_table";
+    protected static final String inputFullTableName = inputSchemaName + "." + inputTableName;
 
     @TempDir
     protected Path testRoot;

--- a/src/it/java/uk/gov/justice/digital/test/InMemoryOperationalDataStore.java
+++ b/src/it/java/uk/gov/justice/digital/test/InMemoryOperationalDataStore.java
@@ -74,10 +74,15 @@ public class InMemoryOperationalDataStore {
         return DRIVER_CLASS_NAME;
     }
 
-    public Connection getJdbcConnection() throws SQLException {
+    public Properties getJdbcProperties() {
         Properties jdbcProps = new Properties();
         jdbcProps.put("user", getUsername());
         jdbcProps.put("password", getPassword());
+        return jdbcProps;
+    }
+
+    public Connection getJdbcConnection() throws SQLException {
+        Properties jdbcProps = getJdbcProperties();
         Connection connection = DriverManager.getConnection(getJdbcUrl(), jdbcProps);
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {

--- a/src/it/java/uk/gov/justice/digital/test/SharedTestFunctions.java
+++ b/src/it/java/uk/gov/justice/digital/test/SharedTestFunctions.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.test;
 
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.service.operationaldatastore.dataaccess.OperationalDataStoreConnectionDetailsService;
 
@@ -21,9 +24,20 @@ public class SharedTestFunctions {
     }
 
     public static void givenSchemaExists(String schemaName, Connection testQueryConnection) throws SQLException {
-        try(Statement statement = testQueryConnection.createStatement()) {
+        try (Statement statement = testQueryConnection.createStatement()) {
             statement.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName);
         }
+    }
+
+    public static void givenEmptyTableExists(String fullTableName, Dataset<Row> df, Connection testQueryConnection, InMemoryOperationalDataStore operationalDataStore) throws SQLException {
+        df.write().mode(SaveMode.Overwrite).jdbc(operationalDataStore.getJdbcUrl(), fullTableName, operationalDataStore.getJdbcProperties());
+        try (Statement statement = testQueryConnection.createStatement()) {
+            statement.execute("TRUNCATE TABLE " + fullTableName);
+        }
+    }
+
+    public static void givenEmptyTableExists(String schemaName, String tableName, Dataset<Row> df, Connection testQueryConnection, InMemoryOperationalDataStore operationalDataStore) throws SQLException {
+        givenEmptyTableExists(schemaName + "." + tableName, df, testQueryConnection, operationalDataStore);
     }
 
     public static void givenTablesToWriteToOperationalDataStoreTableNameIsConfigured(JobArguments arguments, String fullTableName) {
@@ -31,7 +45,7 @@ public class SharedTestFunctions {
     }
 
     public static void givenTablesToWriteToOperationalDataStore(String configSchema, String configTable, String schemaName, String tableName, Connection testQueryConnection) throws SQLException {
-        try(Statement statement = testQueryConnection.createStatement()) {
+        try (Statement statement = testQueryConnection.createStatement()) {
             statement.execute(format("CREATE TABLE IF NOT EXISTS %s.%s (source VARCHAR, table_name VARCHAR)", configSchema, configTable));
             statement.execute(format("INSERT INTO %s.%s VALUES ('%s', '%s')", configSchema, configTable, schemaName, tableName));
         }
@@ -40,9 +54,9 @@ public class SharedTestFunctions {
     public static void assertOperationalDataStoreContainsForPK(String schemaName, String table, String data, int primaryKey, Connection testQueryConnection) throws SQLException {
         String sql = format("SELECT COUNT(1) AS cnt FROM %s.%s WHERE %s = %d AND %s = '%s'",
                 schemaName, table, PRIMARY_KEY_COLUMN, primaryKey, DATA_COLUMN, data);
-        try(Statement statement = testQueryConnection.createStatement()) {
+        try (Statement statement = testQueryConnection.createStatement()) {
             ResultSet resultSet = statement.executeQuery(sql);
-            if(resultSet.next()) {
+            if (resultSet.next()) {
                 int count = resultSet.getInt(1);
                 assertEquals(1, count);
             }
@@ -62,7 +76,7 @@ public class SharedTestFunctions {
             }
         } catch (SQLException e) {
             // If the table doesn't exist then that is fine and it doesn't contain the primary key
-            if(!(e.getMessage().contains("Table") && e.getMessage().contains("not found"))) {
+            if (!(e.getMessage().contains("Table") && e.getMessage().contains("not found"))) {
                 throw e;
             }
         }

--- a/src/main/java/uk/gov/justice/digital/exception/OperationalDataStoreException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/OperationalDataStoreException.java
@@ -7,4 +7,8 @@ public class OperationalDataStoreException extends RuntimeException {
     public OperationalDataStoreException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public OperationalDataStoreException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccess.java
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.exception.OperationalDataStoreException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
@@ -104,6 +105,20 @@ public class OperationalDataStoreDataAccess {
         DataHubOperationalDataStoreManagedTable thisTable =
                 new DataHubOperationalDataStoreManagedTable(sourceReference.getSource(), sourceReference.getTable());
         return managedTables.contains(thisTable);
+    }
+
+    public boolean tableExists(SourceReference sourceReference) {
+        String sql = format(
+                "SELECT EXISTS (SELECT  FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s')",
+                sourceReference.getSource(), sourceReference.getTable());
+        try (Connection connection = dataSource.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                ResultSet rs = statement.executeQuery(sql);
+                return (rs.next() && rs.getBoolean(1));
+            }
+        } catch (SQLException e) {
+            throw new OperationalDataStoreException("Exception while checking if tables exists", e);
+        }
     }
 
     @VisibleForTesting

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccess.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccess.java
@@ -70,6 +70,8 @@ public class OperationalDataStoreDataAccess {
         logger.debug("Writing data to Operational DataStore");
         dataframe.write()
                 .mode(SaveMode.Overwrite)
+                // We truncate instead of dropping and recreating the table since DDL is managed in the Transfer Component
+                .option("truncate", "true")
                 .jdbc(jdbcUrl, destinationTableName, jdbcProps);
         logger.debug("Finished writing data to Operational DataStore in {}ms", System.currentTimeMillis() - startTime);
     }

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccessTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccessTest.java
@@ -105,6 +105,7 @@ class OperationalDataStoreDataAccessTest {
 
         when(dataframe.write()).thenReturn(dataframeWriter);
         when(dataframeWriter.mode(any(SaveMode.class))).thenReturn(dataframeWriter);
+        when(dataframeWriter.option(any(), any())).thenReturn(dataframeWriter);
 
         underTest.overwriteTable(dataframe, destinationTableName);
 
@@ -116,6 +117,24 @@ class OperationalDataStoreDataAccessTest {
         verify(dataframeWriter, times(1)).mode(SaveMode.Overwrite);
         verify(dataframeWriter, times(1))
                 .jdbc("jdbc-url", destinationTableName, expectedProperties);
+    }
+
+    @Test
+    void overwriteTableShouldTruncateRatherThanDrop() {
+        String destinationTableName = "some.table";
+
+        when(dataframe.write()).thenReturn(dataframeWriter);
+        when(dataframeWriter.mode(any(SaveMode.class))).thenReturn(dataframeWriter);
+        when(dataframeWriter.option(any(), any())).thenReturn(dataframeWriter);
+
+        underTest.overwriteTable(dataframe, destinationTableName);
+
+        Properties expectedProperties = new Properties();
+        expectedProperties.put("user", "username");
+        expectedProperties.put("password", "password");
+        expectedProperties.put("driver", "org.postgresql.Driver");
+
+        verify(dataframeWriter, times(1)).option("truncate", "true");
     }
 
     @Test


### PR DESCRIPTION
- So far table creation has been managed by Spark.
- We will need to move to the migrations in the transfer component as materialised views are created on top of these tables.
- This PR supports this by switching the batch load from truncating and recreating a table that already exists in the ODS to just truncating the data
- It also exits with an error telling the user to create the table in the Transfer Component if it has not already been created.
- See https://dsdmoj.atlassian.net/browse/DPR2-904 for further details