### PR TITLE
DPR2-709: Make maxFilesPerTrigger configurable

### DIFF
--- a/src/it/java/uk/gov/justice/digital/client/s3/S3DataProviderIT.java
+++ b/src/it/java/uk/gov/justice/digital/client/s3/S3DataProviderIT.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.config.JobArguments.CDC_FILE_GLOB_PATTERN_DEFAULT;
+import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.MinimalTestData.inserts;
@@ -93,6 +94,7 @@ public class S3DataProviderIT extends BaseMinimalDataIntegrationTest {
         when(arguments.getRawS3Path()).thenReturn(testRootPath.toString());
         when(arguments.enableStreamingSourceArchiving()).thenReturn(false);
         when(arguments.getCdcFileGlobPattern()).thenReturn(CDC_FILE_GLOB_PATTERN_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
 
         Dataset<Row> df = underTest.getStreamingSourceDataWithSchemaInference(spark, sourceName, tableName);
         StreamingQuery query = df.writeStream()
@@ -109,6 +111,7 @@ public class S3DataProviderIT extends BaseMinimalDataIntegrationTest {
         when(arguments.getRawS3Path()).thenReturn(testRootPath.toString());
         when(arguments.enableStreamingSourceArchiving()).thenReturn(false);
         when(arguments.getCdcFileGlobPattern()).thenReturn(CDC_FILE_GLOB_PATTERN_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getSource()).thenReturn(sourceName);
         when(sourceReference.getTable()).thenReturn(tableName);
@@ -130,6 +133,7 @@ public class S3DataProviderIT extends BaseMinimalDataIntegrationTest {
         when(arguments.enableStreamingSourceArchiving()).thenReturn(true);
         when(arguments.getProcessedRawFilesPath()).thenReturn(processedRawFilesPath);
         when(arguments.getCdcFileGlobPattern()).thenReturn(CDC_FILE_GLOB_PATTERN_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
 
         Dataset<Row> df = underTest.getStreamingSourceDataWithSchemaInference(spark, sourceName, tableName);
 
@@ -148,6 +152,7 @@ public class S3DataProviderIT extends BaseMinimalDataIntegrationTest {
         when(arguments.enableStreamingSourceArchiving()).thenReturn(true);
         when(arguments.getProcessedRawFilesPath()).thenReturn(processedRawFilesPath);
         when(arguments.getCdcFileGlobPattern()).thenReturn(CDC_FILE_GLOB_PATTERN_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getSource()).thenReturn(sourceName);
         when(sourceReference.getTable()).thenReturn(tableName);

--- a/src/it/java/uk/gov/justice/digital/client/s3/S3DataProviderNoFilesIT.java
+++ b/src/it/java/uk/gov/justice/digital/client/s3/S3DataProviderNoFilesIT.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,6 +50,7 @@ public class S3DataProviderNoFilesIT extends BaseMinimalDataIntegrationTest {
 
         when(arguments.getRawS3Path()).thenReturn(testRootPath.toString());
         when(arguments.getCdcFileGlobPattern()).thenReturn(JobArguments.CDC_FILE_GLOB_PATTERN_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
         when(sourceReference.getSource()).thenReturn(sourceName);
         when(sourceReference.getTable()).thenReturn(tableName);
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
@@ -76,6 +78,7 @@ public class S3DataProviderNoFilesIT extends BaseMinimalDataIntegrationTest {
 
         when(arguments.getRawS3Path()).thenReturn(testRootPath.toString());
         when(arguments.getCdcFileGlobPattern()).thenReturn(JobArguments.CDC_FILE_GLOB_PATTERN_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
         when(sourceReference.getSource()).thenReturn(sourceName);
         when(sourceReference.getTable()).thenReturn(tableName);
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS;
+import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
 
 class JobArgumentsIntegrationTest {
 
@@ -69,6 +70,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.ORCHESTRATION_MAX_ATTEMPTS, "10" },
             { JobArguments.MAX_S3_PAGE_SIZE, "100" },
             { JobArguments.CLEAN_CDC_CHECKPOINT, "false" },
+            { JobArguments.GLUE_TRIGGER_NAME, "dpr-glue-trigger-name" },
             { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, "60" },
             { JobArguments.DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD, "false" },
             { JobArguments.OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME, "some-connection-name" },
@@ -127,6 +129,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.ORCHESTRATION_MAX_ATTEMPTS, validArguments.orchestrationMaxAttempts() },
                 { JobArguments.MAX_S3_PAGE_SIZE, validArguments.getMaxObjectsPerPage() },
                 { JobArguments.CLEAN_CDC_CHECKPOINT, validArguments.cleanCdcCheckpoint() },
+                { JobArguments.GLUE_TRIGGER_NAME, validArguments.getGlueTriggerName() },
                 { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, validArguments.getBroadcastTimeoutSeconds() },
                 { JobArguments.DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD, validArguments.disableAutoBroadcastJoinThreshold() },
                 { JobArguments.OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME, validArguments.getOperationalDataStoreGlueConnectionName() },
@@ -402,11 +405,36 @@ class JobArgumentsIntegrationTest {
     }
 
     @Test
-    public void cleanCdcCheckpointShouldDefaultToFalseWhenMissing() {
+    public void cleanCdcCheckpointShouldDefaultToFalseWhenNotProvided() {
         HashMap<String, String> args = cloneTestArguments();
         args.remove(JobArguments.CLEAN_CDC_CHECKPOINT);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertFalse(jobArguments.cleanCdcCheckpoint());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true, true", "false, false", "True, true", "False, false" })
+    public void shouldConvertValidValueForActivateGlueTriggerToBoolean(String input, Boolean expected) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.ACTIVATE_GLUE_TRIGGER, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(expected, jobArguments.activateGlueTrigger());
+    }
+
+    @Test
+    public void activateGlueTriggerShouldDefaultToFalseWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.ACTIVATE_GLUE_TRIGGER);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertFalse(jobArguments.activateGlueTrigger());
+    }
+
+    @Test
+    public void streamingJobMaxFilePerTriggerShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.STREAMING_JOB_MAX_FILES_PER_TRIGGER);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER, jobArguments.streamingJobMaxFilePerTrigger());
     }
 
     @Test

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.config.JobArguments.OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT;
+import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
 import static uk.gov.justice.digital.test.MinimalTestData.createRow;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenDatastoreCredentials;
 import static uk.gov.justice.digital.test.SharedTestFunctions.givenSchemaExists;
@@ -186,6 +187,7 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
         givenRetrySettingsAreConfigured(arguments);
         givenLoadingSchemaIsConfigured();
         when(arguments.getOperationalDataStoreJdbcBatchSize()).thenReturn(OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT);
+        when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
     }
 
     private void whenTheJobRuns() {

--- a/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
+import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS;
 import static uk.gov.justice.digital.config.JobArguments.OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT;
 import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
@@ -364,6 +365,7 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
     private void givenSettingsAreConfigured() {
         givenPathsAreConfigured();
         givenRetrySettingsAreConfigured(arguments);
+        when(arguments.getBroadcastTimeoutSeconds()).thenReturn(DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS);
         lenient().when(arguments.getOperationalDataStoreJdbcBatchSize()).thenReturn(OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT);
     }
 

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -136,7 +136,9 @@ public class S3DataProvider {
     }
 
     private Dataset<Row> getStreamingDataset(SparkSession sparkSession, String fileGlobPath, StructType schema) {
-        DataStreamReader streamReader = sparkSession.readStream().schema(schema);
+        DataStreamReader streamReader = sparkSession.readStream()
+                .option("maxFilesPerTrigger", arguments.streamingJobMaxFilePerTrigger())
+                .schema(schema);
 
         if (arguments.enableStreamingSourceArchiving()) {
             String processedRawFilesLocation = ensureEndsWithSlash(arguments.getRawS3Path()) + arguments.getProcessedRawFilesPath();

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -129,10 +129,12 @@ public class JobArguments {
     static final Integer DEFAULT_MAX_S3_PAGE_SIZE = 1000;
     static final String CLEAN_CDC_CHECKPOINT = "dpr.clean.cdc.checkpoint";
     static final String SPARK_BROADCAST_TIMEOUT_SECONDS = "dpr.spark.broadcast.timeout.seconds";
-    static final Integer DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS = 300;
+    public static final Integer DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS = 300;
     static final String DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD = "dpr.disable.auto.broadcast.join.threshold";
     static final String GLUE_TRIGGER_NAME = "dpr.glue.trigger.name";
     static final String ACTIVATE_GLUE_TRIGGER = "dpr.glue.trigger.activate";
+    static final String STREAMING_JOB_MAX_FILES_PER_TRIGGER = "dpr.streaming.job.max.files.per.trigger";
+    public static final long STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER = 1000;
     static final String OPERATIONAL_DATA_STORE_WRITE_ENABLED = "dpr.operational.data.store.write.enabled";
     static final String OPERATIONAL_DATA_STORE_GLUE_CONNECTION_NAME = "dpr.operational.data.store.glue.connection.name";
     static final String OPERATIONAL_DATA_STORE_LOADING_SCHEMA_NAME = "dpr.operational.data.store.loading.schema.name";
@@ -484,6 +486,10 @@ public class JobArguments {
 
     public boolean activateGlueTrigger() {
         return getArgument(ACTIVATE_GLUE_TRIGGER, false);
+    }
+
+    public long streamingJobMaxFilePerTrigger() {
+        return getArgument(STREAMING_JOB_MAX_FILES_PER_TRIGGER, STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
     }
 
     private String getArgument(String argumentName) {


### PR DESCRIPTION
This PR makes the maxFilesPerTrigger configurable. The config defaults to 1000 which is also the default in spark streaming. This will help us lower the pressure on the raw-zone s3 bucket when there are many streaming jobs reading files from it.