### PR TITLE
DPR2-1101: Fix schema mismatch in reload diff

### DIFF
--- a/src/main/java/uk/gov/justice/digital/job/CreateReloadDiffJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/CreateReloadDiffJob.java
@@ -27,8 +27,6 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Optional;
 
-import static uk.gov.justice.digital.common.CommonDataFields.withCheckpointField;
-import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 import static uk.gov.justice.digital.config.JobProperties.SPARK_JOB_NAME_PROPERTY;
 
@@ -124,7 +122,7 @@ public class CreateReloadDiffJob implements Runnable {
                     val diffOutputPath = createValidatedPath(jobArguments.getTempReloadS3Path(), jobArguments.getTempReloadOutputFolder());
                     val rawDataFrame = dataProvider.getBatchSourceData(sparkSession, rawFilePaths);
                     val rawArchiveDataFrame = archiveFilePaths.isEmpty() ?
-                            sparkSession.emptyDataset(RowEncoder.apply(withCheckpointField(withMetadataFields(sourceReference.getSchema())))) :
+                            sparkSession.emptyDataset(RowEncoder.apply(rawDataFrame.schema())) :
                             dataProvider.getBatchSourceData(sparkSession, archiveFilePaths);
 
                     reloadDiffProcessor.createDiff(sourceReference, diffOutputPath, rawDataFrame, rawArchiveDataFrame, dmsStartTime);

--- a/src/main/java/uk/gov/justice/digital/job/batchprocessing/ReloadDiffProcessor.java
+++ b/src/main/java/uk/gov/justice/digital/job/batchprocessing/ReloadDiffProcessor.java
@@ -56,17 +56,17 @@ public class ReloadDiffProcessor {
         logger.info("Processing reload diffs to delete");
         Dataset<Row> recordsToDelete = getRecordsToDelete(sourceReference, raw, activeArchiveRecords)
                 .withColumn(CHECKPOINT_COL, lit(formattedStartTime));
-        storageService.writeParquet(createOutputPath(sourceReference, outputBasePath, "toDelete"), recordsToDelete);
+        storageService.overwriteParquet(createOutputPath(sourceReference, outputBasePath, "toDelete"), recordsToDelete);
 
         logger.info("Processing reload diffs to insert");
         Dataset<Row> recordsToInsert = getRecordsToInsert(sourceReference, raw, activeArchiveRecords)
                 .withColumn(CHECKPOINT_COL, lit(formattedStartTime));
-        storageService.writeParquet(createOutputPath(sourceReference, outputBasePath, "toInsert"), recordsToInsert);
+        storageService.overwriteParquet(createOutputPath(sourceReference, outputBasePath, "toInsert"), recordsToInsert);
 
         logger.info("Processing reload diffs to update");
         Dataset<Row> recordsToUpdate = getRecordsToUpdate(sourceReference, raw, activeArchiveRecords, recordsToInsert)
                 .withColumn(CHECKPOINT_COL, lit(formattedStartTime));
-        storageService.writeParquet(createOutputPath(sourceReference, outputBasePath, "toUpdate"), recordsToUpdate);
+        storageService.overwriteParquet(createOutputPath(sourceReference, outputBasePath, "toUpdate"), recordsToUpdate);
 
         activeArchiveRecords.unpersist();
     }

--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -269,7 +269,7 @@ public class DataStorageService {
         updateDeltaManifestForTable(spark, tableId.toPath());
     }
 
-    public void writeParquet(String path, Dataset<Row> dataset) {
+    public void overwriteParquet(String path, Dataset<Row> dataset) {
         dataset.write().mode(SaveMode.Overwrite).parquet(path);
     }
 

--- a/src/test/java/uk/gov/justice/digital/job/CreateReloadDiffJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/CreateReloadDiffJobTest.java
@@ -49,8 +49,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
-import static uk.gov.justice.digital.common.CommonDataFields.withCheckpointField;
-import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
 import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
 import static uk.gov.justice.digital.test.MinimalTestData.CHECKPOINT_COL_VALUE;
@@ -256,7 +254,7 @@ class CreateReloadDiffJobTest extends BaseSparkTest {
 
         Dataset<Row> actualArchiveDataset = archiveDatasetCaptor.getValue();
         assertThat(actualArchiveDataset.collectAsList(), is(empty()));
-        assertThat(actualArchiveDataset.schema(), is(equalTo(withCheckpointField(withMetadataFields(TEST_DATA_SCHEMA)))));
+        assertThat(actualArchiveDataset.schema(), is(equalTo(TEST_DATA_SCHEMA)));
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/ReloadDiffProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/ReloadDiffProcessorTest.java
@@ -82,7 +82,7 @@ class ReloadDiffProcessorTest extends BaseSparkTest {
 
         underTest.createDiff(sourceReference, OUTPUT_BASE_PATH, rawDataset, rawDataset, reloadTime);
 
-        verify(dataStorageService, times(3)).writeParquet(outputPathCaptor.capture(), datasetCaptor.capture());
+        verify(dataStorageService, times(3)).overwriteParquet(outputPathCaptor.capture(), datasetCaptor.capture());
         assertThat(datasetCaptor.getValue().collectAsList(), is(empty()));
 
         List<String> expectedOutputPaths = Arrays.asList(createPath("toDelete"), createPath("toInsert"), createPath("toUpdate"));
@@ -103,7 +103,7 @@ class ReloadDiffProcessorTest extends BaseSparkTest {
 
         underTest.createDiff(sourceReference, OUTPUT_BASE_PATH, rawDataset, spark.emptyDataset(encoder), reloadTime);
 
-        verify(dataStorageService, times(3)).writeParquet(outputPathCaptor.capture(), datasetCaptor.capture());
+        verify(dataStorageService, times(3)).overwriteParquet(outputPathCaptor.capture(), datasetCaptor.capture());
 
         List<Dataset<Row>> capturedRecords = datasetCaptor.getAllValues();
         Dataset<Row> recordsToDelete = capturedRecords.get(0);
@@ -140,7 +140,7 @@ class ReloadDiffProcessorTest extends BaseSparkTest {
 
         underTest.createDiff(sourceReference, OUTPUT_BASE_PATH, rawDataset, archiveDataset, reloadTime);
 
-        verify(dataStorageService, times(3)).writeParquet(outputPathCaptor.capture(), datasetCaptor.capture());
+        verify(dataStorageService, times(3)).overwriteParquet(outputPathCaptor.capture(), datasetCaptor.capture());
 
         List<Dataset<Row>> capturedRecords = datasetCaptor.getAllValues();
         Dataset<Row> recordsToDelete = capturedRecords.get(0);
@@ -176,7 +176,7 @@ class ReloadDiffProcessorTest extends BaseSparkTest {
 
         underTest.createDiff(sourceReference, OUTPUT_BASE_PATH, rawDataset, archiveDataset, reloadTime);
 
-        verify(dataStorageService, times(3)).writeParquet(outputPathCaptor.capture(), datasetCaptor.capture());
+        verify(dataStorageService, times(3)).overwriteParquet(outputPathCaptor.capture(), datasetCaptor.capture());
 
         List<Dataset<Row>> capturedRecords = datasetCaptor.getAllValues();
         Dataset<Row> recordsToDelete = capturedRecords.get(0);
@@ -218,7 +218,7 @@ class ReloadDiffProcessorTest extends BaseSparkTest {
 
         underTest.createDiff(sourceReference, OUTPUT_BASE_PATH, rawDataset, archiveDataset, reloadTime);
 
-        verify(dataStorageService, times(3)).writeParquet(outputPathCaptor.capture(), datasetCaptor.capture());
+        verify(dataStorageService, times(3)).overwriteParquet(outputPathCaptor.capture(), datasetCaptor.capture());
 
         List<Dataset<Row>> capturedRecords = datasetCaptor.getAllValues();
         Dataset<Row> recordsToDelete = capturedRecords.get(0);

--- a/src/test/java/uk/gov/justice/digital/service/DataStorageServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DataStorageServiceTest.java
@@ -451,7 +451,7 @@ class DataStorageServiceTest extends BaseSparkTest {
     }
 
     @Test
-    void shouldWriteParquet() {
+    void shouldOverwriteParquet() {
         JobArguments mockJobArguments = mock(JobArguments.class);
         int retryAttempts = 1;
         givenConfiguredRetriesJobArgs(retryAttempts, mockJobArguments);
@@ -461,7 +461,7 @@ class DataStorageServiceTest extends BaseSparkTest {
         when(mockDataFrameWriter.mode(SaveMode.Overwrite)).thenReturn(mockDataFrameWriter);
         String path = "some-path";
 
-        dataStorageService.writeParquet(path, mockDataSet);
+        dataStorageService.overwriteParquet(path, mockDataSet);
 
         verify(mockDataFrameWriter, times(1)).parquet(path);
     }


### PR DESCRIPTION
When the reload diff job is ran and there is no previously archived data, it creates an empty dataset with the specified contracts as its schema. This can create schema mismatch on columns where the raw dataset has a different type from that specified in the contract e.g. `tinyint` and `int` respectively.

This PR fixes this mismatch by using the inferred schema from the raw dataset instead of the schema specified in the contracts.