### PR TITLE
DPR2-709: Return status code 0 for AbortedException

### DIFF
--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.provider;
 import com.amazonaws.services.glue.GlueContext;
 import jakarta.inject.Singleton;
 import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import uk.gov.justice.digital.config.JobArguments;
 


### PR DESCRIPTION
This PR returns an exit status code of zero when an AbortedException is encountered in the CDC job (i.e when the SDK receives a signal to stop).