### PR TITLE
DPR2-1160: try explicit system exit with error code when exception encountered during bootstrap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ ext {
     h2Version = '2.2.224'
     oracleJdbcVersion = '23.5.0.24.07'
     hikariCPVersion = '4.0.3'
+    junitSystemExitVersion = '1.1.2'
 }
 
 dependencies {
@@ -105,6 +106,7 @@ dependencies {
     testImplementation "com.networknt:json-schema-validator:1.0.81"
     testImplementation "com.github.stefanbirkner:system-lambda:$systemLambdaVersion"
     testImplementation "com.h2database:h2:$h2Version"
+    testImplementation "com.ginsberg:junit5-system-exit:$junitSystemExitVersion"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }

--- a/src/main/java/uk/gov/justice/digital/job/CompactionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/CompactionJob.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.job;
 
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.MaintenanceService;
 
@@ -39,8 +37,7 @@ public class CompactionJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(CompactionJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(CompactionJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/CreateReloadDiffJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/CreateReloadDiffJob.java
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.job;
 
 import com.amazonaws.services.glue.util.Job;
 import com.google.common.annotations.VisibleForTesting;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import lombok.val;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.spark.SparkConf;
@@ -17,7 +16,6 @@ import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.SchemaNotFoundException;
 import uk.gov.justice.digital.job.batchprocessing.ReloadDiffProcessor;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.DmsOrchestrationService;
 import uk.gov.justice.digital.service.SourceReferenceService;
@@ -68,8 +66,7 @@ public class CreateReloadDiffJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(CreateReloadDiffJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(CreateReloadDiffJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/DataHubBatchJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubBatchJob.java
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.job;
 
 import com.amazonaws.services.glue.util.Job;
 import com.google.common.annotations.VisibleForTesting;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.val;
@@ -16,10 +15,9 @@ import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.SourceReference;
-import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.exception.DataProviderFailedMergingSchemasException;
+import uk.gov.justice.digital.exception.DataStorageException;
 import uk.gov.justice.digital.job.batchprocessing.BatchProcessor;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.SourceReferenceService;
 import uk.gov.justice.digital.service.TableDiscoveryService;
@@ -68,8 +66,7 @@ public class DataHubBatchJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job started");
-        PicocliRunner.run(DataHubBatchJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(DataHubBatchJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/DataHubCdcJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubCdcJob.java
@@ -4,7 +4,6 @@ import com.amazonaws.AbortedException;
 import com.amazonaws.services.glue.GlueContext;
 import com.amazonaws.services.glue.util.Job;
 import com.google.common.annotations.VisibleForTesting;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.val;
@@ -24,7 +23,6 @@ import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.exception.NoSchemaNoDataException;
 import uk.gov.justice.digital.job.cdc.TableStreamingQuery;
 import uk.gov.justice.digital.job.cdc.TableStreamingQueryProvider;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.TableDiscoveryService;
 
@@ -64,8 +62,7 @@ public class DataHubCdcJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job started");
-        PicocliRunner.run(DataHubCdcJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(DataHubCdcJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -47,7 +47,12 @@ public class DataReconciliationJob implements Runnable {
 
     public static void main(String[] args) {
         logger.info("Job starting");
-        PicocliRunner.run(DataReconciliationJob.class, MicronautContext.withArgs(args));
+        try {
+            PicocliRunner.run(DataReconciliationJob.class, MicronautContext.withArgs(args));
+        } catch (Exception e) {
+            logger.error("Caught exception during Picocli and Micronaut bootstrap", e);
+            System.exit(1);
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -24,7 +24,7 @@ import static uk.gov.justice.digital.config.JobProperties.SPARK_JOB_NAME_PROPERT
 /**
  * Job that runs data reconciliation in the DataHub.
  */
-@CommandLine.Command(name = "DataReconciliationJob", exitCodeOnInvalidInput = 1, exitCodeOnExecutionException = 1)
+@CommandLine.Command(name = "DataReconciliationJob")
 public class DataReconciliationJob implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(DataReconciliationJob.class);
@@ -50,22 +50,22 @@ public class DataReconciliationJob implements Runnable {
     public static void main(String[] args) {
         logger.info("Job starting");
         try {
-            PicocliRunner.run(DataReconciliationJob.class, MicronautContext.withArgs(args));
+//            PicocliRunner.run(DataReconciliationJob.class, MicronautContext.withArgs(args));
 
-//            CommandLine commandLine = new CommandLine(DataReconciliationJob.class, new MicronautFactory(MicronautContext.withArgs(args)));
-//            commandLine.setExitCodeExceptionMapper(exception -> {
-//                logger.error("Getting exit code", exception);
-//                return 1;
-//            });
-//            commandLine.setExecutionExceptionHandler((ex, commandLine1, parseResult) -> {
-//                logger.error("Caught execution exception during Picocli and Micronaut bootstrap", ex);
-//                return 1;
-//            });
-//            commandLine.setParameterExceptionHandler((ex, args1) -> {
-//                logger.error("Caught ParameterException during Picocli and Micronaut bootstrap", ex);
-//                return 1;
-//            });
-//            commandLine.execute(args);
+            CommandLine commandLine = new CommandLine(DataReconciliationJob.class, new MicronautFactory(MicronautContext.withArgs(args)));
+            commandLine.setExitCodeExceptionMapper(exception -> {
+                logger.error("Getting exit code", exception);
+                return 1;
+            });
+            commandLine.setExecutionExceptionHandler((ex, commandLine1, parseResult) -> {
+                logger.error("Caught execution exception during Picocli and Micronaut bootstrap", ex);
+                return 1;
+            });
+            commandLine.setParameterExceptionHandler((ex, args1) -> {
+                logger.error("Caught ParameterException during Picocli and Micronaut bootstrap", ex);
+                return 1;
+            });
+            commandLine.execute(args);
         } catch (Exception e) {
             logger.error("Caught exception during Picocli and Micronaut bootstrap", e);
             System.exit(1);

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.job;
 
 import com.amazonaws.services.glue.util.Job;
+import io.micronaut.configuration.picocli.MicronautFactory;
 import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
 import lombok.val;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
@@ -22,7 +24,7 @@ import static uk.gov.justice.digital.config.JobProperties.SPARK_JOB_NAME_PROPERT
 /**
  * Job that runs data reconciliation in the DataHub.
  */
-@CommandLine.Command(name = "DataReconciliationJob")
+@CommandLine.Command(name = "DataReconciliationJob", exitCodeOnInvalidInput = 1, exitCodeOnExecutionException = 1)
 public class DataReconciliationJob implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(DataReconciliationJob.class);
@@ -49,6 +51,21 @@ public class DataReconciliationJob implements Runnable {
         logger.info("Job starting");
         try {
             PicocliRunner.run(DataReconciliationJob.class, MicronautContext.withArgs(args));
+
+//            CommandLine commandLine = new CommandLine(DataReconciliationJob.class, new MicronautFactory(MicronautContext.withArgs(args)));
+//            commandLine.setExitCodeExceptionMapper(exception -> {
+//                logger.error("Getting exit code", exception);
+//                return 1;
+//            });
+//            commandLine.setExecutionExceptionHandler((ex, commandLine1, parseResult) -> {
+//                logger.error("Caught execution exception during Picocli and Micronaut bootstrap", ex);
+//                return 1;
+//            });
+//            commandLine.setParameterExceptionHandler((ex, args1) -> {
+//                logger.error("Caught ParameterException during Picocli and Micronaut bootstrap", ex);
+//                return 1;
+//            });
+//            commandLine.execute(args);
         } catch (Exception e) {
             logger.error("Caught exception during Picocli and Micronaut bootstrap", e);
             System.exit(1);

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.job;
 
 import com.amazonaws.services.glue.util.Job;
-import io.micronaut.configuration.picocli.MicronautFactory;
-import io.micronaut.configuration.picocli.PicocliRunner;
-import io.micronaut.context.ApplicationContext;
 import lombok.val;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
@@ -12,10 +9,9 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
-import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTotalCountResults;
 import uk.gov.justice.digital.service.datareconciliation.DataReconciliationService;
+import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTotalCountResults;
 
 import javax.inject.Inject;
 
@@ -47,12 +43,8 @@ public class DataReconciliationJob implements Runnable {
         this.dataReconciliationService = dataReconciliationService;
     }
 
-    public static void main(String[] args) {
-        logger.info("Job starting");
-        CommandLine commandLine = new CommandLine(DataReconciliationJob.class, new MicronautFactory(MicronautContext.withArgs(args)));
-        int exitCode = commandLine.execute(args);
-        logger.info("Job finished with exit code {}", exitCode);
-        System.exit(exitCode);
+    public static void main(String... args) {
+        PicocliMicronautExecutor.execute(DataReconciliationJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -49,29 +49,10 @@ public class DataReconciliationJob implements Runnable {
 
     public static void main(String[] args) {
         logger.info("Job starting");
-        try {
-//            PicocliRunner.run(DataReconciliationJob.class, MicronautContext.withArgs(args));
-
-            CommandLine commandLine = new CommandLine(DataReconciliationJob.class, new MicronautFactory(MicronautContext.withArgs(args)));
-            commandLine.setExitCodeExceptionMapper(exception -> {
-                logger.error("Getting exit code", exception);
-                return 1;
-            });
-            commandLine.setExecutionExceptionHandler((ex, commandLine1, parseResult) -> {
-                logger.error("Caught execution exception during Picocli and Micronaut bootstrap", ex);
-                return 1;
-            });
-            commandLine.setParameterExceptionHandler((ex, args1) -> {
-                logger.error("Caught ParameterException during Picocli and Micronaut bootstrap", ex);
-                return 1;
-            });
-            int exitCode = commandLine.execute(args);
-            logger.info("Exit code: {}", exitCode);
-            System.exit(exitCode);
-        } catch (Exception e) {
-            logger.error("Caught exception during Picocli and Micronaut bootstrap", e);
-            System.exit(1);
-        }
+        CommandLine commandLine = new CommandLine(DataReconciliationJob.class, new MicronautFactory(MicronautContext.withArgs(args)));
+        int exitCode = commandLine.execute(args);
+        logger.info("Job finished with exit code {}", exitCode);
+        System.exit(exitCode);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -65,7 +65,9 @@ public class DataReconciliationJob implements Runnable {
                 logger.error("Caught ParameterException during Picocli and Micronaut bootstrap", ex);
                 return 1;
             });
-            commandLine.execute(args);
+            int exitCode = commandLine.execute(args);
+            logger.info("Exit code: {}", exitCode);
+            System.exit(exitCode);
         } catch (Exception e) {
             logger.error("Caught exception during Picocli and Micronaut bootstrap", e);
             System.exit(1);

--- a/src/main/java/uk/gov/justice/digital/job/GlueTriggerActivationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/GlueTriggerActivationJob.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.job;
 
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.GlueOrchestrationService;
 
 import javax.inject.Inject;
@@ -26,8 +24,7 @@ public class GlueTriggerActivationJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(GlueTriggerActivationJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(GlueTriggerActivationJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/HiveTableCreationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/HiveTableCreationJob.java
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.job;
 
 import com.google.common.collect.ImmutableSet;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.HiveTableService;
 
@@ -38,8 +36,7 @@ public class HiveTableCreationJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(HiveTableCreationJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(HiveTableCreationJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/PicocliMicronautExecutor.java
+++ b/src/main/java/uk/gov/justice/digital/job/PicocliMicronautExecutor.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.job;
+
+import io.micronaut.configuration.picocli.MicronautFactory;
+import io.micronaut.context.ApplicationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.job.context.MicronautContext;
+
+import java.time.Clock;
+
+public class PicocliMicronautExecutor {
+
+    private static final Logger logger = LoggerFactory.getLogger(PicocliMicronautExecutor.class);
+
+    /**
+     * Executes the provided class as a Picocli Command in the same way as
+     * io.micronaut.configuration.picocli.PicocliRunner#execute.
+     * We can't use PicocliRunner#execute directly because it does not expose a signature that
+     * lets us set the ApplicationContext to our custom MicronautContext.
+     * @param cls The class to execute
+     * @param args The command line args we will use with Micronaut to instantiate JobArguments
+     */
+    public static void execute(Class<?> cls, String... args) {
+        logger.info("Job starting");
+        ApplicationContext applicationContext = MicronautContext.withArgs(args).registerSingleton(Clock.class, Clock.systemUTC());
+        CommandLine commandLine = new CommandLine(cls, new MicronautFactory(applicationContext));
+        int exitCode = commandLine.execute();
+        logger.info("Job finished with exit code {}", exitCode);
+        System.exit(exitCode);
+    }
+
+    private PicocliMicronautExecutor() {}
+}

--- a/src/main/java/uk/gov/justice/digital/job/RawFileArchiveJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/RawFileArchiveJob.java
@@ -1,20 +1,17 @@
 package uk.gov.justice.digital.job;
 
 import com.google.common.collect.ImmutableSet;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.CheckpointReaderService;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
 import javax.inject.Inject;
-import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -47,8 +44,7 @@ public class RawFileArchiveJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(RawFileArchiveJob.class, MicronautContext.withArgs(args).registerSingleton(Clock.class, Clock.systemUTC()));
+        PicocliMicronautExecutor.execute(RawFileArchiveJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -1,20 +1,19 @@
 package uk.gov.justice.digital.job;
 
 import com.google.common.collect.ImmutableSet;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
 import javax.inject.Inject;
-import java.time.Clock;
 import java.time.Duration;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Job that deletes s3 files from a list of bucket(s).
@@ -39,8 +38,7 @@ public class S3DataDeletionJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(S3DataDeletionJob.class, MicronautContext.withArgs(args).registerSingleton(Clock.class, Clock.systemUTC()));
+        PicocliMicronautExecutor.execute(S3DataDeletionJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
@@ -1,18 +1,15 @@
 package uk.gov.justice.digital.job;
 
 import com.google.common.collect.ImmutableSet;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
 import javax.inject.Inject;
-import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,8 +39,7 @@ public class S3FileTransferJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(S3FileTransferJob.class, MicronautContext.withArgs(args).registerSingleton(Clock.class, Clock.systemUTC()));
+        PicocliMicronautExecutor.execute(S3FileTransferJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/StopDmsTaskJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/StopDmsTaskJob.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.job;
 
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.DmsOrchestrationService;
 
 import javax.inject.Inject;
@@ -30,8 +28,7 @@ public class StopDmsTaskJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(StopDmsTaskJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(StopDmsTaskJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/StopGlueInstanceJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/StopGlueInstanceJob.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.job;
 
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.GlueOrchestrationService;
 
 import javax.inject.Inject;
@@ -30,8 +28,7 @@ public class StopGlueInstanceJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(StopGlueInstanceJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(StopGlueInstanceJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.job;
 
 import com.google.common.collect.ImmutableSet;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.HiveTableService;
@@ -41,8 +39,7 @@ public class SwitchHiveTableJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(SwitchHiveTableJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(SwitchHiveTableJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
@@ -1,19 +1,16 @@
 package uk.gov.justice.digital.job;
 
 import com.google.common.collect.ImmutableSet;
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.service.CheckpointReaderService;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
 import javax.inject.Inject;
-import java.time.Clock;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
@@ -46,8 +43,7 @@ public class UnprocessedRawFilesCheckJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(UnprocessedRawFilesCheckJob.class, MicronautContext.withArgs(args).registerSingleton(Clock.class, Clock.systemUTC()));
+        PicocliMicronautExecutor.execute(UnprocessedRawFilesCheckJob.class, args);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.job;
 
-import io.micronaut.configuration.picocli.PicocliRunner;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.job.context.MicronautContext;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.MaintenanceService;
 
@@ -39,8 +37,7 @@ public class VacuumJob implements Runnable {
     }
 
     public static void main(String[] args) {
-        logger.info("Job starting");
-        PicocliRunner.run(VacuumJob.class, MicronautContext.withArgs(args));
+        PicocliMicronautExecutor.execute(VacuumJob.class, args);
     }
 
     @Override

--- a/src/test/java/uk/gov/justice/digital/job/PicocliMicronautExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/PicocliMicronautExecutorTest.java
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.job;
+
+import com.ginsberg.junit.exit.ExpectSystemExitWithStatus;
+import org.junit.jupiter.api.Test;
+
+class PicocliMicronautExecutorTest {
+
+    @Test
+    @ExpectSystemExitWithStatus(1)
+    void aJobThatFailsToInstantiateShouldSystemExitWithNonZeroCode() {
+        // The job with no arguments should return a status code of 1
+        String[] emptyArgs = new String[0];
+        PicocliMicronautExecutor.execute(DataReconciliationJob.class, emptyArgs);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/job/PicocliMicronautExecutorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/PicocliMicronautExecutorTest.java
@@ -7,6 +7,7 @@ class PicocliMicronautExecutorTest {
 
     @Test
     @ExpectSystemExitWithStatus(1)
+    @SuppressWarnings("java:S2699")
     void aJobThatFailsToInstantiateShouldSystemExitWithNonZeroCode() {
         // The job with no arguments should return a status code of 1
         String[] emptyArgs = new String[0];


### PR DESCRIPTION
- Fixes a bug where if a job fails while micronaut is creating objects whilst bootstrapping the dependency injection object graph then it would return a success exit code
- This resulted in jobs appearing as successful in glue when they should be reported as failed
- Introduces a class PicocliMicronautExecutor to run the job and handle exit code because Micronaut's PicocliRunner doesn't expose the execute method we need with ApplicationContext as a parameter
- We need ApplicationContext as a parameter because of the custom MicronautContext we are using to instantiate JobArguments, etc.