### PR TITLE
DPR2-1124 optional configuration for which reconciliations to run

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -22,10 +22,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS;
-import static uk.gov.justice.digital.config.JobArguments.RECONCILIATIONS_TO_RUN_DEFAULT;
+import static uk.gov.justice.digital.config.JobArguments.RECONCILIATION_CHECKS_TO_RUN_DEFAULT;
 import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
-import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CHANGE_DATA_COUNTS;
-import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CURRENT_STATE_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
 
 class JobArgumentsIntegrationTest {
 
@@ -544,19 +544,19 @@ class JobArgumentsIntegrationTest {
     }
 
     @Test
-    public void shouldGetCurrentStateCountsReconciliationsToRun() {
+    public void shouldGetCurrentStateCountsReconciliationCheckToRun() {
         HashMap<String, String> args = new HashMap<>();
-        args.put(JobArguments.RECONCILIATIONS_TO_RUN, "current_state_counts");
+        args.put(JobArguments.RECONCILIATION_CHECKS_TO_RUN, "current_state_counts");
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(ImmutableSet.of(CURRENT_STATE_COUNTS), jobArguments.getReconciliationsToRun());
+        assertEquals(ImmutableSet.of(CURRENT_STATE_COUNTS), jobArguments.getReconciliationChecksToRun());
     }
 
     @Test
-    public void shouldGetChangeDataCountsReconciliationsToRun() {
+    public void shouldGetChangeDataCountsReconciliationCheckToRun() {
         HashMap<String, String> args = new HashMap<>();
-        args.put(JobArguments.RECONCILIATIONS_TO_RUN, "change_data_counts");
+        args.put(JobArguments.RECONCILIATION_CHECKS_TO_RUN, "change_data_counts");
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(ImmutableSet.of(CHANGE_DATA_COUNTS), jobArguments.getReconciliationsToRun());
+        assertEquals(ImmutableSet.of(CHANGE_DATA_COUNTS), jobArguments.getReconciliationChecksToRun());
     }
 
     @ParameterizedTest
@@ -567,24 +567,25 @@ class JobArgumentsIntegrationTest {
             "current_state_counts,change_data_counts,",
             "current_state_counts,,change_data_counts,",
             "current_state_counts, ,change_data_counts,",
-            ",current_state_counts, ,change_data_counts,"
+            ",current_state_counts, ,change_data_counts,",
+            "current_state_counts,current_state_counts,change_data_counts,change_data_counts"
     })
-    public void shouldGetMultipleReconciliationsToRun(String input) {
+    public void shouldGetMultipleReconciliationChecksToRun(String input) {
         HashMap<String, String> args = new HashMap<>();
-        args.put(JobArguments.RECONCILIATIONS_TO_RUN, input);
+        args.put(JobArguments.RECONCILIATION_CHECKS_TO_RUN, input);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertThat(
-                jobArguments.getReconciliationsToRun(),
+                jobArguments.getReconciliationChecksToRun(),
                 containsInAnyOrder(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS)
         );
     }
 
     @Test
-    public void getReconciliationsToRunShouldDefaultToAllWhenMissing() {
+    public void getReconciliationChecksToRunShouldDefaultWhenMissing() {
         HashMap<String, String> args = cloneTestArguments();
-        args.remove(JobArguments.RECONCILIATIONS_TO_RUN);
+        args.remove(JobArguments.RECONCILIATION_CHECKS_TO_RUN);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(RECONCILIATIONS_TO_RUN_DEFAULT, jobArguments.getReconciliationsToRun());
+        assertEquals(RECONCILIATION_CHECKS_TO_RUN_DEFAULT, jobArguments.getReconciliationChecksToRun());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -22,7 +22,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS;
+import static uk.gov.justice.digital.config.JobArguments.RECONCILIATIONS_TO_RUN_DEFAULT;
 import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CHANGE_DATA_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CURRENT_STATE_COUNTS;
 
 class JobArgumentsIntegrationTest {
 
@@ -538,6 +541,50 @@ class JobArgumentsIntegrationTest {
     @Test
     public void shouldThrowAnExceptionWhenAMissingArgumentIsRequested() {
         assertThrows(IllegalStateException.class, emptyArguments::getAwsRegion);
+    }
+
+    @Test
+    public void shouldGetCurrentStateCountsReconciliationsToRun() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.RECONCILIATIONS_TO_RUN, "current_state_counts");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(ImmutableSet.of(CURRENT_STATE_COUNTS), jobArguments.getReconciliationsToRun());
+    }
+
+    @Test
+    public void shouldGetChangeDataCountsReconciliationsToRun() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.RECONCILIATIONS_TO_RUN, "change_data_counts");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(ImmutableSet.of(CHANGE_DATA_COUNTS), jobArguments.getReconciliationsToRun());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "current_state_counts,change_data_counts",
+            "current_state_counts, change_data_counts",
+            "CURRENT_STATE_COUNTS,change_data_counts",
+            "current_state_counts,change_data_counts,",
+            "current_state_counts,,change_data_counts,",
+            "current_state_counts, ,change_data_counts,",
+            ",current_state_counts, ,change_data_counts,"
+    })
+    public void shouldGetMultipleReconciliationsToRun(String input) {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.RECONCILIATIONS_TO_RUN, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertThat(
+                jobArguments.getReconciliationsToRun(),
+                containsInAnyOrder(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS)
+        );
+    }
+
+    @Test
+    public void getReconciliationsToRunShouldDefaultToAllWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.RECONCILIATIONS_TO_RUN);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(RECONCILIATIONS_TO_RUN_DEFAULT, jobArguments.getReconciliationsToRun());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -11,11 +11,17 @@ import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.justice.digital.client.s3.S3ObjectClient.DELIMITER;
@@ -144,6 +150,8 @@ public class JobArguments {
     public static final long OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT = 1000;
     static final String NOMIS_SOURCE_SCHEMA_NAME = "dpr.nomis.source.schema.name";
     static final String NOMIS_GLUE_CONNECTION_NAME = "dpr.nomis.glue.connection.name";
+    static final String RECONCILIATIONS_TO_RUN = "dpr.reconciliations.to.run";
+    static final Set<ReconciliationType> RECONCILIATIONS_TO_RUN_DEFAULT = new HashSet<>(Arrays.asList(ReconciliationType.values()));
 
     private final Map<String, String> config;
 
@@ -500,6 +508,20 @@ public class JobArguments {
 
     public String getNomisGlueConnectionName() {
         return getArgument(NOMIS_GLUE_CONNECTION_NAME);
+    }
+
+    public Set<ReconciliationType> getReconciliationsToRun() {
+        return Optional
+                .ofNullable(config.get(RECONCILIATIONS_TO_RUN))
+                .map(s -> s.toLowerCase().split(","))
+                .map(tokens ->
+                    Arrays.stream(tokens)
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .map(ReconciliationType::fromString)
+                            .collect(Collectors.toSet())
+                )
+                .orElse(RECONCILIATIONS_TO_RUN_DEFAULT);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -15,13 +15,8 @@ import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationChe
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.justice.digital.client.s3.S3ObjectClient.DELIMITER;
@@ -513,7 +508,8 @@ public class JobArguments {
     public Set<ReconciliationCheck> getReconciliationChecksToRun() {
         return Optional
                 .ofNullable(config.get(RECONCILIATION_CHECKS_TO_RUN))
-                .map(s -> s.toLowerCase().split(","))
+                .map(String::toLowerCase)
+                .map(s -> s.split(","))
                 .map(tokens ->
                     Arrays.stream(tokens)
                             .map(String::trim)

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -11,7 +11,7 @@ import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType;
+import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -150,8 +150,8 @@ public class JobArguments {
     public static final long OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT = 1000;
     static final String NOMIS_SOURCE_SCHEMA_NAME = "dpr.nomis.source.schema.name";
     static final String NOMIS_GLUE_CONNECTION_NAME = "dpr.nomis.glue.connection.name";
-    static final String RECONCILIATIONS_TO_RUN = "dpr.reconciliations.to.run";
-    static final Set<ReconciliationType> RECONCILIATIONS_TO_RUN_DEFAULT = new HashSet<>(Arrays.asList(ReconciliationType.values()));
+    static final String RECONCILIATION_CHECKS_TO_RUN = "dpr.reconciliation.checks.to.run";
+    static final Set<ReconciliationCheck> RECONCILIATION_CHECKS_TO_RUN_DEFAULT = new HashSet<>(Arrays.asList(ReconciliationCheck.values()));
 
     private final Map<String, String> config;
 
@@ -510,18 +510,18 @@ public class JobArguments {
         return getArgument(NOMIS_GLUE_CONNECTION_NAME);
     }
 
-    public Set<ReconciliationType> getReconciliationsToRun() {
+    public Set<ReconciliationCheck> getReconciliationChecksToRun() {
         return Optional
-                .ofNullable(config.get(RECONCILIATIONS_TO_RUN))
+                .ofNullable(config.get(RECONCILIATION_CHECKS_TO_RUN))
                 .map(s -> s.toLowerCase().split(","))
                 .map(tokens ->
                     Arrays.stream(tokens)
                             .map(String::trim)
                             .filter(s -> !s.isEmpty())
-                            .map(ReconciliationType::fromString)
+                            .map(ReconciliationCheck::fromString)
                             .collect(Collectors.toSet())
                 )
-                .orElse(RECONCILIATIONS_TO_RUN_DEFAULT);
+                .orElse(RECONCILIATION_CHECKS_TO_RUN_DEFAULT);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.datareconciliation.DataReconciliationService;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
 
 import javax.inject.Inject;
@@ -77,7 +78,7 @@ public class DataReconciliationJob implements Runnable {
 
     @VisibleForTesting
     void runJob(SparkSession sparkSession) {
-        DataReconciliationResults results = dataReconciliationService.reconcileData(sparkSession);
+        DataReconciliationResult results = dataReconciliationService.reconcileData(sparkSession);
         String resultSummary = results.summary();
         if (results.isSuccess()) {
             logger.info("Data reconciliation SUCCEEDED:\n\n{}", resultSummary);

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ChangeDataCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ChangeDataCountService.java
@@ -6,6 +6,7 @@ import org.apache.spark.sql.SparkSession;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.datareconciliation.model.ChangeDataTableCount;
 import uk.gov.justice.digital.service.datareconciliation.model.ChangeDataTotalCounts;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
 import uk.gov.justice.digital.service.datareconciliation.model.DmsChangeDataCountsPair;
 
 import java.util.List;
@@ -29,7 +30,7 @@ public class ChangeDataCountService {
         this.rawChangeDataCountService = rawChangeDataCountService;
     }
 
-    ChangeDataTotalCounts changeDataCounts(SparkSession sparkSession, List<SourceReference> sourceReferences, String dmsTaskId) {
+    DataReconciliationResult changeDataCounts(SparkSession sparkSession, List<SourceReference> sourceReferences, String dmsTaskId) {
         DmsChangeDataCountsPair dmsChangeDataCountsPair = dmsChangeDataCountService.dmsChangeDataCounts(sourceReferences, dmsTaskId);
 
         Map<String, ChangeDataTableCount> rawCounts = rawChangeDataCountService.changeDataCounts(sparkSession, sourceReferences);

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.exception.OperationalDataStoreException;
 import uk.gov.justice.digital.service.NomisDataAccessService;
 import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTableCount;
 import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTotalCounts;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
 
 import java.util.List;
@@ -49,7 +50,7 @@ public class CurrentStateCountService {
     /**
      * Retrieve record counts from data stores that contain current state for every SourceReference/table.
      */
-    CurrentStateTotalCounts currentStateCounts(SparkSession sparkSession, List<SourceReference> sourceReferences) {
+    DataReconciliationResult currentStateCounts(SparkSession sparkSession, List<SourceReference> sourceReferences) {
         CurrentStateTotalCounts currentStateCountResults = new CurrentStateTotalCounts();
         sourceReferences.forEach(sourceReference -> {
             CurrentStateTableCount countResults = currentStateCountForTable(sparkSession, sourceReference);

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
@@ -11,11 +11,15 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.SourceReferenceService;
-import uk.gov.justice.digital.service.datareconciliation.model.ChangeDataTotalCounts;
-import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTotalCounts;
+import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CHANGE_DATA_COUNTS;
 
 
 /**
@@ -47,7 +51,7 @@ public class DataReconciliationService {
         this.changeDataCountService = changeDataCountService;
     }
 
-    public DataReconciliationResults reconcileData(SparkSession sparkSession) {
+    public DataReconciliationResult reconcileData(SparkSession sparkSession) {
         String inputDomain = jobArguments.getConfigKey();
         String dmsTaskId = jobArguments.getDmsTaskId();
 
@@ -56,9 +60,20 @@ public class DataReconciliationService {
         ImmutableSet<ImmutablePair<String, String>> configuredTables = configService.getConfiguredTables(inputDomain);
         List<SourceReference> allSourceReferences = sourceReferenceService.getAllSourceReferences(configuredTables);
 
-        CurrentStateTotalCounts currentStateTotalCounts = currentStateCountService.currentStateCounts(sparkSession, allSourceReferences);
-        ChangeDataTotalCounts changeDataTotalCounts = changeDataCountService.changeDataCounts(sparkSession, allSourceReferences, dmsTaskId);
-        return new DataReconciliationResults(currentStateTotalCounts, changeDataTotalCounts);
+        Set<ReconciliationType> reconciliationsToRun = jobArguments.getReconciliationsToRun();
+        List<DataReconciliationResult> results = reconciliationsToRun.stream().map(toRun -> {
+            logger.info("Configured to run {}", toRun);
+            switch (toRun) {
+                case CHANGE_DATA_COUNTS:
+                    return changeDataCountService.changeDataCounts(sparkSession, allSourceReferences, dmsTaskId);
+                case CURRENT_STATE_COUNTS:
+                    return currentStateCountService.currentStateCounts(sparkSession, allSourceReferences);
+                default:
+                    throw new IllegalStateException("Unexpected reconciliation result: " + toRun);
+            }
+        }).collect(Collectors.toList());
+
+        return new DataReconciliationResults(results);
     }
 }
 

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
@@ -11,15 +11,13 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.SourceReferenceService;
-import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType;
+import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CHANGE_DATA_COUNTS;
 
 
 /**
@@ -60,16 +58,16 @@ public class DataReconciliationService {
         ImmutableSet<ImmutablePair<String, String>> configuredTables = configService.getConfiguredTables(inputDomain);
         List<SourceReference> allSourceReferences = sourceReferenceService.getAllSourceReferences(configuredTables);
 
-        Set<ReconciliationType> reconciliationsToRun = jobArguments.getReconciliationsToRun();
-        List<DataReconciliationResult> results = reconciliationsToRun.stream().map(toRun -> {
-            logger.info("Configured to run {}", toRun);
-            switch (toRun) {
+        Set<ReconciliationCheck> reconciliationChecksToRun = jobArguments.getReconciliationChecksToRun();
+        List<DataReconciliationResult> results = reconciliationChecksToRun.stream().map(checkToRun -> {
+            logger.info("Configured to run {}", checkToRun);
+            switch (checkToRun) {
                 case CHANGE_DATA_COUNTS:
                     return changeDataCountService.changeDataCounts(sparkSession, allSourceReferences, dmsTaskId);
                 case CURRENT_STATE_COUNTS:
                     return currentStateCountService.currentStateCounts(sparkSession, allSourceReferences);
                 default:
-                    throw new IllegalStateException("Unexpected reconciliation result: " + toRun);
+                    throw new IllegalStateException("Unexpected reconciliation result: " + checkToRun);
             }
         }).collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
@@ -9,7 +9,7 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChangeDataTotalCounts {
+public class ChangeDataTotalCounts implements DataReconciliationResult {
 
     private static final String MISSING_COUNTS_MESSAGE = "MISSING COUNTS";
 
@@ -17,13 +17,15 @@ public class ChangeDataTotalCounts {
     private Map<String, ChangeDataTableCount> dmsCounts;
     private Map<String, ChangeDataTableCount> dmsAppliedCounts;
 
-    public boolean countsMatch() {
+    @Override
+    public boolean isSuccess() {
         return sameTables() && rawCountsMatchDmsCounts();
     }
 
+    @Override
     public String summary() {
         StringBuilder sb = new StringBuilder("Change Data Total Counts ");
-        if (countsMatch()) {
+        if (isSuccess()) {
             sb.append("MATCH:\n\n");
         } else {
             sb.append("DO NOT MATCH:\n\n");

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTotalCounts.java
@@ -12,7 +12,7 @@ import java.util.Map;
  */
 @EqualsAndHashCode
 @ToString
-public class CurrentStateTotalCounts {
+public class CurrentStateTotalCounts implements DataReconciliationResult {
 
     private final Map<String, CurrentStateTableCount> tableToResult = new HashMap<>();
 
@@ -28,13 +28,15 @@ public class CurrentStateTotalCounts {
         return tableToResult.get(fullTableName);
     }
 
-    public boolean countsMatch() {
+    @Override
+    public boolean isSuccess() {
         return tableToResult.values().stream().allMatch(CurrentStateTableCount::countsMatch);
     }
 
+    @Override
     public String summary() {
         StringBuilder sb = new StringBuilder("Current State Total Counts ");
-        if (countsMatch()) {
+        if (isSuccess()) {
             sb.append("MATCH:\n");
         } else {
             sb.append("DO NOT MATCH:\n");

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResult.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResult.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.service.datareconciliation.model;
 
+/**
+ * The result of a data reconciliation check, or an aggregate result of multiple checks
+ */
 public interface DataReconciliationResult {
     boolean isSuccess();
     String summary();

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResult.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResult.java
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+public interface DataReconciliationResult {
+    boolean isSuccess();
+    String summary();
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResults.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResults.java
@@ -2,25 +2,26 @@ package uk.gov.justice.digital.service.datareconciliation.model;
 
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
-public class DataReconciliationResults {
+public class DataReconciliationResults implements DataReconciliationResult {
 
-    private final CurrentStateTotalCounts currentStateTotalCounts;
-    private final ChangeDataTotalCounts changeDataTotalCounts;
+    private final List<DataReconciliationResult> results;
 
-    public DataReconciliationResults(
-            CurrentStateTotalCounts currentStateTotalCounts,
-            ChangeDataTotalCounts changeDataTotalCounts
-    ) {
-        this.currentStateTotalCounts = currentStateTotalCounts;
-        this.changeDataTotalCounts = changeDataTotalCounts;
+    public DataReconciliationResults(List<DataReconciliationResult> results) {
+        this.results = results;
     }
 
+    @Override
     public boolean isSuccess() {
-        return currentStateTotalCounts.countsMatch() && changeDataTotalCounts.countsMatch();
+        return results.stream().allMatch(DataReconciliationResult::isSuccess);
     }
 
+    @Override
     public String summary() {
-        return currentStateTotalCounts.summary() + "\n\n" + changeDataTotalCounts.summary();
+        return results.stream()
+                .map(DataReconciliationResult::summary)
+                .reduce("", (s1, s2) -> s1 + "\n\n" + s2);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheck.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheck.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.service.datareconciliation.model;
 
+/**
+ * The data reconciliation checks that can be run by the Data Reconciliation service
+ */
 public enum ReconciliationCheck {
     CURRENT_STATE_COUNTS,
     CHANGE_DATA_COUNTS;

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheck.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheck.java
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.service.datareconciliation.model;
 
-public enum ReconciliationType {
+public enum ReconciliationCheck {
     CURRENT_STATE_COUNTS,
     CHANGE_DATA_COUNTS;
 
-    public static ReconciliationType fromString(String reconciliationType) {
+    public static ReconciliationCheck fromString(String reconciliationType) {
         switch (reconciliationType.trim().toLowerCase()) {
             case "current_state_counts":
                 return CURRENT_STATE_COUNTS;

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationType.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationType.java
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+public enum ReconciliationType {
+    CURRENT_STATE_COUNTS,
+    CHANGE_DATA_COUNTS;
+
+    public static ReconciliationType fromString(String reconciliationType) {
+        switch (reconciliationType.trim().toLowerCase()) {
+            case "current_state_counts":
+                return CURRENT_STATE_COUNTS;
+            case "change_data_counts":
+                return CHANGE_DATA_COUNTS;
+            default:
+                throw new IllegalArgumentException("Unknown reconciliation type: " + reconciliationType);
+        }
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/ChangeDataCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/ChangeDataCountServiceTest.java
@@ -62,7 +62,7 @@ class ChangeDataCountServiceTest {
         when(dmsChangeDataCountService.dmsChangeDataCounts(any(), any())).thenReturn(dmsChangeDataCountsPair);
         when(rawChangeDataCountService.changeDataCounts(any(), any())).thenReturn(rawChangeDataCounts);
 
-        ChangeDataTotalCounts result = underTest.changeDataCounts(sparkSession, sourceReferences, DMS_TASK_ID);
+        ChangeDataTotalCounts result = (ChangeDataTotalCounts) underTest.changeDataCounts(sparkSession, sourceReferences, DMS_TASK_ID);
 
         assertEquals(dmsChangeDataCountsPair.getDmsChangeDataCounts(), result.getDmsCounts());
         assertEquals(dmsChangeDataCountsPair.getDmsAppliedChangeDataCounts(), result.getDmsAppliedCounts());

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
@@ -107,7 +107,8 @@ class CurrentStateCountServiceTest {
         when(operationalDataStoreService.isOperationalDataStoreManagedTable(sourceReference2)).thenReturn(true);
         when(operationalDataStoreService.getTableRowCount("namespace.source_table2")).thenReturn(odsCount2);
 
-        CurrentStateTotalCounts results = underTest.currentStateCounts(sparkSession, Arrays.asList(sourceReference1, sourceReference2));
+        CurrentStateTotalCounts results =
+                (CurrentStateTotalCounts) underTest.currentStateCounts(sparkSession, Arrays.asList(sourceReference1, sourceReference2));
 
         CurrentStateTableCount expectedTable1Counts = new CurrentStateTableCount(1L, 1L, 1L, 1L);
         CurrentStateTableCount table1Result = results.get("source.table");

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationServiceTest.java
@@ -26,8 +26,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CHANGE_DATA_COUNTS;
-import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationType.CURRENT_STATE_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
 
 @ExtendWith(MockitoExtension.class)
 class DataReconciliationServiceTest {
@@ -60,7 +60,7 @@ class DataReconciliationServiceTest {
 
     @Test
     void shouldGetCurrentStateCounts() {
-        when(jobArguments.getReconciliationsToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS));
+        when(jobArguments.getReconciliationChecksToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS));
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
                 ImmutablePair.of("schema", "table1"),
                 ImmutablePair.of("schema", "table2")
@@ -82,7 +82,7 @@ class DataReconciliationServiceTest {
 
     @Test
     void shouldGetChangeDataCounts() {
-        when(jobArguments.getReconciliationsToRun()).thenReturn(ImmutableSet.of(CHANGE_DATA_COUNTS));
+        when(jobArguments.getReconciliationChecksToRun()).thenReturn(ImmutableSet.of(CHANGE_DATA_COUNTS));
         when(jobArguments.getDmsTaskId()).thenReturn(DMS_TASK_ID);
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
                 ImmutablePair.of("schema", "table1"),
@@ -105,7 +105,7 @@ class DataReconciliationServiceTest {
 
     @Test
     void shouldGetCurrentStateCountsAndChangeDataCounts() {
-        when(jobArguments.getReconciliationsToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
+        when(jobArguments.getReconciliationChecksToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
         when(jobArguments.getDmsTaskId()).thenReturn(DMS_TASK_ID);
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
                 ImmutablePair.of("schema", "table1"),
@@ -130,7 +130,7 @@ class DataReconciliationServiceTest {
 
     @Test
     void shouldGetConfiguredTables() {
-        when(jobArguments.getReconciliationsToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
+        when(jobArguments.getReconciliationChecksToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
         when(jobArguments.getConfigKey()).thenReturn("config-key");
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
                 ImmutablePair.of("schema", "table1"),
@@ -150,7 +150,7 @@ class DataReconciliationServiceTest {
 
     @Test
     void shouldGetAllSourceReferences() {
-        when(jobArguments.getReconciliationsToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
+        when(jobArguments.getReconciliationChecksToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
                 ImmutablePair.of("schema", "table1"),
                 ImmutablePair.of("schema", "table2")

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
@@ -23,7 +23,7 @@ class ChangeDataTotalCountsTest {
     }
 
     @Test
-    void countsShouldMatchForMatchingCounts() {
+    void shouldBeSuccessForMatchingCounts() {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -33,12 +33,12 @@ class ChangeDataTotalCountsTest {
         dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
-        assertTrue(underTest.countsMatch());
+        assertTrue(underTest.isSuccess());
     }
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
-    void countsShouldNotMatchForDifferentInsertCounts(long rawInsertCount, long dmsInsertCount, long dmsAppliedInsertCount) {
+    void shouldBeFailureForDifferentInsertCounts(long rawInsertCount, long dmsInsertCount, long dmsAppliedInsertCount) {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -48,12 +48,12 @@ class ChangeDataTotalCountsTest {
         dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(dmsAppliedInsertCount, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
-        assertFalse(underTest.countsMatch());
+        assertFalse(underTest.isSuccess());
     }
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
-    void countsShouldNotMatchForDifferentUpdateCounts(long rawUpdateCount, long dmsUpdateCount, long dmsAppliedUpdateCount) {
+    void shouldBeFailureForDifferentUpdateCounts(long rawUpdateCount, long dmsUpdateCount, long dmsAppliedUpdateCount) {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -63,12 +63,12 @@ class ChangeDataTotalCountsTest {
         dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, dmsAppliedUpdateCount, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
-        assertFalse(underTest.countsMatch());
+        assertFalse(underTest.isSuccess());
     }
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
-    void countsShouldNotMatchForDifferentDeleteCounts(long rawDeleteCount, long dmsDeleteCount, long dmsAppliedDeleteCount) {
+    void shouldBeFailureForDifferentDeleteCounts(long rawDeleteCount, long dmsDeleteCount, long dmsAppliedDeleteCount) {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -78,11 +78,11 @@ class ChangeDataTotalCountsTest {
         dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, dmsAppliedDeleteCount));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
-        assertFalse(underTest.countsMatch());
+        assertFalse(underTest.isSuccess());
     }
 
     @Test
-    void countsShouldNotMatchForDifferentDmsTable() {
+    void shouldBeFailureForDifferentDmsTable() {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -92,11 +92,11 @@ class ChangeDataTotalCountsTest {
         dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
-        assertFalse(underTest.countsMatch());
+        assertFalse(underTest.isSuccess());
     }
 
     @Test
-    void countsShouldNotMatchForDifferentDmsAppliedTable() {
+    void shouldBeFailureForDifferentDmsAppliedTable() {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -106,7 +106,7 @@ class ChangeDataTotalCountsTest {
         dmsAppliedCounts.put("different table", new ChangeDataTableCount(1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
-        assertFalse(underTest.countsMatch());
+        assertFalse(underTest.isSuccess());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTotalCountsTest.java
@@ -11,28 +11,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CurrentStateTotalCountsTest {
 
     @Test
-    void countsShouldNotMatchIfAnyResultHasMismatchedCounts() {
+    void shouldBeFailureIfAnyResultHasMismatchedCounts() {
         // Exhaustive testing of different cases is included in the tests for CurrentStateTableCount
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
         underTest.put("table1", new CurrentStateTableCount(1L, 1L, 1L, 1L));
         underTest.put("table2", new CurrentStateTableCount(999L, 1L, 1L, 1L));
 
-        assertFalse(underTest.countsMatch());
+        assertFalse(underTest.isSuccess());
     }
 
     @Test
-    void countsShouldMatchIfAllResultsHaveMatchedCounts() {
+    void shouldBeSuccessIfAllResultsHaveMatchedCounts() {
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
         underTest.put("table1", new CurrentStateTableCount(1L, 1L, 1L, 1L));
         underTest.put("table2", new CurrentStateTableCount(2L, 2L, 2L));
 
-        assertTrue(underTest.countsMatch());
+        assertTrue(underTest.isSuccess());
     }
 
     @Test
-    void countsShouldMatchIfThereAreNoCounts() {
+    void shouldBeSuccessIfThereAreNoCounts() {
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
-        assertTrue(underTest.countsMatch());
+        assertTrue(underTest.isSuccess());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.service.datareconciliation.model;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +32,8 @@ class DataReconciliationResultsTest {
         ChangeDataTotalCounts allMatchingChangeDataTotalCounts =
                 new ChangeDataTotalCounts(changeDataTableCountMap1, changeDataTableCountMap1, changeDataTableCountMap1);
 
-        DataReconciliationResults underTest = new DataReconciliationResults(matchingCurrentStateTotalCounts, allMatchingChangeDataTotalCounts);
+        DataReconciliationResults underTest =
+                new DataReconciliationResults(Arrays.asList(matchingCurrentStateTotalCounts, allMatchingChangeDataTotalCounts));
         assertTrue(underTest.isSuccess());
     }
 
@@ -40,7 +42,8 @@ class DataReconciliationResultsTest {
         ChangeDataTotalCounts notMatchingChangeDataTotalCounts =
                 new ChangeDataTotalCounts(changeDataTableCountMap1, changeDataTableCountMap2, changeDataTableCountMap1);
 
-        DataReconciliationResults underTest = new DataReconciliationResults(notMatchingCurrentStateTotalCounts, notMatchingChangeDataTotalCounts);
+        DataReconciliationResults underTest =
+                new DataReconciliationResults(Arrays.asList(notMatchingCurrentStateTotalCounts, notMatchingChangeDataTotalCounts));
 
         assertFalse(underTest.isSuccess());
     }
@@ -50,7 +53,8 @@ class DataReconciliationResultsTest {
         ChangeDataTotalCounts matchingChangeDataTotalCounts =
                 new ChangeDataTotalCounts(changeDataTableCountMap1, changeDataTableCountMap1, changeDataTableCountMap1);
 
-        DataReconciliationResults underTest = new DataReconciliationResults(notMatchingCurrentStateTotalCounts, matchingChangeDataTotalCounts);
+        DataReconciliationResults underTest =
+                new DataReconciliationResults(Arrays.asList(notMatchingCurrentStateTotalCounts, matchingChangeDataTotalCounts));
 
         assertFalse(underTest.isSuccess());
     }
@@ -60,7 +64,8 @@ class DataReconciliationResultsTest {
         ChangeDataTotalCounts notMatchingChangeDataTotalCounts =
                 new ChangeDataTotalCounts(changeDataTableCountMap1, changeDataTableCountMap2, changeDataTableCountMap1);
 
-        DataReconciliationResults underTest = new DataReconciliationResults(matchingCurrentStateTotalCounts, notMatchingChangeDataTotalCounts);
+        DataReconciliationResults underTest =
+                new DataReconciliationResults(Arrays.asList(matchingCurrentStateTotalCounts, notMatchingChangeDataTotalCounts));
 
         assertFalse(underTest.isSuccess());
     }
@@ -70,8 +75,9 @@ class DataReconciliationResultsTest {
         ChangeDataTotalCounts allMatchingChangeDataTotalCounts =
                 new ChangeDataTotalCounts(changeDataTableCountMap1, changeDataTableCountMap1, changeDataTableCountMap1);
 
-        DataReconciliationResults underTest = new DataReconciliationResults(matchingCurrentStateTotalCounts, allMatchingChangeDataTotalCounts);
-        String expected = "Current State Total Counts MATCH:\n" +
+        DataReconciliationResults underTest =
+                new DataReconciliationResults(Arrays.asList(matchingCurrentStateTotalCounts, allMatchingChangeDataTotalCounts));
+        String expected = "\n\nCurrent State Total Counts MATCH:\n" +
                 "For table table1:\n" +
                 "\tNomis: 1, Structured Zone: 1, Curated Zone: 1, Operational DataStore: skipped\t - MATCH\n" +
                 "\n" +


### PR DESCRIPTION
- `dpr.reconciliation.checks.to.run` config job argument can be set to a single check or a comma separated list of checks.
- Checks available currently are `current_state_counts` and `change_data_counts` with at least one more to follow in future work
- If the job argument is not set then it defaults to the previous behaviour of running all checks
- Unify the interface for the results of a check/checks in `DataReconciliationResult`