### PR TITLE
DPR2-1124 better logging when set of tables do not match

### DIFF
--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
@@ -33,6 +35,13 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
 
         if (!sameTables()) {
             sb.append("\nThe set of tables for DMS vs Raw zone DO NOT MATCH\n\n");
+            String dmsTables = sortedListOfTables(dmsCounts.keySet());
+            String dmsAppliedTables = sortedListOfTables(dmsAppliedCounts.keySet());
+            String rawTables = sortedListOfTables(rawZoneCounts.keySet());
+            sb.append("DMS Tables: ").append(dmsTables).append("\n");
+            sb.append("DMS Applied Tables: ").append(dmsAppliedTables).append("\n");
+            sb.append("Raw Zone/Raw Archive Tables: ").append(rawTables).append("\n");
+            sb.append("\n");
         }
 
         dmsCounts.forEach((tableName, dmsCount) -> {
@@ -63,6 +72,10 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
         });
 
         return sb.toString();
+    }
+
+    private static String sortedListOfTables(Set<String> tables) {
+        return tables.stream().sorted().collect(Collectors.joining(", "));
     }
 
     private boolean rawCountsMatchDmsCounts() {

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
@@ -170,6 +170,10 @@ class ChangeDataTotalCountsTest {
                 "\n" +
                 "The set of tables for DMS vs Raw zone DO NOT MATCH\n" +
                 "\n" +
+                "DMS Tables: table1\n" +
+                "DMS Applied Tables: table1\n" +
+                "Raw Zone/Raw Archive Tables: different table\n" +
+                "\n" +
                 "For table table1 DOES NOT MATCH:\n" +
                 "\tMISSING COUNTS\t - Raw\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS\n" +
@@ -185,6 +189,7 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
         rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put("table2", new ChangeDataTableCount(1L, 1L, 1L));
         dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
         dmsAppliedCounts.put("different table", new ChangeDataTableCount(1L, 1L, 1L));
 
@@ -194,6 +199,10 @@ class ChangeDataTotalCountsTest {
                 "\n" +
                 "\n" +
                 "The set of tables for DMS vs Raw zone DO NOT MATCH\n" +
+                "\n" +
+                "DMS Tables: table1\n" +
+                "DMS Applied Tables: different table\n" +
+                "Raw Zone/Raw Archive Tables: table1, table2\n" +
                 "\n" +
                 "For table table1 DOES NOT MATCH:\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - Raw\n" +


### PR DESCRIPTION
- Adds details to what is logged when the set of tables for DMS vs DMS applied vs Raw/Raw archive do not match
- Previously it just told you they did not match
- Now it lists the names of the tables in each datastore to amke it easier to work out what the problem is