### PR TITLE
DPR2-1127: Use delta instead of parquet when reading structured and curated

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -118,6 +118,13 @@ public class S3DataProvider {
                 .parquet(filePath);
     }
 
+    public Dataset<Row> getBatchDeltaTableData(SparkSession sparkSession, String filePath) {
+        return sparkSession
+                .read()
+                .format("delta")
+                .load(filePath);
+    }
+
     public StructType inferSchema(SparkSession sparkSession, String sourceName, String tableName) {
         // Attempt to infer schema from files in the raw zone.
         // If there is a failure due to FileNotFoundException which occurs when a file gets archived then the schema inference is done using data already in the raw archive

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
@@ -98,7 +98,7 @@ public class CurrentStateCountService {
     private long getStructuredCount(SparkSession sparkSession, String structuredTablePath, String sourceName, String tableName) {
         long structuredCount;
         try {
-            Dataset<Row> structured = s3DataProvider.getBatchSourceData(sparkSession, structuredTablePath);
+            Dataset<Row> structured = s3DataProvider.getBatchDeltaTableData(sparkSession, structuredTablePath);
             logger.info("Reading Structured count for table {}/{}", sourceName, tableName);
             structuredCount = structured.count();
         } catch (Exception e) {
@@ -115,7 +115,7 @@ public class CurrentStateCountService {
     private long getCuratedCount(SparkSession sparkSession, String curatedTablePath, String sourceName, String tableName, String structuredTablePath) {
         long curatedCount;
         try {
-            Dataset<Row> curated = s3DataProvider.getBatchSourceData(sparkSession, curatedTablePath);
+            Dataset<Row> curated = s3DataProvider.getBatchDeltaTableData(sparkSession, curatedTablePath);
             logger.info("Reading Curated count for table {}/{}", sourceName, tableName);
             curatedCount = curated.count();
         } catch (Exception e) {

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
@@ -65,8 +65,8 @@ class CurrentStateCountServiceTest {
         when(jobArguments.getStructuredS3Path()).thenReturn("s3://structured");
         when(jobArguments.getCuratedS3Path()).thenReturn("s3://curated");
 
-        when(s3DataProvider.getBatchSourceData(sparkSession, "s3://structured/source/table")).thenReturn(structured1);
-        when(s3DataProvider.getBatchSourceData(sparkSession, "s3://curated/source/table")).thenReturn(curated1);
+        when(s3DataProvider.getBatchDeltaTableData(sparkSession, "s3://structured/source/table")).thenReturn(structured1);
+        when(s3DataProvider.getBatchDeltaTableData(sparkSession, "s3://curated/source/table")).thenReturn(curated1);
     }
 
     @Test
@@ -91,8 +91,8 @@ class CurrentStateCountServiceTest {
         when(sourceReference2.getFullOperationalDataStoreTableNameWithSchema()).thenReturn("namespace.source_table2");
         when(sourceReference2.getFullDatahubTableName()).thenReturn("source.table2");
 
-        when(s3DataProvider.getBatchSourceData(sparkSession, "s3://structured/source/table2")).thenReturn(structured2);
-        when(s3DataProvider.getBatchSourceData(sparkSession, "s3://curated/source/table2")).thenReturn(curated2);
+        when(s3DataProvider.getBatchDeltaTableData(sparkSession, "s3://structured/source/table2")).thenReturn(structured2);
+        when(s3DataProvider.getBatchDeltaTableData(sparkSession, "s3://curated/source/table2")).thenReturn(curated2);
 
         long oracleCount2 = 4L;
         long structuredCount2 = 3L;


### PR DESCRIPTION
- Structured and Curated zones are stored in Delta format
- Therefore we need to use delta format to read them as reading them as raw parquet results in deleted rows showing up during reconciliation
- This PR changes the reconciliation of current data counts to read using delta format