### PR TITLE
DPR2-1127: Fail early with null connection or credential details

### DIFF
--- a/src/main/java/uk/gov/justice/digital/datahub/model/JDBCCredentials.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/JDBCCredentials.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.datahub.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class JDBCCredentials {
-    @JsonProperty(value = "username", required = true)
     private String username;
-    @JsonProperty(value = "password", required = true)
     private String password;
 }

--- a/src/main/java/uk/gov/justice/digital/datahub/model/JDBCCredentials.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/JDBCCredentials.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class JDBCCredentials {
-    @JsonProperty(required = true)
+    @JsonProperty(value = "username", required = true)
     private String username;
-    @JsonProperty(required = true)
+    @JsonProperty(value = "password", required = true)
     private String password;
 }

--- a/src/main/java/uk/gov/justice/digital/datahub/model/JDBCCredentials.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/JDBCCredentials.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.datahub.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class JDBCCredentials {
+    @JsonProperty(required = true)
     private String username;
+    @JsonProperty(required = true)
     private String password;
 }

--- a/src/main/java/uk/gov/justice/digital/exception/JDBCGlueConnectionDetailsException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/JDBCGlueConnectionDetailsException.java
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.exception;
+
+public class JDBCGlueConnectionDetailsException extends RuntimeException {
+
+    private static final long serialVersionUID = -9016956480838963212L;
+
+    public JDBCGlueConnectionDetailsException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.datareconciliation.DataReconciliationService;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
-import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
 
 import javax.inject.Inject;
 

--- a/src/main/java/uk/gov/justice/digital/service/JDBCGlueConnectionDetailsService.java
+++ b/src/main/java/uk/gov/justice/digital/service/JDBCGlueConnectionDetailsService.java
@@ -8,9 +8,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.client.glue.GlueClient;
 import uk.gov.justice.digital.client.secretsmanager.SecretsManagerClient;
-import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.JDBCCredentials;
 import uk.gov.justice.digital.datahub.model.JDBCGlueConnectionDetails;
+import uk.gov.justice.digital.exception.JDBCGlueConnectionDetailsException;
 
 import java.util.Map;
 
@@ -39,11 +39,21 @@ public class JDBCGlueConnectionDetailsService {
         logger.debug("Getting connection details for connection {}", connectionName);
         com.amazonaws.services.glue.model.Connection connection = glueClient.getConnection(connectionName);
         Map<String, String> connectionProperties = connection.getConnectionProperties();
-        String url = connectionProperties.get("JDBC_CONNECTION_URL");
+        String jdbcUrl = connectionProperties.get("JDBC_CONNECTION_URL");
+        if (jdbcUrl == null) {
+            throw new JDBCGlueConnectionDetailsException("JDBC url was null");
+        }
         String jdbcDriverClassName = connectionProperties.get("JDBC_DRIVER_CLASS_NAME");
+        if (jdbcDriverClassName == null) {
+            throw new JDBCGlueConnectionDetailsException("JDBC driver class name was null");
+        }
+        logger.debug("Using connection URL {}", jdbcUrl);
         String secretId = connectionProperties.get("SECRET_ID");
         JDBCCredentials credentials = secretsManagerClient.getSecret(secretId, JDBCCredentials.class);
-        JDBCGlueConnectionDetails connectionDetails = new JDBCGlueConnectionDetails(url, jdbcDriverClassName, credentials);
+        if (credentials.getUsername() == null || credentials.getPassword() == null) {
+            throw new JDBCGlueConnectionDetailsException("Username or password was null");
+        }
+        JDBCGlueConnectionDetails connectionDetails = new JDBCGlueConnectionDetails(jdbcUrl, jdbcDriverClassName, credentials);
         logger.debug("Finished getting connection details for connection {} in {}ms", connectionName, System.currentTimeMillis() - startTime);
         return connectionDetails;
     }

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/JDBCGlueConnectionDetailsServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/JDBCGlueConnectionDetailsServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class JDBCGlueConnectionDetailsServiceTest {
 
-    private final static String connectionName = "some-connection-name";
+    private static final String CONNECTION_NAME = "some-connection-name";
     @Mock
     private GlueClient mockGlueClient;
     @Mock
@@ -55,17 +55,17 @@ class JDBCGlueConnectionDetailsServiceTest {
 
         JDBCCredentials credentials = new JDBCCredentials(expectedUsername, expectedPassword);
 
-        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockGlueClient.getConnection(CONNECTION_NAME)).thenReturn(mockConnection);
         when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
         when(mockSecretsManagerClient.getSecret(secretId, JDBCCredentials.class)).thenReturn(credentials);
 
-        JDBCGlueConnectionDetails result = underTest.getConnectionDetails(connectionName);
+        JDBCGlueConnectionDetails result = underTest.getConnectionDetails(CONNECTION_NAME);
         assertEquals(expectedUrl, result.getUrl());
         assertEquals(expectedDriver, result.getJdbcDriverClassName());
         assertEquals(expectedUsername, result.getCredentials().getUsername());
         assertEquals(expectedPassword, result.getCredentials().getPassword());
 
-        verify(mockGlueClient, times(1)).getConnection(connectionName);
+        verify(mockGlueClient, times(1)).getConnection(CONNECTION_NAME);
         verify(mockSecretsManagerClient, times(1)).getSecret(secretId, JDBCCredentials.class);
     }
 
@@ -77,10 +77,10 @@ class JDBCGlueConnectionDetailsServiceTest {
         connectionProperties.put("JDBC_DRIVER_CLASS_NAME", "driver");
         connectionProperties.put("SECRET_ID", "secret");
 
-        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockGlueClient.getConnection(CONNECTION_NAME)).thenReturn(mockConnection);
         when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
 
-        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(CONNECTION_NAME));
     }
 
     @Test
@@ -91,15 +91,14 @@ class JDBCGlueConnectionDetailsServiceTest {
         connectionProperties.put("JDBC_DRIVER_CLASS_NAME", null);
         connectionProperties.put("SECRET_ID", "secret");
 
-        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockGlueClient.getConnection(CONNECTION_NAME)).thenReturn(mockConnection);
         when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
 
-        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(CONNECTION_NAME));
     }
 
     @Test
     void shouldThrowForNullUsername() {
-        String connectionName = "some-connection-name";
         String secretId = "some-secret-id";
 
         Map<String, String> connectionProperties = new HashMap<>();
@@ -109,16 +108,15 @@ class JDBCGlueConnectionDetailsServiceTest {
 
         JDBCCredentials credentials = new JDBCCredentials(null, "password");
 
-        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockGlueClient.getConnection(CONNECTION_NAME)).thenReturn(mockConnection);
         when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
         when(mockSecretsManagerClient.getSecret(secretId, JDBCCredentials.class)).thenReturn(credentials);
 
-        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(CONNECTION_NAME));
     }
 
     @Test
     void shouldThrowForNullPassword() {
-        String connectionName = "some-connection-name";
         String secretId = "some-secret-id";
 
         Map<String, String> connectionProperties = new HashMap<>();
@@ -128,10 +126,10 @@ class JDBCGlueConnectionDetailsServiceTest {
 
         JDBCCredentials credentials = new JDBCCredentials("user", null);
 
-        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockGlueClient.getConnection(CONNECTION_NAME)).thenReturn(mockConnection);
         when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
         when(mockSecretsManagerClient.getSecret(secretId, JDBCCredentials.class)).thenReturn(credentials);
 
-        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(CONNECTION_NAME));
     }
 }

--- a/src/test/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/JDBCGlueConnectionDetailsServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/JDBCGlueConnectionDetailsServiceTest.java
@@ -8,16 +8,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.glue.GlueClient;
 import uk.gov.justice.digital.client.secretsmanager.SecretsManagerClient;
-import uk.gov.justice.digital.config.JobArguments;
-import uk.gov.justice.digital.datahub.model.JDBCGlueConnectionDetails;
 import uk.gov.justice.digital.datahub.model.JDBCCredentials;
+import uk.gov.justice.digital.datahub.model.JDBCGlueConnectionDetails;
+import uk.gov.justice.digital.exception.JDBCGlueConnectionDetailsException;
 import uk.gov.justice.digital.service.JDBCGlueConnectionDetailsService;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class JDBCGlueConnectionDetailsServiceTest {
 
+    private final static String connectionName = "some-connection-name";
     @Mock
     private GlueClient mockGlueClient;
     @Mock
@@ -45,7 +46,6 @@ class JDBCGlueConnectionDetailsServiceTest {
         String expectedDriver = "org.postgresql.Driver";
         String expectedUsername = "user";
         String expectedPassword = "pass";
-        String connectionName = "some-connection-name";
         String secretId = "some-secret-id";
 
         Map<String, String> connectionProperties = new HashMap<>();
@@ -67,5 +67,71 @@ class JDBCGlueConnectionDetailsServiceTest {
 
         verify(mockGlueClient, times(1)).getConnection(connectionName);
         verify(mockSecretsManagerClient, times(1)).getSecret(secretId, JDBCCredentials.class);
+    }
+
+    @Test
+    void shouldThrowForNullJdbcConnectionUrl() {
+
+        Map<String, String> connectionProperties = new HashMap<>();
+        connectionProperties.put("JDBC_CONNECTION_URL", null);
+        connectionProperties.put("JDBC_DRIVER_CLASS_NAME", "driver");
+        connectionProperties.put("SECRET_ID", "secret");
+
+        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
+
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+    }
+
+    @Test
+    void shouldThrowForNullDriverClassName() {
+
+        Map<String, String> connectionProperties = new HashMap<>();
+        connectionProperties.put("JDBC_CONNECTION_URL", "connection url");
+        connectionProperties.put("JDBC_DRIVER_CLASS_NAME", null);
+        connectionProperties.put("SECRET_ID", "secret");
+
+        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
+
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+    }
+
+    @Test
+    void shouldThrowForNullUsername() {
+        String connectionName = "some-connection-name";
+        String secretId = "some-secret-id";
+
+        Map<String, String> connectionProperties = new HashMap<>();
+        connectionProperties.put("JDBC_CONNECTION_URL", "connectionurl");
+        connectionProperties.put("JDBC_DRIVER_CLASS_NAME", "driver");
+        connectionProperties.put("SECRET_ID", secretId);
+
+        JDBCCredentials credentials = new JDBCCredentials(null, "password");
+
+        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
+        when(mockSecretsManagerClient.getSecret(secretId, JDBCCredentials.class)).thenReturn(credentials);
+
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
+    }
+
+    @Test
+    void shouldThrowForNullPassword() {
+        String connectionName = "some-connection-name";
+        String secretId = "some-secret-id";
+
+        Map<String, String> connectionProperties = new HashMap<>();
+        connectionProperties.put("JDBC_CONNECTION_URL", "connectionurl");
+        connectionProperties.put("JDBC_DRIVER_CLASS_NAME", "driver");
+        connectionProperties.put("SECRET_ID", secretId);
+
+        JDBCCredentials credentials = new JDBCCredentials("user", null);
+
+        when(mockGlueClient.getConnection(connectionName)).thenReturn(mockConnection);
+        when(mockConnection.getConnectionProperties()).thenReturn(connectionProperties);
+        when(mockSecretsManagerClient.getSecret(secretId, JDBCCredentials.class)).thenReturn(credentials);
+
+        assertThrows(JDBCGlueConnectionDetailsException.class, () -> underTest.getConnectionDetails(connectionName));
     }
 }


### PR DESCRIPTION
During testing I saw an issue where spark used "spark" as a username in its JDBC reader. This was because the contents of a secret had a misspelling for username causing it to be set to null, and spark to default to the username "spark". This was difficult to troubleshoot because the error message was unhelpful so I have added some defensive null checks with descriptive error messages.