### PR TITLE
DPR2-1105: Make vacuum and compaction jobs runnable for a domain

### DIFF
--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceCompactionIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.service;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.config.JobArguments;
@@ -35,7 +36,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
         long originalNumFilesAgencyLocations = countParquetFiles(agencyLocationsTablePathDepth2);
         long originalNumFilesInternalLocations = countParquetFiles(internalLocationsTablePathDepth3);
 
-        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.compactDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
 
         // In this test we verify compaction using both the effect on number of files and the reported delta operations.
         // In other tests we just check the delta operations in metadata.
@@ -57,7 +58,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
     public void shouldCompactDeltaTablesWhenRecursingWithDepth2() {
         int depthLimit = 2;
 
-        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.compactDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
 
         assertEquals(1, numberOfCompactions(offendersTablePath.toString()));
         assertEquals(1, numberOfCompactions(offenderBookingsTablePath.toString()));
@@ -69,7 +70,7 @@ class MaintenanceServiceCompactionIntegrationTest extends DeltaTablesTestBase {
     public void shouldCompactDeltaTablesWhenRecursingWithDepth3() {
         int depthLimit = 3;
 
-        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.compactDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
 
         assertEquals(1, numberOfCompactions(offendersTablePath.toString()));
         assertEquals(1, numberOfCompactions(offenderBookingsTablePath.toString()));

--- a/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/MaintenanceServiceVacuumIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.service;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.config.JobArguments;
@@ -36,8 +37,8 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
     public void shouldVacuumDeltaTablesWhenRecursingWithDepth1() throws Exception {
         int depthLimit = 1;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
-        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
-        underTest.vacuumDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.compactDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
+        underTest.vacuumDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
 
         // The tables in the root have been compacted
         assertEquals(1, countParquetFiles(offendersTablePath));
@@ -51,8 +52,8 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
     public void shouldVacuumDeltaTablesWhenRecursingWithDepth2() throws Exception {
         int depthLimit = 2;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
-        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
-        underTest.vacuumDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.compactDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
+        underTest.vacuumDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
 
         // The tables in the root and 2nd level have been compacted
         assertEquals(1, countParquetFiles(offendersTablePath));
@@ -66,8 +67,8 @@ class MaintenanceServiceVacuumIntegrationTest extends DeltaTablesTestBase {
     public void shouldVacuumDeltaTablesWhenRecursingWithDepth3() throws Exception {
         int depthLimit = 3;
         // Compaction followed by vacuum on a table with zero retention should result in a single parquet file
-        underTest.compactDeltaTables(spark, rootPath.toString(), depthLimit);
-        underTest.vacuumDeltaTables(spark, rootPath.toString(), depthLimit);
+        underTest.compactDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
+        underTest.vacuumDeltaTables(spark, rootPath.toString(), ImmutableSet.of(), depthLimit);
 
         // The tables have all been compacted down to level 3 subdirectories
         assertEquals(1, countParquetFiles(offendersTablePath));

--- a/src/main/java/uk/gov/justice/digital/job/CompactionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/CompactionJob.java
@@ -1,18 +1,21 @@
 package uk.gov.justice.digital.job;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
+import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.MaintenanceService;
 
 import javax.inject.Inject;
+import java.util.Optional;
 
 import static picocli.CommandLine.Command;
 
 /**
- * Job that runs a delta lake compaction on any tables it finds immediately under the provided Hadoop compatible path.
+ * Job that runs a delta lake compaction on tables belonging to a provided domain or otherwise any tables it finds immediately under the provided Hadoop compatible path.
  * A compaction will rewrite small files into larger files that are more efficient for read operations. It will
  * not remove the old files that it has compacted until a separate vacuum is run.
  */
@@ -22,16 +25,19 @@ public class CompactionJob implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(CompactionJob.class);
 
     private final MaintenanceService maintenanceService;
+    private final ConfigService configService;
     private final SparkSessionProvider sparkSessionProvider;
     private final JobArguments jobArguments;
 
     @Inject
     public CompactionJob(
             MaintenanceService maintenanceService,
+            ConfigService configService,
             SparkSessionProvider sparkSessionProvider,
             JobArguments jobArguments
     ) {
         this.maintenanceService = maintenanceService;
+        this.configService = configService;
         this.sparkSessionProvider = sparkSessionProvider;
         this.jobArguments = jobArguments;
     }
@@ -48,8 +54,15 @@ public class CompactionJob implements Runnable {
 
             String rootPath = jobArguments.getMaintenanceTablesRootPath();
             int maxDepth = jobArguments.getMaintenanceListTableRecurseMaxDepth();
+            Optional<String> optionalConfigKey = jobArguments.getOptionalConfigKey();
 
-            maintenanceService.compactDeltaTables(spark, rootPath, maxDepth);
+            if (optionalConfigKey.isPresent()) {
+                ImmutableSet<String> configuredTablePaths = configService.getConfiguredTablePaths(optionalConfigKey.get());
+                maintenanceService.compactDeltaTables(spark, rootPath, configuredTablePaths, maxDepth);
+            } else {
+                maintenanceService.compactDeltaTables(spark, rootPath, ImmutableSet.of(), maxDepth);
+            }
+
             logger.info("Compaction finished");
         } catch (Exception e) {
             logger.error("Caught exception during job run", e);

--- a/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
@@ -1,18 +1,21 @@
 package uk.gov.justice.digital.job;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
+import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.MaintenanceService;
 
 import javax.inject.Inject;
+import java.util.Optional;
 
 import static picocli.CommandLine.Command;
 
 /**
- * Job that runs a delta lake vacuum on any tables it finds immediately under the provided Hadoop compatible path.
+ * Job that runs a delta lake vacuum on tables belonging to a provided domain or otherwise any tables it finds immediately under the provided Hadoop compatible path.
  * A vacuum removes files which have expired in the delta lake history. If run after the compaction job this
  * job will remove the pre-compaction files once their table's retention period `delta.deletedFileRetentionDuration`
  * has passed.
@@ -22,16 +25,19 @@ public class VacuumJob implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(VacuumJob.class);
     private final MaintenanceService maintenanceService;
+    private final ConfigService configService;
     private final SparkSessionProvider sparkSessionProvider;
     private final JobArguments jobArguments;
 
     @Inject
     public VacuumJob(
             MaintenanceService maintenanceService,
+            ConfigService configService,
             SparkSessionProvider sparkSessionProvider,
             JobArguments jobArguments
     ) {
         this.maintenanceService = maintenanceService;
+        this.configService = configService;
         this.sparkSessionProvider = sparkSessionProvider;
         this.jobArguments = jobArguments;
     }
@@ -48,8 +54,15 @@ public class VacuumJob implements Runnable {
 
             String rootPath = jobArguments.getMaintenanceTablesRootPath();
             int maxDepth = jobArguments.getMaintenanceListTableRecurseMaxDepth();
+            Optional<String> optionalConfigKey = jobArguments.getOptionalConfigKey();
 
-            maintenanceService.vacuumDeltaTables(spark, rootPath, maxDepth);
+            if (optionalConfigKey.isPresent()) {
+                ImmutableSet<String> configuredTablePaths = configService.getConfiguredTablePaths(optionalConfigKey.get());
+                maintenanceService.vacuumDeltaTables(spark, rootPath, configuredTablePaths, maxDepth);
+            } else {
+                maintenanceService.vacuumDeltaTables(spark, rootPath, ImmutableSet.of(), maxDepth);
+            }
+
             logger.info("Vacuum finished");
         } catch (Exception e) {
             logger.error("Caught exception during job run", e);

--- a/src/main/java/uk/gov/justice/digital/service/ConfigService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ConfigService.java
@@ -23,4 +23,12 @@ public class ConfigService {
         if (configuredTables.isEmpty()) throw new ConfigServiceException("No tables configured for key " + configKey);
         return configuredTables;
     }
+
+    public ImmutableSet<String> getConfiguredTablePaths(String configKey) {
+        return ImmutableSet.copyOf(getConfiguredTables(configKey)
+                .stream()
+                .map(pair -> pair.left + "/" + pair.right)
+                .iterator()
+        );
+    }
 }


### PR DESCRIPTION
This PR makes the Compaction and Vacuum jobs configurable to run per domain by passing the `dpr.config.key` and `dpr.config.s3.bucket`. When the config key is missing then the jobs run for all tables in the given `dpr.maintenance.root.path`.