### PR TITLE
DPR2-1135: Handle missing tables in structured/curated zones by setting count to zero.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3DataProvider.java
@@ -8,6 +8,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.delta.DeltaAnalysisException;
 import org.apache.spark.sql.streaming.DataStreamReader;
 import org.apache.spark.sql.types.StructType;
 import org.jetbrains.annotations.NotNull;
@@ -83,7 +84,8 @@ public class S3DataProvider {
         //  We sometimes only want to catch AnalysisException and check if it is because the path does not exist,
         //  but we can't be more specific than Exception in what we catch because the Java compiler will complain
         //  that AnalysisException isn't declared as thrown due to Scala trickery.
-        return e instanceof AnalysisException && e.getMessage().startsWith("Path does not exist");
+        return (e instanceof AnalysisException && e.getMessage().startsWith("Path does not exist")) ||
+                (e instanceof DeltaAnalysisException && e.getMessage().contains("doesn't exist"));
     }
 
 

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3DataProviderTest.java
@@ -4,6 +4,7 @@ import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.delta.DeltaAnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,8 @@ class S3DataProviderTest {
     private DataFrameReader dfReader;
     @Mock
     private AnalysisException analysisException;
+    @Mock
+    private DeltaAnalysisException deltaAnalysisException;
 
     private S3DataProvider underTest;
 
@@ -83,6 +86,12 @@ class S3DataProviderTest {
     void isPathDoesNotExistExceptionShouldReturnTrueWhenPathDoesNotExist() {
         when(analysisException.getMessage()).thenReturn("Path does not exist");
         assertTrue(S3DataProvider.isPathDoesNotExistException(analysisException));
+    }
+
+    @Test
+    void isPathDoesNotExistExceptionShouldReturnTrueWhenDeltaPathDoesNotExist() {
+        when(deltaAnalysisException.getMessage()).thenReturn("Delta table `s3://some-bucket/some-path` doesn't exist.");
+        assertTrue(S3DataProvider.isPathDoesNotExistException(deltaAnalysisException));
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.service.datareconciliation;
 
-import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.delta.DeltaAnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,8 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
-import uk.gov.justice.digital.exception.ReconciliationDataSourceException;
 import uk.gov.justice.digital.exception.OperationalDataStoreException;
+import uk.gov.justice.digital.exception.ReconciliationDataSourceException;
 import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTableCount;
 import uk.gov.justice.digital.service.datareconciliation.model.CurrentStateTotalCounts;
 import uk.gov.justice.digital.service.operationaldatastore.OperationalDataStoreService;
@@ -51,7 +51,7 @@ class CurrentStateCountServiceTest {
     @Mock
     private Dataset<Row> curated2;
     @Mock
-    private AnalysisException analysisException;
+    private DeltaAnalysisException deltaAnalysisException;
 
     @InjectMocks
     private CurrentStateCountService underTest;
@@ -205,9 +205,9 @@ class CurrentStateCountServiceTest {
     @Test
     void shouldReturnZeroCountWhenStructuredTablePathDoesNotExist() {
         when(reconciliationDataSourceService.getTableRowCount("table")).thenReturn(1L);
-        when(analysisException.getMessage()).thenReturn("Path does not exist");
+        when(deltaAnalysisException.getMessage()).thenReturn("Delta table `s3://bucket/path/path` doesn't exist.");
         when(structured1.count()).thenAnswer(i -> {
-            throw analysisException;
+            throw deltaAnalysisException;
         });
         when(curated1.count()).thenReturn(1L);
 
@@ -226,10 +226,10 @@ class CurrentStateCountServiceTest {
     @Test
     void shouldReturnZeroCountWhenCuratedTablePathDoesNotExist() {
         when(reconciliationDataSourceService.getTableRowCount("table")).thenReturn(1L);
-        when(analysisException.getMessage()).thenReturn("Path does not exist");
+        when(deltaAnalysisException.getMessage()).thenReturn("Delta table `s3://bucket/path/path` doesn't exist.");
         when(structured1.count()).thenReturn(1L);
         when(curated1.count()).thenAnswer(i -> {
-            throw analysisException;
+            throw deltaAnalysisException;
         });
 
         when(operationalDataStoreService.isEnabled()).thenReturn(true);


### PR DESCRIPTION
- When structured or curated tables are missing then set reconciliation count to zero