### PR TITLE
DPR2-1136: Report reconciliation failures to cloudwatch.

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -83,6 +83,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE, "10000" },
             { JobArguments.RECONCILIATION_DATASOURCE_GLUE_CONNECTION_NAME, "my-connection" },
             { JobArguments.RECONCILIATION_DATASOURCE_SOURCE_SCHEMA_NAME, "OMS_OWNER" },
+            { JobArguments.RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE, "SomeNamespace" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -144,6 +145,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE, Long.toString(validArguments.getOperationalDataStoreJdbcBatchSize()) },
                 { JobArguments.RECONCILIATION_DATASOURCE_GLUE_CONNECTION_NAME, validArguments.getReconciliationDataSourceGlueConnectionName() },
                 { JobArguments.RECONCILIATION_DATASOURCE_SOURCE_SCHEMA_NAME, validArguments.getReconciliationDataSourceSourceSchemaName() },
+                { JobArguments.RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE, validArguments.getReconciliationCloudwatchMetricsNamespace() },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -588,14 +590,47 @@ class JobArgumentsIntegrationTest {
         assertEquals(RECONCILIATION_CHECKS_TO_RUN_DEFAULT, jobArguments.getReconciliationChecksToRun());
     }
 
-
     @ParameterizedTest
     @CsvSource({ "true, true", "false, false", "True, true", "False, false" })
-    public void shouldGetShouldReconciliationDataSourceTableNamesBeUpperCase(String input, boolean expected) {
+    public void shouldReconciliationDataSourceTableNamesBeUpperCaseShouldParseInput(String input, boolean expected) {
         HashMap<String, String> args = new HashMap<>();
         args.put(JobArguments.RECONCILIATION_DATASOURCE_SHOULD_UPPERCASE_TABLENAMES, input);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(expected, jobArguments.shouldReconciliationDataSourceTableNamesBeUpperCase());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true, true", "false, false", "True, true", "False, false" })
+    public void shouldReconciliationFailJobIfChecksFailShouldParseInput(String input, boolean expected) {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(expected, jobArguments.shouldReconciliationFailJobIfChecksFail());
+    }
+
+    @Test
+    public void shouldReconciliationFailJobIfChecksFailShouldDefaultToFalseWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertFalse(jobArguments.shouldReconciliationFailJobIfChecksFail());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true, true", "false, false", "True, true", "False, false" })
+    public void shouldReportReconciliationResultsToCloudwatchShouldParseInput(String input, boolean expected) {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH, input);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(expected, jobArguments.shouldReportReconciliationResultsToCloudwatch());
+    }
+
+    @Test
+    public void shouldReportReconciliationResultsToCloudwatchShouldDefaultToFalseWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertFalse(jobArguments.shouldReportReconciliationResultsToCloudwatch());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/main/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClient.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.client.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+@Singleton
+public class CloudwatchClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(CloudwatchClient.class);
+
+    private final AmazonCloudWatch client;
+
+    @Inject
+    public CloudwatchClient(CloudwatchClientProvider cloudwatchClientProvider) {
+        this.client = cloudwatchClientProvider.getClient();
+    }
+
+    public void putMetrics(String namespace, Collection<MetricDatum> metricData) {
+        logger.debug("Putting metrics to namespace {}", namespace);
+        PutMetricDataRequest putMetricDataRequest = new PutMetricDataRequest();
+        putMetricDataRequest.setNamespace(namespace);
+        putMetricDataRequest.setMetricData(metricData);
+        client.putMetricData(putMetricDataRequest);
+        logger.debug("Finished putting metrics to namespace {}", namespace);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClientProvider.java
+++ b/src/main/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClientProvider.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.client.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import jakarta.inject.Singleton;
+import uk.gov.justice.digital.client.ClientProvider;
+
+@Singleton
+public class CloudwatchClientProvider implements ClientProvider<AmazonCloudWatch> {
+    @Override
+    public AmazonCloudWatch getClient() {
+        return AmazonCloudWatchClientBuilder.defaultClient();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -148,6 +148,9 @@ public class JobArguments {
     static final String RECONCILIATION_DATASOURCE_SHOULD_UPPERCASE_TABLENAMES = "dpr.reconciliation.datasource.should.uppercase.tablenames";
     static final String RECONCILIATION_CHECKS_TO_RUN = "dpr.reconciliation.checks.to.run";
     static final Set<ReconciliationCheck> RECONCILIATION_CHECKS_TO_RUN_DEFAULT = new HashSet<>(Arrays.asList(ReconciliationCheck.values()));
+    static final String RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS = "dpr.reconciliation.fail.job.if.checks.fail";
+    static final String RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH = "dpr.reconciliation.report.results.to.cloudwatch";
+    static final String RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE = "dpr.reconciliation.cloudwatch.metrics.namespace";
 
     private final Map<String, String> config;
 
@@ -523,6 +526,18 @@ public class JobArguments {
                             .collect(Collectors.toSet())
                 )
                 .orElse(RECONCILIATION_CHECKS_TO_RUN_DEFAULT);
+    }
+
+    public boolean shouldReconciliationFailJobIfChecksFail() {
+        return getArgument(RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS, false);
+    }
+
+    public boolean shouldReportReconciliationResultsToCloudwatch() {
+        return getArgument(RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH, false);
+    }
+
+    public String getReconciliationCloudwatchMetricsNamespace() {
+        return getArgument(RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataReconciliationJob.java
@@ -83,7 +83,9 @@ public class DataReconciliationJob implements Runnable {
             logger.info("Data reconciliation SUCCEEDED:\n\n{}", resultSummary);
         } else {
             logger.error("Data reconciliation FAILED WITH DIFFERENCES:\n\n{}", resultSummary);
-            System.exit(1);
+            if (jobArguments.shouldReconciliationFailJobIfChecksFail()) {
+                System.exit(1);
+            }
         }
     }
 

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
@@ -33,6 +33,7 @@ public class DataReconciliationService {
     private final SourceReferenceService sourceReferenceService;
     private final CurrentStateCountService currentStateCountService;
     private final ChangeDataCountService changeDataCountService;
+    private final ReconciliationMetricReportingService metricReportingService;
 
     @Inject
     public DataReconciliationService(
@@ -40,13 +41,15 @@ public class DataReconciliationService {
             ConfigService configService,
             SourceReferenceService sourceReferenceService,
             CurrentStateCountService currentStateCountService,
-            ChangeDataCountService changeDataCountService
+            ChangeDataCountService changeDataCountService,
+            ReconciliationMetricReportingService metricReportingService
     ) {
         this.jobArguments = jobArguments;
         this.configService = configService;
         this.sourceReferenceService = sourceReferenceService;
         this.currentStateCountService = currentStateCountService;
         this.changeDataCountService = changeDataCountService;
+        this.metricReportingService = metricReportingService;
     }
 
     public DataReconciliationResult reconcileData(SparkSession sparkSession) {
@@ -71,7 +74,9 @@ public class DataReconciliationService {
             }
         }).collect(Collectors.toList());
 
-        return new DataReconciliationResults(results);
+        DataReconciliationResults dataReconciliationResults = new DataReconciliationResults(results);
+        metricReportingService.reportMetrics(dataReconciliationResults);
+        return dataReconciliationResults;
     }
 }
 

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/DisabledReconciliationMetricReportingService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/DisabledReconciliationMetricReportingService.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
+
+@Singleton
+@Requires(missingProperty = "dpr.reconciliation.report.results.to.cloudwatch")
+public class DisabledReconciliationMetricReportingService implements ReconciliationMetricReportingService {
+    @Override
+    public void reportMetrics(DataReconciliationResults dataReconciliationResults) {
+        // No op
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingService.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
+
+public interface ReconciliationMetricReportingService {
+    void reportMetrics(DataReconciliationResults dataReconciliationResults);
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingServiceImpl.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingServiceImpl.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import uk.gov.justice.digital.client.cloudwatch.CloudwatchClient;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
+
+@Singleton
+@Requires(property = "dpr.reconciliation.report.results.to.cloudwatch")
+public class ReconciliationMetricReportingServiceImpl implements ReconciliationMetricReportingService {
+
+    private final JobArguments jobArguments;
+    private final CloudwatchClient cloudwatchClient;
+
+
+    @Inject
+    public ReconciliationMetricReportingServiceImpl(
+            JobArguments jobArguments,
+            CloudwatchClient cloudwatchClient
+    ) {
+        this.jobArguments = jobArguments;
+        this.cloudwatchClient = cloudwatchClient;
+    }
+
+    @Override
+    public void reportMetrics(DataReconciliationResults dataReconciliationResults) {
+        String inputDomain = jobArguments.getConfigKey();
+        cloudwatchClient.putMetrics(jobArguments.getReconciliationCloudwatchMetricsNamespace(), dataReconciliationResults.toCloudwatchMetricData(inputDomain));
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingServiceImpl.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingServiceImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.service.datareconciliation;
 
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -7,9 +9,16 @@ import uk.gov.justice.digital.client.cloudwatch.CloudwatchClient;
 import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.amazonaws.services.cloudwatch.model.StandardUnit.Count;
+
 @Singleton
 @Requires(property = "dpr.reconciliation.report.results.to.cloudwatch")
 public class ReconciliationMetricReportingServiceImpl implements ReconciliationMetricReportingService {
+
+    private static final String FAILED_RECONCILIATION_CHECKS_METRIC_NAME = "FailedReconciliationChecks";
 
     private final JobArguments jobArguments;
     private final CloudwatchClient cloudwatchClient;
@@ -27,6 +36,18 @@ public class ReconciliationMetricReportingServiceImpl implements ReconciliationM
     @Override
     public void reportMetrics(DataReconciliationResults dataReconciliationResults) {
         String inputDomain = jobArguments.getConfigKey();
-        cloudwatchClient.putMetrics(jobArguments.getReconciliationCloudwatchMetricsNamespace(), dataReconciliationResults.toCloudwatchMetricData(inputDomain));
+        Set<MetricDatum> metrics = new HashSet<>();
+        metrics.add(
+                new MetricDatum()
+                        .withMetricName(FAILED_RECONCILIATION_CHECKS_METRIC_NAME)
+                        .withUnit(Count)
+                        .withDimensions(
+                                new Dimension()
+                                        .withName("InputDomain")
+                                        .withValue(inputDomain)
+                        )
+                        .withValue((double) dataReconciliationResults.numReconciliationChecksFailing())
+        );
+        cloudwatchClient.putMetrics(jobArguments.getReconciliationCloudwatchMetricsNamespace(), metrics);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
@@ -68,10 +67,6 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
         });
 
         return sb.toString();
-    }
-
-    private static String sortedListOfTables(Set<String> tables) {
-        return tables.stream().sorted().collect(Collectors.joining(", "));
     }
 
     private boolean rawCountsMatchDmsCounts() {

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,13 +36,8 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
 
         if (!sameTables()) {
             sb.append("\nThe set of tables for DMS vs Raw zone DO NOT MATCH\n\n");
-            String dmsTables = sortedListOfTables(dmsCounts.keySet());
-            String dmsAppliedTables = sortedListOfTables(dmsAppliedCounts.keySet());
-            String rawTables = sortedListOfTables(rawZoneCounts.keySet());
-            sb.append("DMS Tables: ").append(dmsTables).append("\n");
-            sb.append("DMS Applied Tables: ").append(dmsAppliedTables).append("\n");
-            sb.append("Raw Zone/Raw Archive Tables: ").append(rawTables).append("\n");
-            sb.append("\n");
+            sb.append("DMS Tables missing in Raw: ").append(tablesInDmsMissingFromRaw()).append("\n");
+            sb.append("Raw Zone/Raw Archive Tables missing in DMS: ").append(tablesInRawMissingFromDms()).append("\n");
         }
 
         dmsCounts.forEach((tableName, dmsCount) -> {
@@ -98,5 +94,17 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
         } else {
             return MISSING_COUNTS_MESSAGE;
         }
+    }
+
+    private Set<String> tablesInDmsMissingFromRaw() {
+        Set<String> result = new HashSet<>(dmsCounts.keySet());
+        result.removeAll(rawZoneCounts.keySet());
+        return result;
+    }
+
+    private Set<String> tablesInRawMissingFromDms() {
+        HashSet<String> result = new HashSet<>(rawZoneCounts.keySet());
+        result.removeAll(dmsCounts.keySet());
+        return result;
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResults.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResults.java
@@ -1,19 +1,11 @@
 package uk.gov.justice.digital.service.datareconciliation.model;
 
-import com.amazonaws.services.cloudwatch.model.Dimension;
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import lombok.Getter;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
-import static com.amazonaws.services.cloudwatch.model.StandardUnit.Count;
 
 @Getter
 public class DataReconciliationResults implements DataReconciliationResult {
-
-    private static final String FAILED_RECONCILIATION_CHECKS_METRIC_NAME = "FailedReconciliationChecks";
 
     private final List<DataReconciliationResult> results;
 
@@ -33,21 +25,7 @@ public class DataReconciliationResults implements DataReconciliationResult {
                 .reduce("", (s1, s2) -> s1 + "\n\n" + s2);
     }
 
-    public Set<MetricDatum> toCloudwatchMetricData(String inputDomain) {
-        Set<MetricDatum> metrics = new HashSet<>();
-        long numReconciliationChecksFailing = results.stream().filter(r -> !r.isSuccess()).count();
-
-        metrics.add(
-                new MetricDatum()
-                        .withMetricName(FAILED_RECONCILIATION_CHECKS_METRIC_NAME)
-                        .withUnit(Count)
-                        .withDimensions(
-                                new Dimension()
-                                    .withName("InputDomain")
-                                    .withValue(inputDomain)
-                        )
-                        .withValue((double) numReconciliationChecksFailing)
-        );
-        return metrics;
+    public long numReconciliationChecksFailing() {
+        return results.stream().filter(r -> !r.isSuccess()).count();
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResults.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResults.java
@@ -1,11 +1,19 @@
 package uk.gov.justice.digital.service.datareconciliation.model;
 
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import lombok.Getter;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import static com.amazonaws.services.cloudwatch.model.StandardUnit.Count;
 
 @Getter
 public class DataReconciliationResults implements DataReconciliationResult {
+
+    private static final String FAILED_RECONCILIATION_CHECKS_METRIC_NAME = "FailedReconciliationChecks";
 
     private final List<DataReconciliationResult> results;
 
@@ -23,5 +31,23 @@ public class DataReconciliationResults implements DataReconciliationResult {
         return results.stream()
                 .map(DataReconciliationResult::summary)
                 .reduce("", (s1, s2) -> s1 + "\n\n" + s2);
+    }
+
+    public Set<MetricDatum> toCloudwatchMetricData(String inputDomain) {
+        Set<MetricDatum> metrics = new HashSet<>();
+        long numReconciliationChecksFailing = results.stream().filter(r -> !r.isSuccess()).count();
+
+        metrics.add(
+                new MetricDatum()
+                        .withMetricName(FAILED_RECONCILIATION_CHECKS_METRIC_NAME)
+                        .withUnit(Count)
+                        .withDimensions(
+                                new Dimension()
+                                    .withName("InputDomain")
+                                    .withValue(inputDomain)
+                        )
+                        .withValue((double) numReconciliationChecksFailing)
+        );
+        return metrics;
     }
 }

--- a/src/test/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClientTest.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.client.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloudwatchClientTest {
+
+    @Mock
+    private CloudwatchClientProvider cloudwatchClientProvider;
+    @Mock
+    private AmazonCloudWatch client;
+    @Captor
+    private ArgumentCaptor<PutMetricDataRequest> putMetricDataCaptor;
+
+    private CloudwatchClient underTest;
+
+    @BeforeEach
+    void setup() {
+        when(cloudwatchClientProvider.getClient()).thenReturn(client);
+        underTest = new CloudwatchClient(cloudwatchClientProvider);
+    }
+
+    @Test
+    void shouldPutMetrics() {
+        String inputNamespace = "SomeNamespace";
+        Collection<MetricDatum> inputMetricData = new HashSet<>();
+        inputMetricData.add(new MetricDatum().withMetricName("SomeMetric"));
+
+        underTest.putMetrics(inputNamespace, inputMetricData);
+
+        verify(client, times(1)).putMetricData(putMetricDataCaptor.capture());
+
+        PutMetricDataRequest putMetricDataRequest = putMetricDataCaptor.getValue();
+
+        assertEquals(inputNamespace, putMetricDataRequest.getNamespace());
+        assertEquals(inputMetricData, putMetricDataRequest.getMetricData());
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/cloudwatch/CloudwatchClientTest.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -50,6 +51,6 @@ class CloudwatchClientTest {
         PutMetricDataRequest putMetricDataRequest = putMetricDataCaptor.getValue();
 
         assertEquals(inputNamespace, putMetricDataRequest.getNamespace());
-        assertEquals(inputMetricData, putMetricDataRequest.getMetricData());
+        assertIterableEquals(inputMetricData, putMetricDataRequest.getMetricData());
     }
 }

--- a/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
@@ -60,11 +60,12 @@ class DataReconciliationJobTest {
 
     @Test
     @SuppressWarnings("java:S2699")
-    void runJobShouldNotExitWithErrorCodeWhenConfiguredNotToButResultIsFailure() {
+    void runJobShouldNotExitWhenConfiguredNotToButResultIsFailure() {
         when(dataReconciliationService.reconcileData(sparkSession)).thenReturn(results);
         when(results.isSuccess()).thenReturn(false);
         when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(false);
 
+        // If this call completes without a System.exit crashing the test then the test is successful
         underTest.runJob(sparkSession);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.job;
 
 import com.ginsberg.junit.exit.ExpectSystemExitWithStatus;
+import com.ginsberg.junit.exit.FailOnSystemExit;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,17 +56,19 @@ class DataReconciliationJobTest {
         when(results.isSuccess()).thenReturn(false);
         when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(true);
 
+        // If this call completes with a System.exit(1) then the test is successful
         underTest.runJob(sparkSession);
     }
 
     @Test
+    @FailOnSystemExit
     @SuppressWarnings("java:S2699")
     void runJobShouldNotExitWhenConfiguredNotToButResultIsFailure() {
         when(dataReconciliationService.reconcileData(sparkSession)).thenReturn(results);
         when(results.isSuccess()).thenReturn(false);
         when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(false);
 
-        // If this call completes without a System.exit crashing the test then the test is successful
+        // If this call completes without a System.exit then the test is successful
         underTest.runJob(sparkSession);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
@@ -50,7 +50,7 @@ class DataReconciliationJobTest {
     @Test
     @ExpectSystemExitWithStatus(1)
     @SuppressWarnings("java:S2699")
-    void runJobShouldSystemExitWithErrorExitCodeWhenResultIsFailure() {
+    void runJobShouldExitWithErrorCodeWhenConfiguredToAndResultIsFailure() {
         when(dataReconciliationService.reconcileData(sparkSession)).thenReturn(results);
         when(results.isSuccess()).thenReturn(false);
         when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(true);
@@ -60,7 +60,7 @@ class DataReconciliationJobTest {
 
     @Test
     @SuppressWarnings("java:S2699")
-    void runJobShouldNotSystemExitWithErrorExitCodeWhenConfiguredNotTo() {
+    void runJobShouldNotExitWithErrorCodeWhenConfiguredNotToButResultIsFailure() {
         when(dataReconciliationService.reconcileData(sparkSession)).thenReturn(results);
         when(results.isSuccess()).thenReturn(false);
         when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(false);

--- a/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/DataReconciliationJobTest.java
@@ -53,6 +53,17 @@ class DataReconciliationJobTest {
     void runJobShouldSystemExitWithErrorExitCodeWhenResultIsFailure() {
         when(dataReconciliationService.reconcileData(sparkSession)).thenReturn(results);
         when(results.isSuccess()).thenReturn(false);
+        when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(true);
+
+        underTest.runJob(sparkSession);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699")
+    void runJobShouldNotSystemExitWithErrorExitCodeWhenConfiguredNotTo() {
+        when(dataReconciliationService.reconcileData(sparkSession)).thenReturn(results);
+        when(results.isSuccess()).thenReturn(false);
+        when(jobArguments.shouldReconciliationFailJobIfChecksFail()).thenReturn(false);
 
         underTest.runJob(sparkSession);
     }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationServiceTest.java
@@ -55,6 +55,8 @@ class DataReconciliationServiceTest {
     private CurrentStateTotalCounts currentStateResult;
     @Mock
     private ChangeDataTotalCounts changeDataResult;
+    @Mock
+    private ReconciliationMetricReportingService metricReportingService;
 
     @InjectMocks
     private DataReconciliationService underTest;

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationServiceTest.java
@@ -202,4 +202,25 @@ class DataReconciliationServiceTest {
 
         verify(sourceReferenceService, times(1)).getAllSourceReferences(configuredTables);
     }
+
+    @Test
+    void shouldReportMetrics() {
+        when(jobArguments.getReconciliationChecksToRun()).thenReturn(ImmutableSet.of(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
+        when(jobArguments.getDmsTaskId()).thenReturn(DMS_TASK_ID);
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(
+                ImmutablePair.of("schema", "table1"),
+                ImmutablePair.of("schema", "table2")
+        );
+        when(configService.getConfiguredTables(any())).thenReturn(configuredTables);
+        List<SourceReference> allSourceReferences = Arrays.asList(
+                sourceReference1, sourceReference2
+        );
+        when(sourceReferenceService.getAllSourceReferences(configuredTables)).thenReturn(allSourceReferences);
+        when(currentStateCountService.currentStateCounts(sparkSession, allSourceReferences)).thenReturn(currentStateResult);
+        when(changeDataCountService.changeDataCounts(sparkSession, allSourceReferences, DMS_TASK_ID)).thenReturn(changeDataResult);
+
+        DataReconciliationResults results = ((DataReconciliationResults) underTest.reconcileData(sparkSession));
+
+        verify(metricReportingService, times(1)).reportMetrics(results);
+    }
 }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/DisabledReconciliationMetricReportingServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/DisabledReconciliationMetricReportingServiceTest.java
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DisabledReconciliationMetricReportingServiceTest {
+
+    @Mock
+    private DataReconciliationResults dataReconciliationResults;
+
+    @Test
+    void reportMetricsShouldDoNothing() {
+        DisabledReconciliationMetricReportingService underTest = new DisabledReconciliationMetricReportingService();
+        underTest.reportMetrics(dataReconciliationResults);
+
+        verifyNoInteractions(dataReconciliationResults);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationMetricReportingServiceImplTest.java
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.cloudwatch.CloudwatchClient;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.amazonaws.services.cloudwatch.model.StandardUnit.Count;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReconciliationMetricReportingServiceImplTest {
+
+    private static final String DOMAIN = "some domain";
+    private static final String NAMESPACE = "SomeNamespace";
+    @Mock
+    private JobArguments jobArguments;
+    @Mock
+    private CloudwatchClient cloudwatchClient;
+    @Mock
+    private DataReconciliationResults dataReconciliationResults;
+    @Captor
+    private ArgumentCaptor<Collection<MetricDatum>> metricDatumCaptor;
+
+    private ReconciliationMetricReportingServiceImpl underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new ReconciliationMetricReportingServiceImpl(jobArguments, cloudwatchClient);
+    }
+
+    @Test
+    void reportMetricsShouldPutMetrics() {
+
+        when(jobArguments.getConfigKey()).thenReturn(DOMAIN);
+        when(jobArguments.getReconciliationCloudwatchMetricsNamespace()).thenReturn(NAMESPACE);
+        when(dataReconciliationResults.numReconciliationChecksFailing()).thenReturn(2L);
+
+        underTest.reportMetrics(dataReconciliationResults);
+
+        verify(cloudwatchClient, times(1)).putMetrics(eq(NAMESPACE), metricDatumCaptor.capture());
+
+        Collection<MetricDatum> sentMetrics = metricDatumCaptor.getValue();
+
+        assertEquals(1, sentMetrics.size());
+        MetricDatum datum = sentMetrics.iterator().next();
+
+        assertEquals("FailedReconciliationChecks", datum.getMetricName());
+        assertEquals(2L, datum.getValue());
+        assertEquals(Count.toString(), datum.getUnit());
+        List<Dimension> dimensions = datum.getDimensions();
+        assertEquals(1, dimensions.size());
+        Dimension dimension = dimensions.get(0);
+        assertEquals("InputDomain", dimension.getName());
+        assertEquals(DOMAIN, dimension.getValue());
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
@@ -170,10 +170,8 @@ class ChangeDataTotalCountsTest {
                 "\n" +
                 "The set of tables for DMS vs Raw zone DO NOT MATCH\n" +
                 "\n" +
-                "DMS Tables: table1\n" +
-                "DMS Applied Tables: table1\n" +
-                "Raw Zone/Raw Archive Tables: different table\n" +
-                "\n" +
+                "DMS Tables missing in Raw: [table1]\n" +
+                "Raw Zone/Raw Archive Tables missing in DMS: [different table]\n" +
                 "For table table1 DOES NOT MATCH:\n" +
                 "\tMISSING COUNTS\t - Raw\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS\n" +
@@ -200,10 +198,8 @@ class ChangeDataTotalCountsTest {
                 "\n" +
                 "The set of tables for DMS vs Raw zone DO NOT MATCH\n" +
                 "\n" +
-                "DMS Tables: table1\n" +
-                "DMS Applied Tables: different table\n" +
-                "Raw Zone/Raw Archive Tables: table1, table2\n" +
-                "\n" +
+                "DMS Tables missing in Raw: []\n" +
+                "Raw Zone/Raw Archive Tables missing in DMS: [table2]\n" +
                 "For table table1 DOES NOT MATCH:\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - Raw\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS\n" +

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DataReconciliationResultsTest {
 
@@ -89,5 +91,47 @@ class DataReconciliationResultsTest {
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS Applied\n";
         assertEquals(expected, underTest.summary());
+    }
+
+    @Test
+    void shouldCalculateNumReconciliationChecksFailingForMixedSuccessAndFailure() {
+        DataReconciliationResult r1 = mock(DataReconciliationResult.class);
+        DataReconciliationResult r2 = mock(DataReconciliationResult.class);
+        DataReconciliationResult r3 = mock(DataReconciliationResult.class);
+
+        when(r1.isSuccess()).thenReturn(true);
+        when(r2.isSuccess()).thenReturn(true);
+        when(r3.isSuccess()).thenReturn(false);
+
+        DataReconciliationResults results = new DataReconciliationResults(Arrays.asList(r1, r2, r3));
+        assertEquals(1L, results.numReconciliationChecksFailing());
+    }
+
+    @Test
+    void shouldCalculateNumReconciliationChecksFailingForAllSuccess() {
+        DataReconciliationResult r1 = mock(DataReconciliationResult.class);
+        DataReconciliationResult r2 = mock(DataReconciliationResult.class);
+        DataReconciliationResult r3 = mock(DataReconciliationResult.class);
+
+        when(r1.isSuccess()).thenReturn(true);
+        when(r2.isSuccess()).thenReturn(true);
+        when(r3.isSuccess()).thenReturn(true);
+
+        DataReconciliationResults results = new DataReconciliationResults(Arrays.asList(r1, r2, r3));
+        assertEquals(0L, results.numReconciliationChecksFailing());
+    }
+
+    @Test
+    void shouldCalculateNumReconciliationChecksFailingForAllFailure() {
+        DataReconciliationResult r1 = mock(DataReconciliationResult.class);
+        DataReconciliationResult r2 = mock(DataReconciliationResult.class);
+        DataReconciliationResult r3 = mock(DataReconciliationResult.class);
+
+        when(r1.isSuccess()).thenReturn(false);
+        when(r2.isSuccess()).thenReturn(false);
+        when(r3.isSuccess()).thenReturn(false);
+
+        DataReconciliationResults results = new DataReconciliationResults(Arrays.asList(r1, r2, r3));
+        assertEquals(3L, results.numReconciliationChecksFailing());
     }
 }


### PR DESCRIPTION
- Reports reconciliaiton job failures to cloudwatch metrics
- Single dimension of domain (e.g. prisoner, activities) to keep custom metric costs low (only one custom metric per input domain)
- It reports a count of how many reconciliation checks failed