### PR TITLE
DPR2-1500: Make spark streaming trigger interval configurable

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS;
 import static uk.gov.justice.digital.config.JobArguments.RECONCILIATION_CHECKS_TO_RUN_DEFAULT;
 import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
+import static uk.gov.justice.digital.config.JobArguments.DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
 
@@ -73,6 +74,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.ORCHESTRATION_MAX_ATTEMPTS, "10" },
             { JobArguments.MAX_S3_PAGE_SIZE, "100" },
             { JobArguments.CLEAN_CDC_CHECKPOINT, "false" },
+            { JobArguments.CDC_TRIGGER_INTERVAL_SECONDS, "30" },
             { JobArguments.GLUE_TRIGGER_NAME, "dpr-glue-trigger-name" },
             { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, "60" },
             { JobArguments.DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD, "false" },
@@ -135,6 +137,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.ORCHESTRATION_MAX_ATTEMPTS, validArguments.orchestrationMaxAttempts() },
                 { JobArguments.MAX_S3_PAGE_SIZE, validArguments.getMaxObjectsPerPage() },
                 { JobArguments.CLEAN_CDC_CHECKPOINT, validArguments.cleanCdcCheckpoint() },
+                { JobArguments.CDC_TRIGGER_INTERVAL_SECONDS, validArguments.getCdcTriggerIntervalSeconds() },
                 { JobArguments.GLUE_TRIGGER_NAME, validArguments.getGlueTriggerName() },
                 { JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS, validArguments.getBroadcastTimeoutSeconds() },
                 { JobArguments.DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD, validArguments.disableAutoBroadcastJoinThreshold() },
@@ -411,6 +414,14 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.MAX_S3_PAGE_SIZE);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(1000, jobArguments.getMaxObjectsPerPage());
+    }
+
+    @Test
+    public void getCdcTriggerIntervalSecondsShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.CDC_TRIGGER_INTERVAL_SECONDS);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS, jobArguments.getCdcTriggerIntervalSeconds());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -129,6 +129,8 @@ public class JobArguments {
     static final String MAX_S3_PAGE_SIZE = "dpr.s3.max.page.size";
     static final Integer DEFAULT_MAX_S3_PAGE_SIZE = 1000;
     static final String CLEAN_CDC_CHECKPOINT = "dpr.clean.cdc.checkpoint";
+    static final String CDC_TRIGGER_INTERVAL_SECONDS = "dpr.cdc.trigger.interval.seconds";
+    static final long DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS = 60;
     static final String SPARK_BROADCAST_TIMEOUT_SECONDS = "dpr.spark.broadcast.timeout.seconds";
     public static final Integer DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS = 300;
     static final String DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD = "dpr.disable.auto.broadcast.join.threshold";
@@ -487,6 +489,10 @@ public class JobArguments {
 
     public boolean cleanCdcCheckpoint() {
         return getArgument(CLEAN_CDC_CHECKPOINT, false);
+    }
+
+    public long getCdcTriggerIntervalSeconds() {
+        return getArgument(CDC_TRIGGER_INTERVAL_SECONDS, DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS);
     }
 
     public String getGlueTriggerName() {

--- a/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryProvider.java
+++ b/src/main/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryProvider.java
@@ -79,6 +79,7 @@ public class TableStreamingQueryProvider {
                 inputSourceName,
                 inputTableName,
                 arguments.getCheckpointLocation(),
+                arguments.getCdcTriggerIntervalSeconds(),
                 sourceData,
                 batchProcessingFunc
         );
@@ -95,6 +96,7 @@ public class TableStreamingQueryProvider {
                 inputSourceName,
                 inputTableName,
                 arguments.getCheckpointLocation(),
+                arguments.getCdcTriggerIntervalSeconds(),
                 sourceData,
                 batchProcessingFunc
         );

--- a/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryTest.java
@@ -34,6 +34,7 @@ import static uk.gov.justice.digital.test.TestHelpers.convertListToSeq;
 class TableStreamingQueryTest extends BaseSparkTest {
     private static final String source = "some-source";
     private static final String table = "some-table";
+    private static final long TEST_CDC_TRIGGER_INTERVAL_SECONDS = 5;
     private static List<Row> testData;
     private static Seq<Row> testDataSeq;
     @Mock
@@ -62,6 +63,7 @@ class TableStreamingQueryTest extends BaseSparkTest {
                 source,
                 table,
                 checkpointPath,
+                TEST_CDC_TRIGGER_INTERVAL_SECONDS,
                 streamingDataframe,
                 batchProcessingFunc
         );


### PR DESCRIPTION
This PR makes the spark streaming trigger interval configurable with a default of 60 seconds.
This will reduce the frequency of calls to S3 when the batch processing times are very short.