### PR TITLE
DPR2-1133: Primary key reconciliation

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -27,6 +27,7 @@ import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_M
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.PRIMARY_KEY_RECONCILIATION;
 
 class JobArgumentsIntegrationTest {
 
@@ -570,6 +571,14 @@ class JobArgumentsIntegrationTest {
         args.put(JobArguments.RECONCILIATION_CHECKS_TO_RUN, "change_data_counts");
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(ImmutableSet.of(CHANGE_DATA_COUNTS), jobArguments.getReconciliationChecksToRun());
+    }
+
+    @Test
+    public void shouldGetPrimaryKeyReconciliationCheckToRun() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put(JobArguments.RECONCILIATION_CHECKS_TO_RUN, "primary_key_reconciliation");
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(ImmutableSet.of(PRIMARY_KEY_RECONCILIATION), jobArguments.getReconciliationChecksToRun());
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -20,6 +20,8 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.stream.Collectors;
 
 import static uk.gov.justice.digital.client.s3.S3ObjectClient.DELIMITER;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
 
 /**
  * Class that defines and provides access to the job arguments that we support.
@@ -149,7 +151,7 @@ public class JobArguments {
     static final String RECONCILIATION_DATASOURCE_GLUE_CONNECTION_NAME = "dpr.reconciliation.datasource.glue.connection.name";
     static final String RECONCILIATION_DATASOURCE_SHOULD_UPPERCASE_TABLENAMES = "dpr.reconciliation.datasource.should.uppercase.tablenames";
     static final String RECONCILIATION_CHECKS_TO_RUN = "dpr.reconciliation.checks.to.run";
-    static final Set<ReconciliationCheck> RECONCILIATION_CHECKS_TO_RUN_DEFAULT = new HashSet<>(Arrays.asList(ReconciliationCheck.values()));
+    static final Set<ReconciliationCheck> RECONCILIATION_CHECKS_TO_RUN_DEFAULT = new HashSet<>(Arrays.asList(CURRENT_STATE_COUNTS, CHANGE_DATA_COUNTS));
     static final String RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS = "dpr.reconciliation.fail.job.if.checks.fail";
     static final String RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH = "dpr.reconciliation.report.results.to.cloudwatch";
     static final String RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE = "dpr.reconciliation.cloudwatch.metrics.namespace";

--- a/src/main/java/uk/gov/justice/digital/datahub/model/SourceReference.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/SourceReference.java
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.datahub.model;
 
 import lombok.Data;
 import org.apache.spark.sql.Column;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -56,14 +54,6 @@ public class SourceReference {
             return keys.stream()
                     .map(s -> source + "." + s + " = " + target + "." + s)
                     .collect(Collectors.joining(" and "));
-        }
-
-        public Column getJoinExpr(Dataset<Row> left, Dataset<Row> right) {
-            return getKeyColumnNames()
-                    .stream()
-                    .map(colName -> left.col(colName).equalTo(right.col(colName)))
-                    .reduce(Column::and)
-                    .orElseThrow(() -> new IllegalArgumentException("Unable to find join expression for " + left + " and " + right));
         }
 
         public Collection<String> getKeyColumnNames() {

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
@@ -57,9 +57,7 @@ public class DataReconciliationService {
 
     public DataReconciliationResult reconcileData(SparkSession sparkSession) {
         String inputDomain = jobArguments.getConfigKey();
-        String dmsTaskId = jobArguments.getDmsTaskId();
-
-        logger.info("Reconciling with input domain: {}, DMS Task ID: {}", inputDomain, dmsTaskId);
+        logger.info("Reconciling input domain: {}", inputDomain);
 
         ImmutableSet<ImmutablePair<String, String>> configuredTables = configService.getConfiguredTables(inputDomain);
         List<SourceReference> allSourceReferences = sourceReferenceService.getAllSourceReferences(configuredTables);
@@ -69,13 +67,17 @@ public class DataReconciliationService {
             logger.info("Configured to run {}", checkToRun);
             switch (checkToRun) {
                 case CHANGE_DATA_COUNTS:
+                    String dmsTaskId = jobArguments.getDmsTaskId();
+                    logger.info("Getting change data counts with DMS Task ID: {}", dmsTaskId);
                     return changeDataCountService.changeDataCounts(sparkSession, allSourceReferences, dmsTaskId);
                 case CURRENT_STATE_COUNTS:
+                    logger.info("Getting current state counts");
                     return currentStateCountService.currentStateCounts(sparkSession, allSourceReferences);
                 case PRIMARY_KEY_RECONCILIATION:
+                    logger.info("Running primary key reconciliation");
                     return primaryKeyReconciliationService.primaryKeyReconciliation(sparkSession, allSourceReferences);
                 default:
-                    throw new IllegalStateException("Unexpected reconciliation result: " + checkToRun);
+                    throw new IllegalStateException("Unexpected reconciliation check type: " + checkToRun);
             }
         }).collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/DataReconciliationService.java
@@ -11,9 +11,9 @@ import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.SourceReferenceService;
-import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResult;
 import uk.gov.justice.digital.service.datareconciliation.model.DataReconciliationResults;
+import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck;
 
 import java.util.List;
 import java.util.Set;
@@ -34,6 +34,7 @@ public class DataReconciliationService {
     private final CurrentStateCountService currentStateCountService;
     private final ChangeDataCountService changeDataCountService;
     private final ReconciliationMetricReportingService metricReportingService;
+    private final PrimaryKeyReconciliationService primaryKeyReconciliationService;
 
     @Inject
     public DataReconciliationService(
@@ -42,7 +43,8 @@ public class DataReconciliationService {
             SourceReferenceService sourceReferenceService,
             CurrentStateCountService currentStateCountService,
             ChangeDataCountService changeDataCountService,
-            ReconciliationMetricReportingService metricReportingService
+            ReconciliationMetricReportingService metricReportingService,
+            PrimaryKeyReconciliationService primaryKeyReconciliationService
     ) {
         this.jobArguments = jobArguments;
         this.configService = configService;
@@ -50,6 +52,7 @@ public class DataReconciliationService {
         this.currentStateCountService = currentStateCountService;
         this.changeDataCountService = changeDataCountService;
         this.metricReportingService = metricReportingService;
+        this.primaryKeyReconciliationService = primaryKeyReconciliationService;
     }
 
     public DataReconciliationResult reconcileData(SparkSession sparkSession) {
@@ -69,6 +72,8 @@ public class DataReconciliationService {
                     return changeDataCountService.changeDataCounts(sparkSession, allSourceReferences, dmsTaskId);
                 case CURRENT_STATE_COUNTS:
                     return currentStateCountService.currentStateCounts(sparkSession, allSourceReferences);
+                case PRIMARY_KEY_RECONCILIATION:
+                    return primaryKeyReconciliationService.primaryKeyReconciliation(sparkSession, allSourceReferences);
                 default:
                     throw new IllegalStateException("Unexpected reconciliation result: " + checkToRun);
             }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/PrimaryKeyReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/PrimaryKeyReconciliationService.java
@@ -15,8 +15,8 @@ import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.datareconciliation.model.PrimaryKeyReconciliationCount;
 import uk.gov.justice.digital.service.datareconciliation.model.PrimaryKeyReconciliationCounts;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static uk.gov.justice.digital.common.ResourcePath.tablePath;
 
@@ -53,9 +53,9 @@ public class PrimaryKeyReconciliationService {
 
     private PrimaryKeyReconciliationCount primaryKeyReconciliationCountsPerTable(SparkSession sparkSession, SourceReference sourceReference) {
         Dataset<Row> curatedPks = primaryKeysInCurated(sparkSession, sourceReference);
-        logger.debug("Curated schema: {}", curatedPks.schema().treeString());
+        logger.debug("Curated schema: {}", (Supplier<String>) () -> curatedPks.schema().treeString());
         Dataset<Row> dataSourcePks = reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference);
-        logger.debug("Data Source schema: {}", dataSourcePks.schema().treeString());
+        logger.debug("Data Source schema: {}", (Supplier<String>) () -> dataSourcePks.schema().treeString());
 
         // We cannot use Dataset#exceptAll method with the version of Spark Glue 4.0 provides so
         // we use join instead. See https://issues.apache.org/jira/browse/SPARK-39612
@@ -65,12 +65,12 @@ public class PrimaryKeyReconciliationService {
 
         long countInCuratedNotDataSource = inCuratedNotDataSource.count();
         if (countInCuratedNotDataSource > 0) {
-            logger.error("In Curated not Data Source: {}", inCuratedNotDataSource.showString(20, 0, false));
+            logger.error("In Curated not Data Source: {}", (Supplier<String>) () -> inCuratedNotDataSource.showString(20, 0, false));
         }
 
         long countInDataSourceNotCurated = inDataSourceNotCurated.count();
         if (countInDataSourceNotCurated > 0) {
-            logger.error("In Data Source not Curated: {}", inDataSourceNotCurated.showString(20, 0, false));
+            logger.error("In Data Source not Curated: {}", (Supplier<String>) () -> inDataSourceNotCurated.showString(20, 0, false));
         }
 
         return new PrimaryKeyReconciliationCount(countInCuratedNotDataSource, countInDataSourceNotCurated);

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/PrimaryKeyReconciliationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/PrimaryKeyReconciliationService.java
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.Seq;
+import uk.gov.justice.digital.client.s3.S3DataProvider;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.service.datareconciliation.model.PrimaryKeyReconciliationCount;
+import uk.gov.justice.digital.service.datareconciliation.model.PrimaryKeyReconciliationCounts;
+
+import java.util.Collection;
+import java.util.List;
+
+import static uk.gov.justice.digital.common.ResourcePath.tablePath;
+
+@Singleton
+public class PrimaryKeyReconciliationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PrimaryKeyReconciliationService.class);
+
+    private final JobArguments jobArguments;
+    private final S3DataProvider s3DataProvider;
+    private final ReconciliationDataSourceService reconciliationDataSourceService;
+
+    @Inject
+    public PrimaryKeyReconciliationService(
+            JobArguments jobArguments,
+            S3DataProvider s3DataProvider,
+            ReconciliationDataSourceService reconciliationDataSourceService
+    ) {
+        this.jobArguments = jobArguments;
+        this.s3DataProvider = s3DataProvider;
+        this.reconciliationDataSourceService = reconciliationDataSourceService;
+    }
+
+    PrimaryKeyReconciliationCounts primaryKeyReconciliation(SparkSession sparkSession, List<SourceReference> sourceReferences) {
+        logger.info("Diffing Curated zone and Data Source primary keys");
+        PrimaryKeyReconciliationCounts results = new PrimaryKeyReconciliationCounts();
+        sourceReferences.forEach(sourceReference -> {
+            logger.info("Diffing Curated zone and Data Source primary keys for {}", sourceReference.getFullDatahubTableName());
+            PrimaryKeyReconciliationCount tableCount = primaryKeyReconciliationCountsPerTable(sparkSession, sourceReference);
+            results.put(sourceReference.getFullDatahubTableName(), tableCount);
+        });
+        return results;
+    }
+
+    private PrimaryKeyReconciliationCount primaryKeyReconciliationCountsPerTable(SparkSession sparkSession, SourceReference sourceReference) {
+        Dataset<Row> curatedPks = primaryKeysInCurated(sparkSession, sourceReference);
+        logger.debug("Curated schema: {}", curatedPks.schema().treeString());
+        Dataset<Row> dataSourcePks = reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference);
+        logger.debug("Data Source schema: {}", dataSourcePks.schema().treeString());
+
+        // We cannot use Dataset#exceptAll method with the version of Spark Glue 4.0 provides so
+        // we use join instead. See https://issues.apache.org/jira/browse/SPARK-39612
+        Column joinExpr = sourceReference.getPrimaryKey().getJoinExpr(curatedPks, dataSourcePks);
+        Dataset<Row> inCuratedNotDataSource = curatedPks.join(dataSourcePks, joinExpr, "left_anti");
+        Dataset<Row> inDataSourceNotCurated = dataSourcePks.join(curatedPks, joinExpr, "left_anti");
+
+        long countInCuratedNotDataSource = inCuratedNotDataSource.count();
+        if (countInCuratedNotDataSource > 0) {
+            logger.error("In Curated not Data Source: {}", inCuratedNotDataSource.showString(20, 0, false));
+        }
+
+        long countInDataSourceNotCurated = inDataSourceNotCurated.count();
+        if (countInDataSourceNotCurated > 0) {
+            logger.error("In Data Source not Curated: {}", inDataSourceNotCurated.showString(20, 0, false));
+        }
+
+        return new PrimaryKeyReconciliationCount(countInCuratedNotDataSource, countInDataSourceNotCurated);
+    }
+
+
+    private Dataset<Row> primaryKeysInCurated(SparkSession sparkSession, SourceReference sourceReference) {
+        logger.debug("Getting Curated Zone primary keys");
+        String fullCuratedPath = tablePath(jobArguments.getCuratedS3Path(), sourceReference.getSource(), sourceReference.getTable());
+        Dataset<Row> curated = s3DataProvider.getBatchSourceData(sparkSession, fullCuratedPath);
+        Seq<Column> sparkKeyColumns = sourceReference.getPrimaryKey().getSparkKeyColumns();
+        return curated.select(sparkKeyColumns);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCount.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCount.java
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+import lombok.Data;
+
+import static java.lang.String.format;
+
+@Data
+public class PrimaryKeyReconciliationCount {
+
+    private final long countInCuratedNotDataSource;
+    private final long countInDataSourceNotCurated;
+
+    public boolean countsAreZero() {
+        return countInCuratedNotDataSource == 0 && countInDataSourceNotCurated == 0;
+    }
+
+    @Override
+    public String toString() {
+        return format(
+                "In Curated but not Data Source: %d, In Data Source but not Curated: %d",
+                countInCuratedNotDataSource,
+                countInDataSourceNotCurated
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCounts.java
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+import lombok.val;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrimaryKeyReconciliationCounts implements DataReconciliationResult {
+
+    private final Map<String, PrimaryKeyReconciliationCount> counts = new HashMap<>();
+
+    public void put(String fullTableName, PrimaryKeyReconciliationCount tableCount) {
+        counts.put(fullTableName, tableCount);
+    }
+
+    /**
+     * Returns the value to which the specified key is mapped, or
+     *  {@code null} if this map contains no mapping for the key
+     */
+    public PrimaryKeyReconciliationCount get(String fullTableName) {
+        return counts.get(fullTableName);
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return counts.values().stream().allMatch(PrimaryKeyReconciliationCount::countsAreZero);
+    }
+
+    @Override
+    public String summary() {
+        StringBuilder sb = new StringBuilder("Primary Key Reconciliation Counts ");
+        if (isSuccess()) {
+            sb.append("MATCH:\n");
+        } else {
+            sb.append("DO NOT MATCH:\n");
+        }
+
+        for (val entrySet: counts.entrySet()) {
+            val tableName = entrySet.getKey();
+            val counts = entrySet.getValue();
+            sb.append("For table ").append(tableName).append(":\n");
+            sb.append("\t").append(counts.toString()).append("\n");
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCounts.java
@@ -37,9 +37,9 @@ public class PrimaryKeyReconciliationCounts implements DataReconciliationResult 
 
         for (val entrySet: counts.entrySet()) {
             val tableName = entrySet.getKey();
-            val counts = entrySet.getValue();
+            val count = entrySet.getValue();
             sb.append("For table ").append(tableName).append(":\n");
-            sb.append("\t").append(counts.toString()).append("\n");
+            sb.append("\t").append(count.toString()).append("\n");
         }
 
         return sb.toString();

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCounts.java
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.service.datareconciliation.model;
 
+import lombok.EqualsAndHashCode;
 import lombok.val;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@EqualsAndHashCode
 public class PrimaryKeyReconciliationCounts implements DataReconciliationResult {
 
     private final Map<String, PrimaryKeyReconciliationCount> counts = new HashMap<>();
@@ -23,7 +25,11 @@ public class PrimaryKeyReconciliationCounts implements DataReconciliationResult 
 
     @Override
     public boolean isSuccess() {
-        return counts.values().stream().allMatch(PrimaryKeyReconciliationCount::countsAreZero);
+        if (counts.isEmpty()) {
+            return false;
+        } else {
+            return counts.values().stream().allMatch(PrimaryKeyReconciliationCount::countsAreZero);
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheck.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheck.java
@@ -5,7 +5,8 @@ package uk.gov.justice.digital.service.datareconciliation.model;
  */
 public enum ReconciliationCheck {
     CURRENT_STATE_COUNTS,
-    CHANGE_DATA_COUNTS;
+    CHANGE_DATA_COUNTS,
+    PRIMARY_KEY_RECONCILIATION;
 
     public static ReconciliationCheck fromString(String reconciliationType) {
         switch (reconciliationType.trim().toLowerCase()) {
@@ -13,6 +14,8 @@ public enum ReconciliationCheck {
                 return CURRENT_STATE_COUNTS;
             case "change_data_counts":
                 return CHANGE_DATA_COUNTS;
+            case "primary_key_reconciliation":
+                return PRIMARY_KEY_RECONCILIATION;
             default:
                 throw new IllegalArgumentException("Unknown reconciliation type: " + reconciliationType);
         }

--- a/src/test/java/uk/gov/justice/digital/datahub/model/PrimaryKeyTest.java
+++ b/src/test/java/uk/gov/justice/digital/datahub/model/PrimaryKeyTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class PrimaryKeyTest {
+class PrimaryKeyTest {
 
     @Test
     void shouldGetSparkConditionForSingleColumnPK() {

--- a/src/test/java/uk/gov/justice/digital/datahub/model/PrimaryKeyTest.java
+++ b/src/test/java/uk/gov/justice/digital/datahub/model/PrimaryKeyTest.java
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.datahub.model;
+
+import org.apache.spark.sql.Column;
+import org.junit.jupiter.api.Test;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PrimaryKeyTest {
+
+    @Test
+    void shouldGetSparkConditionForSingleColumnPK() {
+        String result = new SourceReference.PrimaryKey("pk_column").getSparkCondition("source", "target");
+        String expected = "source.pk_column = target.pk_column";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldGetSparkConditionForMultiColumnPK() {
+        String result = new SourceReference.PrimaryKey(Arrays.asList("pk_column_1", "pk_column_2")).getSparkCondition("source", "target");
+        String expected = "source.pk_column_1 = target.pk_column_1 and source.pk_column_2 = target.pk_column_2";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldGetKeyColumnNamesForSingleColumnPK() {
+        Collection<String> result = new SourceReference.PrimaryKey("pk_column").getKeyColumnNames();
+        assertThat(result, contains("pk_column"));
+    }
+
+    @Test
+    void shouldGetKeyColumnNamesForMultiColumnPK() {
+        Collection<String> result = new SourceReference.PrimaryKey(Arrays.asList("pk_column_1", "pk_column_2")).getKeyColumnNames();
+        assertThat(result, contains("pk_column_1", "pk_column_2"));
+    }
+
+    @Test
+    void shouldGetSparkKeyColumnsForSingleColumnPK() {
+        Seq<Column> result = new SourceReference.PrimaryKey("pk_column").getSparkKeyColumns();
+        Seq<Column> expected = JavaConverters.asScalaBufferConverter(Collections.singletonList(new Column("pk_column"))).asScala().toSeq();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldGetSparkKeyColumnsForMultiColumnPK() {
+        Seq<Column> result = new SourceReference.PrimaryKey(Arrays.asList("pk_column_1", "pk_column_2")).getSparkKeyColumns();
+        List<Column> javaColumns = Arrays.asList(new Column("pk_column_1"), new Column("pk_column_2"));
+        Seq<Column> expected = JavaConverters.asScalaBufferConverter(javaColumns).asScala().toSeq();
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/PrimaryKeyReconciliationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/PrimaryKeyReconciliationServiceTest.java
@@ -1,0 +1,188 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.s3.S3DataProvider;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.service.datareconciliation.model.PrimaryKeyReconciliationCount;
+import uk.gov.justice.digital.service.datareconciliation.model.PrimaryKeyReconciliationCounts;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
+import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
+import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
+import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.MinimalTestData.inserts;
+
+@ExtendWith(MockitoExtension.class)
+class PrimaryKeyReconciliationServiceTest extends BaseSparkTest {
+    private static final PrimaryKeyReconciliationCount ALL_MATCHING_COUNTS = new PrimaryKeyReconciliationCount(0L, 0L);
+    private static final PrimaryKeyReconciliationCount MORE_IN_CURATED_COUNTS = new PrimaryKeyReconciliationCount(1L, 0L);
+    private static final PrimaryKeyReconciliationCount MORE_IN_DATASOURCE_COUNTS = new PrimaryKeyReconciliationCount(0L, 1L);
+
+    private static Dataset<Row> df3Rows;
+    private static Dataset<Row> df2Rows;
+
+    @Mock
+    private S3DataProvider s3DataProvider;
+    @Mock
+    private ReconciliationDataSourceService reconciliationDataSourceService;
+    @Mock
+    private SourceReference sourceReference1;
+    @Mock
+    private SourceReference sourceReference2;
+    @Mock
+    private SourceReference.PrimaryKey primaryKey1;
+    @Mock
+    private SourceReference.PrimaryKey primaryKey2;
+    @Mock
+    private SparkSession sparkSession;
+
+    @InjectMocks
+    private PrimaryKeyReconciliationService underTest;
+
+    @BeforeAll
+    static void setUp() {
+        df3Rows = spark.createDataFrame(Arrays.asList(
+                createRow(1, "2023-11-13 10:50:00.123456", Insert, "1"),
+                createRow(2, "2023-11-13 10:50:00.123456", Insert, "2"),
+                createRow(3, "2023-11-13 10:50:00.123456", Insert, "3")
+        ), TEST_DATA_SCHEMA);
+
+        df2Rows = spark.createDataFrame(Arrays.asList(
+                createRow(1, "2023-11-13 10:50:00.123456", Insert, "1"),
+                createRow(2, "2023-11-13 10:50:00.123456", Insert, "2")
+        ), TEST_DATA_SCHEMA);
+    }
+
+    @Test
+    void whenAllCountsMatch() {
+        Dataset<Row> df = inserts(spark);
+
+        when(sourceReference1.getFullDatahubTableName()).thenReturn("source.table1");
+        when(sourceReference1.getPrimaryKey()).thenReturn(primaryKey1);
+        when(primaryKey1.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference1)).thenReturn(df);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference1)).thenReturn(df);
+
+
+        PrimaryKeyReconciliationCounts result =
+                underTest.primaryKeyReconciliation(sparkSession, Collections.singletonList(sourceReference1));
+
+        PrimaryKeyReconciliationCounts expected = new PrimaryKeyReconciliationCounts();
+        expected.put("source.table1", ALL_MATCHING_COUNTS);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void whenMoreRowsInCurated() {
+        Dataset<Row> curated = df3Rows;
+        Dataset<Row> dataSource = df2Rows;
+
+        when(sourceReference1.getFullDatahubTableName()).thenReturn("source.table1");
+        when(sourceReference1.getPrimaryKey()).thenReturn(primaryKey1);
+        when(primaryKey1.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference1)).thenReturn(curated);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference1)).thenReturn(dataSource);
+
+
+        PrimaryKeyReconciliationCounts result =
+                underTest.primaryKeyReconciliation(sparkSession, Collections.singletonList(sourceReference1));
+
+        PrimaryKeyReconciliationCounts expected = new PrimaryKeyReconciliationCounts();
+        expected.put("source.table1", MORE_IN_CURATED_COUNTS);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void whenMoreRowsInDataSource() {
+        Dataset<Row> curated = df2Rows;
+        Dataset<Row> dataSource = df3Rows;
+
+        when(sourceReference1.getFullDatahubTableName()).thenReturn("source.table1");
+        when(sourceReference1.getPrimaryKey()).thenReturn(primaryKey1);
+        when(primaryKey1.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference1)).thenReturn(curated);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference1)).thenReturn(dataSource);
+
+
+        PrimaryKeyReconciliationCounts result =
+                underTest.primaryKeyReconciliation(sparkSession, Collections.singletonList(sourceReference1));
+
+        PrimaryKeyReconciliationCounts expected = new PrimaryKeyReconciliationCounts();
+        expected.put("source.table1", MORE_IN_DATASOURCE_COUNTS);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void whenProcessingMultipleTables() {
+        Dataset<Row> curated1 = df3Rows;
+        Dataset<Row> dataSource1 = df2Rows;
+
+        Dataset<Row> curated2 = df2Rows;
+        Dataset<Row> dataSource2 = df3Rows;
+
+        when(sourceReference1.getFullDatahubTableName()).thenReturn("source.table1");
+        when(sourceReference1.getPrimaryKey()).thenReturn(primaryKey1);
+        when(primaryKey1.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference1)).thenReturn(curated1);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference1)).thenReturn(dataSource1);
+
+        when(sourceReference2.getFullDatahubTableName()).thenReturn("source.table2");
+        when(sourceReference2.getPrimaryKey()).thenReturn(primaryKey2);
+        when(primaryKey2.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference2)).thenReturn(curated2);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference2)).thenReturn(dataSource2);
+
+
+        PrimaryKeyReconciliationCounts result =
+                underTest.primaryKeyReconciliation(sparkSession, Arrays.asList(sourceReference1, sourceReference2));
+
+        PrimaryKeyReconciliationCounts expected = new PrimaryKeyReconciliationCounts();
+        expected.put("source.table1", MORE_IN_CURATED_COUNTS);
+        expected.put("source.table2", MORE_IN_DATASOURCE_COUNTS);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldDelegateGettingPrimaryKeys() {
+        Dataset<Row> curated1 = df3Rows;
+        Dataset<Row> dataSource1 = df2Rows;
+
+        Dataset<Row> curated2 = df2Rows;
+        Dataset<Row> dataSource2 = df3Rows;
+
+        when(sourceReference1.getFullDatahubTableName()).thenReturn("source.table1");
+        when(sourceReference1.getPrimaryKey()).thenReturn(primaryKey1);
+        when(primaryKey1.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference1)).thenReturn(curated1);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference1)).thenReturn(dataSource1);
+
+        when(sourceReference2.getFullDatahubTableName()).thenReturn("source.table2");
+        when(sourceReference2.getPrimaryKey()).thenReturn(primaryKey2);
+        when(primaryKey2.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
+        when(s3DataProvider.getPrimaryKeysInCurated(sparkSession, sourceReference2)).thenReturn(curated2);
+        when(reconciliationDataSourceService.primaryKeysAsDataframe(sparkSession, sourceReference2)).thenReturn(dataSource2);
+
+        underTest.primaryKeyReconciliation(sparkSession, Arrays.asList(sourceReference1, sourceReference2));
+
+        verify(s3DataProvider, times(1)).getPrimaryKeysInCurated(sparkSession, sourceReference1);
+        verify(s3DataProvider, times(1)).getPrimaryKeysInCurated(sparkSession, sourceReference2);
+        verify(reconciliationDataSourceService, times(1)).primaryKeysAsDataframe(sparkSession, sourceReference1);
+        verify(reconciliationDataSourceService, times(1)).primaryKeysAsDataframe(sparkSession, sourceReference2);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCountTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCountTest.java
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PrimaryKeyReconciliationCountTest {
+
+    @Test
+    void shouldConvertToString() {
+        String expected = "In Curated but not Data Source: 2, In Data Source but not Curated: 5";
+        assertEquals(expected, new PrimaryKeyReconciliationCount(2L, 5L).toString());
+    }
+
+    @Test
+    void countsAreZeroShouldBeTrueForAllZeroCounts() {
+        assertTrue(new PrimaryKeyReconciliationCount(0L, 0L).countsAreZero());
+    }
+
+    @Test
+    void countsAreZeroShouldBeFalseForAllNonZeroCounts() {
+        assertFalse(new PrimaryKeyReconciliationCount(2L, 5L).countsAreZero());
+    }
+
+    @Test
+    void countsAreZeroShouldBeFalseForNonZeroCountInCurated() {
+        assertFalse(new PrimaryKeyReconciliationCount(2L, 0L).countsAreZero());
+    }
+
+    @Test
+    void countsAreZeroShouldBeFalseForNonZeroCountInDataSource() {
+        assertFalse(new PrimaryKeyReconciliationCount(0L, 5L).countsAreZero());
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/PrimaryKeyReconciliationCountsTest.java
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PrimaryKeyReconciliationCountsTest {
+
+    @Test
+    void isSuccessWhenAllHaveZeroCounts() {
+        PrimaryKeyReconciliationCounts underTest = new PrimaryKeyReconciliationCounts();
+        underTest.put("source.table1", new PrimaryKeyReconciliationCount(0L, 0L));
+        underTest.put("source.table2", new PrimaryKeyReconciliationCount(0L, 0L));
+        underTest.put("source.table3", new PrimaryKeyReconciliationCount(0L, 0L));
+        assertTrue(underTest.isSuccess());
+    }
+
+    @Test
+    void isNotSuccessForEmptyCounts() {
+        PrimaryKeyReconciliationCounts underTest = new PrimaryKeyReconciliationCounts();
+        assertFalse(underTest.isSuccess());
+    }
+
+    @Test
+    void isNotSuccessWhenAtLeastOneHasNonZeroCounts() {
+        PrimaryKeyReconciliationCounts underTest = new PrimaryKeyReconciliationCounts();
+        underTest.put("source.table1", new PrimaryKeyReconciliationCount(0L, 1L));
+        underTest.put("source.table2", new PrimaryKeyReconciliationCount(0L, 0L));
+        underTest.put("source.table3", new PrimaryKeyReconciliationCount(0L, 0L));
+        assertFalse(underTest.isSuccess());
+    }
+
+    @Test
+    void summaryShouldCreateStringWhenNotMatch() {
+        PrimaryKeyReconciliationCounts underTest = new PrimaryKeyReconciliationCounts();
+        underTest.put("source.table1", new PrimaryKeyReconciliationCount(0L, 1L));
+        underTest.put("source.table2", new PrimaryKeyReconciliationCount(0L, 0L));
+        underTest.put("source.table3", new PrimaryKeyReconciliationCount(0L, 0L));
+
+        String result = underTest.summary();
+        String expected = "Primary Key Reconciliation Counts DO NOT MATCH:\n" +
+                "For table source.table1:\n" +
+                "\tIn Curated but not Data Source: 0, In Data Source but not Curated: 1\n" +
+                "For table source.table2:\n" +
+                "\tIn Curated but not Data Source: 0, In Data Source but not Curated: 0\n" +
+                "For table source.table3:\n" +
+                "\tIn Curated but not Data Source: 0, In Data Source but not Curated: 0\n";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void summaryShouldCreateStringWhenAllMatch() {
+        PrimaryKeyReconciliationCounts underTest = new PrimaryKeyReconciliationCounts();
+        underTest.put("source.table1", new PrimaryKeyReconciliationCount(0L, 0L));
+        underTest.put("source.table2", new PrimaryKeyReconciliationCount(0L, 0L));
+        underTest.put("source.table3", new PrimaryKeyReconciliationCount(0L, 0L));
+
+        String result = underTest.summary();
+        String expected = "Primary Key Reconciliation Counts MATCH:\n" +
+                "For table source.table1:\n" +
+                "\tIn Curated but not Data Source: 0, In Data Source but not Curated: 0\n" +
+                "For table source.table2:\n" +
+                "\tIn Curated but not Data Source: 0, In Data Source but not Curated: 0\n" +
+                "For table source.table3:\n" +
+                "\tIn Curated but not Data Source: 0, In Data Source but not Curated: 0\n";
+
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheckTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ReconciliationCheckTest.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.service.datareconciliation.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
+import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.PRIMARY_KEY_RECONCILIATION;
+
+class ReconciliationCheckTest {
+
+    @Test
+    void shouldMapCurrentStateCounts() {
+        assertEquals(CURRENT_STATE_COUNTS, ReconciliationCheck.fromString("current_state_counts"));
+    }
+
+    @Test
+    void shouldMapChangeDataCounts() {
+        assertEquals(CHANGE_DATA_COUNTS, ReconciliationCheck.fromString("change_data_counts"));
+    }
+
+    @Test
+    void shouldMapPrimaryKeyReconciliation() {
+        assertEquals(PRIMARY_KEY_RECONCILIATION, ReconciliationCheck.fromString("primary_key_reconciliation"));
+    }
+
+    @Test
+    void shouldThrowForUnrecognisedReconciliationCheck() {
+        assertThrows(IllegalArgumentException.class, () -> ReconciliationCheck.fromString("unknown"));
+    }
+}


### PR DESCRIPTION
- Adds an optional reconciliation check to diff primary keys between data source and curated zones
- The use case is when you know other reconciliations have shown there is a mismatch in row counts and you want to pinpoint the rows that are different
- This is not included in the default reconciliations as it requires more resources