### PR TITLE
DPR2-1559: Ignore temp CDC checkpoint files

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClient.java
@@ -59,6 +59,7 @@ public class S3CheckpointReaderClient {
     @NotNull
     private List<CheckpointFile> orderCheckpointFilesInReverseOrdering(List<String> checkpointFiles) {
         return checkpointFiles.stream()
+                .filter(checkpointFile -> !checkpointFile.toLowerCase().endsWith(".tmp"))
                 .map(checkpointFile -> {
                     Matcher matcher = checkpointFileRegexPattern.matcher(checkpointFile);
                     if (matcher.matches()) {

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClientTest.java
@@ -72,6 +72,24 @@ class S3CheckpointReaderClientTest {
     }
 
     @Test
+    void shouldIgnoreTempFilesFromCheckpointFilesList() {
+        List<String> checkpointFiles = new ArrayList<>();
+        checkpointFiles.add("checkpoint-path/2");
+        checkpointFiles.add("checkpoint-path/0.tmp");
+
+        when(mockS3Client.getObjectAsString(CHECKPOINT_BUCKET, "checkpoint-path/2")).thenReturn(CHECKPOINT_FILE_2);
+
+        Set<String> committedFiles = underTest.getCommittedFiles(CHECKPOINT_BUCKET, checkpointFiles);
+
+        Set<String> expectedCommittedFiles = new HashSet<>();
+        expectedCommittedFiles.add("source/table2/committed-file-1.parquet");
+        expectedCommittedFiles.add("source/table2/committed-file-2.parquet");
+        expectedCommittedFiles.add("source/table2/committed-file-3.parquet");
+
+        assertThat(committedFiles, containsInAnyOrder(expectedCommittedFiles.toArray()));
+    }
+
+    @Test
     void shouldIgnoreCheckpointFilesWithNameHavingLowerNaturalOrderThanTheMostRecentCompactFile() {
         List<String> checkpointFiles = new ArrayList<>();
         checkpointFiles.add("checkpoint-path/0"); // this file has name with lower natural order than the compact file and will be ignored


### PR DESCRIPTION
When a Spark structured streaming is creating a checkpoint file, it first creates it as a .tmp file. This would cause the archive job to fail when unable to retrieve the file name from the .tmp file.

For example the temp file may have a name format of:
`checkpoint/dpr-reporting-hub-cdc-incidents-production/DataHubCdcJob/Datahub_CDC_nomis.incident_case_parties/sources/0/.1381.b52939f2-d6a7-4210-872f-3c33fe8b0225.tmp`

Instead of:
`checkpoint/dpr-reporting-hub-cdc-incidents-production/DataHubCdcJob/Datahub_CDC_nomis.incident_case_parties/sources/0/.1381`

To resolve this issue, this PR ignores checkpoint files with name ending in .tmp. This  means any CDC files committed in the temp file will not be archived until the next scheduled run.