### PR TITLE
DPR2-1643: Allow Glue jobs accept a regex instead of a list of file extensions

### DIFF
--- a/src/main/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClient.java
@@ -15,8 +15,10 @@ import java.util.Optional;
 import java.util.Collections;
 import java.util.Arrays;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static uk.gov.justice.digital.common.RegexPatterns.committedFileRegexPattern;
+import static uk.gov.justice.digital.common.RegexPatterns.checkpointFileRegexPattern;
 
 @Singleton
 public class S3CheckpointReaderClient {
@@ -24,12 +26,6 @@ public class S3CheckpointReaderClient {
     private static final Logger logger = LoggerFactory.getLogger(S3CheckpointReaderClient.class);
 
     private final AmazonS3 s3;
-
-    // Extracts the ordinal and optional compact extension from the checkpoint file name. Example checkpoint file names: 1 or 1.compact
-    private final Pattern checkpointFileRegexPattern = Pattern.compile("^.*\\/(\\d+)(.compact)?$");
-
-    // Extracts the committed file path from a line in the checkpoint file
-    private final Pattern committedFileRegexPattern = Pattern.compile("^\\{\"path\":\"s3:\\/\\/([a-zA-Z-]+)\\/(.*)\",.*");
 
     @Inject
     public S3CheckpointReaderClient(S3ClientProvider clientProvider) {

--- a/src/main/java/uk/gov/justice/digital/common/RegexPatterns.java
+++ b/src/main/java/uk/gov/justice/digital/common/RegexPatterns.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.common;
+
+import java.util.regex.Pattern;
+
+import static uk.gov.justice.digital.config.JobArguments.DEFAULT_FILE_NAME_REGEX;
+
+public class RegexPatterns {
+    public static final Pattern matchAllFiles = Pattern.compile(DEFAULT_FILE_NAME_REGEX);
+
+    public static final Pattern parquetFileRegex = Pattern.compile("(?i).+.parquet$");
+
+    public static final Pattern jsonOrParquetFileRegex = Pattern.compile("(?i).+.json$|.+.parquet$");
+
+    // Extracts the ordinal and optional compact extension from the checkpoint file name. Example checkpoint file names: 1 or 1.compact
+    public static final Pattern checkpointFileRegexPattern = Pattern.compile("^.*\\/(\\d+)(.compact)?$");
+
+    // Extracts the committed file path from a line in the checkpoint file
+    public static final Pattern committedFileRegexPattern = Pattern.compile("^\\{\"path\":\"s3:\\/\\/([a-zA-Z-]+)\\/(.*)\",.*");
+
+    // Extracts the bucket and the folder path from the checkpoint location
+    // As an example s3://dpr-glue-jobs-development/checkpoint/dpr-reporting-hub-cdc-establishments-development/
+    // is extracted to:
+    // bucket - dpr-glue-jobs-development
+    // folder path - checkpoint/dpr-reporting-hub-cdc-establishments-development/
+    public static final Pattern checkpointRegexPattern = Pattern.compile("^s3[A-Za-z]?:\\/\\/([A-Za-z-]+)\\/([\\S\\s]+\\S+)");
+
+    public static final String TABLE_NAME_PATTERN = "^[a-z_0-9]*$";
+
+    public static final Pattern tableNameRegex = Pattern.compile(TABLE_NAME_PATTERN);
+
+    // Private constructor to prevent instantiation.
+    private RegexPatterns() { }
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -15,8 +15,14 @@ import uk.gov.justice.digital.service.datareconciliation.model.ReconciliationChe
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static uk.gov.justice.digital.client.s3.S3ObjectClient.DELIMITER;
@@ -121,7 +127,8 @@ public class JobArguments {
     // A comma separated list of buckets to delete files from
     static final String FILE_DELETION_BUCKETS = "dpr.file.deletion.buckets";
     // A comma separated list of s3 file extensions. The wildcard '*' includes all extensions.
-    static final String ALLOWED_S3_FILE_EXTENSIONS = "dpr.allowed.s3.file.extensions";
+    static final String ALLOWED_S3_FILE_NAME_REGEX = "dpr.allowed.s3.file.regex";
+    public static final String DEFAULT_FILE_NAME_REGEX = ".+";
     static final String ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.orchestration.wait.interval.seconds";
     static final int DEFAULT_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 10;
     static final String ORCHESTRATION_MAX_ATTEMPTS = "dpr.orchestration.max.attempts";
@@ -421,19 +428,8 @@ public class JobArguments {
         return ImmutableSet.copyOf(buckets);
     }
 
-    public ImmutableSet<String> getAllowedS3FileExtensions() {
-        Set<String> extensions = Arrays.stream(getArgument(ALLOWED_S3_FILE_EXTENSIONS).toLowerCase().split(","))
-                .map(item -> item.trim().toLowerCase())
-                .filter(item -> !item.isEmpty())
-                .collect(Collectors.toSet());
-
-        if (extensions.isEmpty()) throw new IllegalStateException("Argument " + ALLOWED_S3_FILE_EXTENSIONS + " evaluated to empty set");
-
-        if (extensions.contains("*")) {
-            return ImmutableSet.of("*");
-        } else {
-            return ImmutableSet.copyOf(extensions);
-        }
+    public Pattern getAllowedS3FileNameRegex() {
+        return Pattern.compile(getArgument(ALLOWED_S3_FILE_NAME_REGEX, DEFAULT_FILE_NAME_REGEX));
     }
 
     public String getStopGlueInstanceJobName() {

--- a/src/main/java/uk/gov/justice/digital/job/RawFileArchiveJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/RawFileArchiveJob.java
@@ -18,6 +18,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
+
 /**
  * Job that archives raw s3 files to a destination bucket.
  */
@@ -67,7 +69,7 @@ public class RawFileArchiveJob implements Runnable {
 
         List<String> committedFiles = getCommittedFilesForConfig(configuredTables);
         Set<String> rawFiles = new HashSet<>(s3FileService
-                .listFilesForConfig(rawBucket, "", configuredTables, ImmutableSet.of(".parquet"), Duration.ZERO));
+                .listFilesForConfig(rawBucket, "", configuredTables, parquetFileRegex, Duration.ZERO));
 
         List<String> filesToArchive = getCommittedFilesNotAlreadyArchived(committedFiles, rawFiles);
 

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Job that deletes s3 files from a list of bucket(s).
@@ -61,13 +62,13 @@ public class S3DataDeletionJob implements Runnable {
 
         final ImmutableSet<String> bucketsToDeleteFilesFrom = jobArguments.getBucketsToDeleteFilesFrom();
         final String sourcePrefix = jobArguments.getSourcePrefix();
-        final ImmutableSet<String> allowedExtensions = jobArguments.getAllowedS3FileExtensions();
+        final Pattern allowedFileNameRegex = jobArguments.getAllowedS3FileNameRegex();
 
         Set<String> failedObjects = new HashSet<>();
 
         for (String bucketToDeleteFilesFrom : bucketsToDeleteFilesFrom) {
             List<String> listedFiles = s3FileService
-                    .listFilesForConfig(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedExtensions, Duration.ZERO);
+                    .listFilesForConfig(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedFileNameRegex, Duration.ZERO);
 
             logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
             failedObjects = s3FileService.deleteObjects(listedFiles, bucketToDeleteFilesFrom);

--- a/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Job that checks if all raw files have been processed.
@@ -86,6 +87,7 @@ public class UnprocessedRawFilesCheckJob implements Runnable {
 
     private boolean verifyRawFilesProcessed() {
         String rawBucket = jobArguments.getTransferSourceBucket();
+        Pattern fileNameRegex = jobArguments.getAllowedS3FileNameRegex();
         ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                 .getConfiguredTables(jobArguments.getConfigKey());
 
@@ -99,7 +101,7 @@ public class UnprocessedRawFilesCheckJob implements Runnable {
 
         logger.info("Listing files in raw bucket");
         List<String> rawFiles = s3FileService
-                .listFilesForConfig(rawBucket, "", configuredTables, ImmutableSet.of(".parquet"), Duration.ZERO);
+                .listFilesForConfig(rawBucket, "", configuredTables, fileNameRegex, Duration.ZERO);
 
         return committedFiles.containsAll(rawFiles);
     }

--- a/src/main/java/uk/gov/justice/digital/service/CheckpointReaderService.java
+++ b/src/main/java/uk/gov/justice/digital/service/CheckpointReaderService.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.service;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,8 +14,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import static uk.gov.justice.digital.common.RegexPatterns.checkpointRegexPattern;
+import static uk.gov.justice.digital.common.RegexPatterns.matchAllFiles;
 import static uk.gov.justice.digital.common.StreamingQuery.getQueryCheckpointPath;
 
 @Singleton
@@ -28,12 +28,6 @@ public class CheckpointReaderService {
     private final S3CheckpointReaderClient checkpointReaderClient;
     private final JobArguments jobArguments;
     private final Clock clock;
-    // Extracts the bucket and the folder path from the checkpoint location
-    // As an example s3://dpr-glue-jobs-development/checkpoint/dpr-reporting-hub-cdc-establishments-development/
-    // is extracted to:
-    // bucket - dpr-glue-jobs-development
-    // folder path - checkpoint/dpr-reporting-hub-cdc-establishments-development/
-    private final Pattern checkpointRegexPattern = Pattern.compile("^s3[A-Za-z]?:\\/\\/([A-Za-z-]+)\\/([\\S\\s]+\\S+)");
 
     @Inject
     public CheckpointReaderService(
@@ -60,7 +54,7 @@ public class CheckpointReaderService {
             List<String> checkpointFiles = s3ObjectClient.getObjectsOlderThan(
                     checkpointBucket,
                     checkpointPath,
-                    ImmutableSet.of("*"),
+                    matchAllFiles,
                     Duration.ZERO,
                     clock
             );

--- a/src/main/java/uk/gov/justice/digital/service/HiveTableService.java
+++ b/src/main/java/uk/gov/justice/digital/service/HiveTableService.java
@@ -17,19 +17,17 @@ import javax.inject.Singleton;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static uk.gov.justice.digital.common.CommonDataFields.withMetadataFields;
 import static uk.gov.justice.digital.common.CommonDataFields.withCheckpointField;
+import static uk.gov.justice.digital.common.RegexPatterns.TABLE_NAME_PATTERN;
+import static uk.gov.justice.digital.common.RegexPatterns.tableNameRegex;
 import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
 
 @Singleton
 public class HiveTableService {
 
     private static final Logger logger = LoggerFactory.getLogger(HiveTableService.class);
-
-    private static final String TABLE_NAME_PATTERN = "^[a-z_0-9]*$";
-    private static final Pattern tableNameRegex = Pattern.compile(TABLE_NAME_PATTERN);
 
     private final JobArguments jobArguments;
     private final SourceReferenceService sourceReferenceService;

--- a/src/test/java/uk/gov/justice/digital/job/RawFileArchiveJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/RawFileArchiveJobTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Collections;
 
+import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -90,7 +91,7 @@ class RawFileArchiveJobTest extends BaseSparkTest {
         when(mockConfigService.getConfiguredTables(CONFIG_KEY)).thenReturn(configuredTables);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable1)).thenReturn(committedFilesTable1);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable2)).thenReturn(committedFilesTable2);
-        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, ImmutableSet.of(".parquet"), Duration.ZERO))
+        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
                 .thenReturn(rawFiles);
         when(mockS3Service.copyObjects(filesToArchiveCaptor.capture(), eq(SOURCE_BUCKET), eq(""), eq(DESTINATION_BUCKET), eq(""), eq(true)))
                 .thenReturn(Collections.emptySet());
@@ -120,7 +121,7 @@ class RawFileArchiveJobTest extends BaseSparkTest {
 
         when(mockConfigService.getConfiguredTables(CONFIG_KEY)).thenReturn(configuredTables);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable)).thenReturn(committedFilesTable);
-        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, ImmutableSet.of(".parquet"), Duration.ZERO))
+        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
                 .thenReturn(Collections.emptyList());
         when(mockS3Service.copyObjects(filesToArchiveCaptor.capture(), eq(SOURCE_BUCKET), eq(""), eq(DESTINATION_BUCKET), eq(""), eq(true)))
                 .thenReturn(Collections.emptySet());

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -17,12 +17,20 @@ import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
+import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class S3DataDeletionJobTest extends BaseSparkTest {
@@ -43,8 +51,6 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
 
     private final static ImmutableSet<String> bucketsToDeleteFrom = ImmutableSet
             .of("bucket-to-delete-from-1", "bucket-to-delete-from-2");
-
-    private static final ImmutableSet<String> parquetFileExtension = ImmutableSet.of(".parquet");
 
     private S3DataDeletionJob underTest;
 
@@ -74,14 +80,14 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
         when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
         when(mockJobArguments.getSourcePrefix()).thenReturn(SOURCE_PREFIX);
-        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
         when(mockS3FileService.listFilesForConfig(
                 listObjectsBucketCaptor.capture(),
                 eq(SOURCE_PREFIX),
                 eq(configuredTables),
-                eq(parquetFileExtension),
+                eq(parquetFileRegex),
                 eq(Duration.ZERO)
         )).thenReturn(objectsToDelete);
 
@@ -120,13 +126,13 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
         when(mockJobArguments.getBucketsToDeleteFilesFrom()).thenReturn(bucketsToDeleteFrom);
         when(mockJobArguments.getSourcePrefix()).thenReturn(SOURCE_PREFIX);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
-        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
         when(mockS3FileService.listFilesForConfig(
                 listObjectsBucketCaptor.capture(),
                 eq(SOURCE_PREFIX),
                 eq(configuredTables),
-                eq(parquetFileExtension),
+                eq(parquetFileRegex),
                 eq(Duration.ZERO)
         )).thenReturn(objectsToDelete);
 

--- a/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
@@ -16,10 +16,18 @@ import uk.gov.justice.digital.service.S3FileService;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
+import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class S3FileTransferJobTest extends BaseSparkTest {
@@ -39,8 +47,6 @@ public class S3FileTransferJobTest extends BaseSparkTest {
 
     private static final long RETENTION_AMOUNT = 2L;
     private static final Duration retentionPeriod = Duration.of(RETENTION_AMOUNT, ChronoUnit.DAYS);
-
-    private static final ImmutableSet<String> parquetFileExtension = ImmutableSet.of(".parquet");
 
     private S3FileTransferJob underTest;
 
@@ -74,11 +80,11 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getTransferDestinationPrefix()).thenReturn(DESTINATION_PREFIX);
         when(mockJobArguments.getFileTransferRetentionPeriod()).thenReturn(retentionPeriod);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
-        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileExtension, retentionPeriod))
+        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
@@ -101,9 +107,9 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getTransferDestinationPrefix()).thenReturn(DESTINATION_PREFIX);
         when(mockJobArguments.getFileTransferRetentionPeriod()).thenReturn(retentionPeriod);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
-        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
-        when(mockS3FileService.listFiles(SOURCE_BUCKET, SOURCE_PREFIX, parquetFileExtension, retentionPeriod))
+        when(mockS3FileService.listFiles(SOURCE_BUCKET, SOURCE_PREFIX, parquetFileRegex, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
@@ -134,11 +140,11 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getTransferDestinationPrefix()).thenReturn(DESTINATION_PREFIX);
         when(mockJobArguments.getFileTransferRetentionPeriod()).thenReturn(retentionPeriod);
         when(mockJobArguments.getFileTransferDeleteCopiedFilesFlag()).thenReturn(true);
-        when(mockJobArguments.getAllowedS3FileExtensions()).thenReturn(parquetFileExtension);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileExtension, retentionPeriod))
+        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))

--- a/src/test/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJobTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 
 @ExtendWith(MockitoExtension.class)
 class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
@@ -78,11 +79,12 @@ class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
         when(mockJobArguments.orchestrationWaitIntervalSeconds()).thenReturn(1);
         when(mockJobArguments.getTransferSourceBucket()).thenReturn(SOURCE_BUCKET);
         when(mockJobArguments.getConfigKey()).thenReturn(CONFIG_KEY);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
         when(mockConfigService.getConfiguredTables(CONFIG_KEY)).thenReturn(configuredTables);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable1)).thenReturn(committedFilesTable1);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable2)).thenReturn(committedFilesTable2);
-        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, ImmutableSet.of(".parquet"), Duration.ZERO))
+        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
                 .thenReturn(rawFiles);
 
         assertDoesNotThrow(() -> underTest.run());
@@ -113,11 +115,12 @@ class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
         when(mockJobArguments.orchestrationWaitIntervalSeconds()).thenReturn(1);
         when(mockJobArguments.getTransferSourceBucket()).thenReturn(SOURCE_BUCKET);
         when(mockJobArguments.getConfigKey()).thenReturn(CONFIG_KEY);
+        when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
         when(mockConfigService.getConfiguredTables(CONFIG_KEY)).thenReturn(configuredTables);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable1)).thenReturn(committedFilesTable1);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable2)).thenReturn(committedFilesTable2);
-        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, ImmutableSet.of(".parquet"), Duration.ZERO))
+        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
                 .thenReturn(rawFiles);
 
         assertEquals(1, SystemLambda.catchSystemExit(() -> underTest.run()));

--- a/src/test/java/uk/gov/justice/digital/service/CheckpointReaderServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/CheckpointReaderServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.service;
 
 import com.amazonaws.AmazonClientException;
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +30,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.gov.justice.digital.common.RegexPatterns.matchAllFiles;
 import static uk.gov.justice.digital.test.Fixtures.fixedClock;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,7 +84,7 @@ class CheckpointReaderServiceTest {
         expectedCommittedFiles.add("committed-file-2");
 
         when(mockJobArguments.getCheckpointLocation()).thenReturn(CHECKPOINT_LOCATION);
-        when(mockS3Client.getObjectsOlderThan(CHECKPOINT_BUCKET, checkpointFolder, ImmutableSet.of("*"), Duration.ZERO, fixedClock)).thenReturn(checkpointFiles);
+        when(mockS3Client.getObjectsOlderThan(CHECKPOINT_BUCKET, checkpointFolder, matchAllFiles, Duration.ZERO, fixedClock)).thenReturn(checkpointFiles);
         when(mockCheckpointReaderClient.getCommittedFiles(CHECKPOINT_BUCKET, checkpointFiles)).thenReturn(expectedCommittedFiles);
 
         Set<String> committedFiles = underTest.getCommittedFilesForTable(configuredTable);

--- a/src/test/java/uk/gov/justice/digital/test/Fixtures.java
+++ b/src/test/java/uk/gov/justice/digital/test/Fixtures.java
@@ -32,7 +32,6 @@ public class Fixtures {
 
     public static Clock fixedClock = Clock.fixed(fixedDateTime.toInstant(ZoneOffset.UTC), utcZoneId);
 
-
     // Private constructor to prevent instantiation.
     private Fixtures() { }
 }


### PR DESCRIPTION
This PR:
- Modifies the argument `dpr.allowed.s3.file.extensions` to `dpr.allowed.s3.file.regex`
- The `dpr.allowed.s3.file.extensions` argument defaults to `.+` which matches all files
- When only CDC files are to be matched the value can be set to `\\d+-\\d+.parquet`