### PR TITLE
DPR2-1633: Fix DMS Postgres Deletes going to violations.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -28,6 +28,9 @@ import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.
 public class ValidationService {
 
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
+
+    private static final String MISSING_OPERATION_COLUMN_MESSAGE = "Missing " + OPERATION + " column";
+
     private final ViolationService violationService;
 
     // This contains a mapping of regex strings used for validating string fields annotated with the validationType metadata
@@ -60,6 +63,7 @@ public class ValidationService {
                     // The order of the 'when' clauses determines the validation error message used - first wins.
                     // Null means there is no validation error.
                     when(pkIsNull(sourceReference), concatenateErrors("Record does not have a primary key"))
+                            .when(col(OPERATION).isNull(), concatenateErrors(MISSING_OPERATION_COLUMN_MESSAGE))
                             .when(col(OPERATION).notEqual(lit(Delete.getName())).and(requiredColumnIsNull(schema.fields())), concatenateErrors("Required column is null"))
                             .otherwise(col(ERROR))
             );

--- a/src/main/java/uk/gov/justice/digital/service/ValidationService.java
+++ b/src/main/java/uk/gov/justice/digital/service/ValidationService.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static org.apache.spark.sql.functions.*;
 import static uk.gov.justice.digital.common.CommonDataFields.*;
+import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 
 @Singleton
 public class ValidationService {
@@ -59,7 +60,7 @@ public class ValidationService {
                     // The order of the 'when' clauses determines the validation error message used - first wins.
                     // Null means there is no validation error.
                     when(pkIsNull(sourceReference), concatenateErrors("Record does not have a primary key"))
-                            .when(requiredColumnIsNull(schema.fields()), concatenateErrors("Required column is null"))
+                            .when(col(OPERATION).notEqual(lit(Delete.getName())).and(requiredColumnIsNull(schema.fields())), concatenateErrors("Required column is null"))
                             .otherwise(col(ERROR))
             );
         } else {

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -77,7 +77,7 @@ class ValidationServiceTest extends BaseSparkTest {
     private ValidationService underTest;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         underTest = new ValidationService(violationService);
         List<Row> input = Arrays.asList(
                 createRow(1, "2023-11-13 10:49:28.000000", Delete, "data"),
@@ -99,7 +99,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void validateRowsShouldValidateBasedOnNullPrimaryKeysAndNonNullColumns() {
+    void validateRowsShouldValidateBasedOnNullPrimaryKeysAndNonNullColumns() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
@@ -128,7 +128,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void validateRowsShouldValidateCompositePrimaryKeys() {
+    void validateRowsShouldValidateCompositePrimaryKeys() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Arrays.asList(PRIMARY_KEY_COLUMN, TIMESTAMP));
@@ -155,7 +155,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void validateRowsShouldIgnoreNullNonPKColumnsForDeletes() {
+    void validateRowsShouldIgnoreNullNonPKColumnsForDeletes() {
         // Deletes from postgres may be output with just the primary key and metadata columns.
         // We shouldn't mark these as invalid because these columns aren't needed to apply a delete operation.
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS_NON_NULLABLE_DATA_COLUMN);
@@ -179,7 +179,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void validateRowsShouldValidateMismatchingSchemas() {
+    void validateRowsShouldValidateMismatchingSchemas() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getVersionId()).thenReturn(VERSION_ID);
 
@@ -205,7 +205,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void validateRowsShouldReturnInvalidWhenNoPrimaryKeyIsPresentInSchema() {
+    void validateRowsShouldReturnInvalidWhenNoPrimaryKeyIsPresentInSchema() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.emptyList());
@@ -325,7 +325,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void handleValidationShouldReturnValidRows() {
+    void handleValidationShouldReturnValidRows() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
@@ -345,7 +345,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void handleValidationShouldWriteViolationsWithInvalidRows() {
+    void handleValidationShouldWriteViolationsWithInvalidRows() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
@@ -377,7 +377,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void handleValidationShouldWriteWholeBatchAsViolationsForSchemaMisMatch() {
+    void handleValidationShouldWriteWholeBatchAsViolationsForSchemaMisMatch() {
         StructType misMatchingSchema = TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS.add(
                 new StructField("extra-column", DataTypes.IntegerType, false, Metadata.empty())
         );
@@ -413,7 +413,7 @@ class ValidationServiceTest extends BaseSparkTest {
     }
 
     @Test
-    public void handleValidationShouldThrowRTEWhenViolationServiceThrows() {
+    void handleValidationShouldThrowRTEWhenViolationServiceThrows() {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));

--- a/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/ValidationServiceTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.common.CommonDataFields.OPERATION;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Delete;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
 import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Update;
@@ -58,13 +57,13 @@ import static uk.gov.justice.digital.test.MinimalTestData.createRow;
 @ExtendWith(MockitoExtension.class)
 class ValidationServiceTest extends BaseSparkTest {
 
-    private static final String source = "source";
-    private static final String table = "table";
-    private static final String requiredColumnIsNullMsg = "Required column is null";
-    private static final String missingOperationColumnMsg = "Missing Op column";
-    private static final String noPkMsg = "Record does not have a primary key";
+    private static final String SOURCE = "source";
+    private static final String TABLE = "table";
+    private static final String REQUIRED_COLUMN_IS_NULL_MSG = "Required column is null";
+    private static final String MISSING_OPERATION_COLUMN_MSG = "Missing Op column";
+    private static final String NO_PK_MSG = "Record does not have a primary key";
     private static final String VERSION_ID = UUID.randomUUID().toString();
-    private static final String schemaMisMatchMsg = "Record does not match schema version " + VERSION_ID;
+    private static final String SCHEMA_MIS_MATCH_MSG = "Record does not match schema version " + VERSION_ID;
     private static final String VALIDATION_TYPE = "{\"validationType\": \"time\"}";
 
     private static Dataset<Row> inputDf;
@@ -111,18 +110,18 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> expected = Arrays.asList(
                 RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, null),
                 RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, null),
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, noPkMsg)
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, REQUIRED_COLUMN_IS_NULL_MSG),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, NO_PK_MSG)
         );
 
         assertEquals(expected.size(), result.size());
@@ -147,9 +146,9 @@ class ValidationServiceTest extends BaseSparkTest {
 
         List<Row> expected = Arrays.asList(
                 RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, null),
-                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, noPkMsg)
+                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG)
         );
 
         assertEquals(expected.size(), result.size());
@@ -196,8 +195,8 @@ class ValidationServiceTest extends BaseSparkTest {
         Dataset<Row> resultDf = underTest.validateRows(thisInputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_DATA_COLUMN);
         List<Row> result = resultDf.collectAsList();
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:29.000000", "I", null, CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(2, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg)
+                RowFactory.create(1, "2023-11-13 10:49:29.000000", "I", null, CHECKPOINT_COL_VALUE, REQUIRED_COLUMN_IS_NULL_MSG),
+                RowFactory.create(2, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, REQUIRED_COLUMN_IS_NULL_MSG)
         );
 
         assertEquals(expected.size(), result.size());
@@ -222,8 +221,8 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, misMatchingSchema).collectAsList();
 
         List<Row> expected = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(2, null, "U", null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG)
         );
 
         assertEquals(expected.size(), result.size());
@@ -244,7 +243,7 @@ class ValidationServiceTest extends BaseSparkTest {
         List<Row> result = underTest.validateRows(thisInputDf, sourceReference, TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS).collectAsList();
 
         List<Row> expected = Collections.singletonList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG)
         );
 
         assertEquals(expected.size(), result.size());
@@ -355,8 +354,8 @@ class ValidationServiceTest extends BaseSparkTest {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
-        when(sourceReference.getSource()).thenReturn(source);
-        when(sourceReference.getTable()).thenReturn(table);
+        when(sourceReference.getSource()).thenReturn(SOURCE);
+        when(sourceReference.getTable()).thenReturn(TABLE);
 
         List<Row> result =
                 underTest.handleValidation(spark, inputDf, sourceReference, TEST_DATA_SCHEMA, STRUCTURED_LOAD).collectAsList();
@@ -375,27 +374,27 @@ class ValidationServiceTest extends BaseSparkTest {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
-        when(sourceReference.getSource()).thenReturn(source);
-        when(sourceReference.getTable()).thenReturn(table);
+        when(sourceReference.getSource()).thenReturn(SOURCE);
+        when(sourceReference.getTable()).thenReturn(TABLE);
 
         underTest.handleValidation(spark, inputDf, sourceReference, TEST_DATA_SCHEMA, STRUCTURED_LOAD).collectAsList();
 
         List<Row> expectedInvalid = Arrays.asList(
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, requiredColumnIsNullMsg),
-                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, missingOperationColumnMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, noPkMsg),
-                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, noPkMsg)
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, REQUIRED_COLUMN_IS_NULL_MSG),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, MISSING_OPERATION_COLUMN_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, NO_PK_MSG),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, NO_PK_MSG)
         );
 
-        verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(source), eq(table), eq(STRUCTURED_LOAD));
+        verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(SOURCE), eq(TABLE), eq(STRUCTURED_LOAD));
 
         List<Row> result = argumentCaptor.getValue().collectAsList();
         assertEquals(expectedInvalid.size(), result.size());
@@ -409,29 +408,29 @@ class ValidationServiceTest extends BaseSparkTest {
         );
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getVersionId()).thenReturn(VERSION_ID);
-        when(sourceReference.getSource()).thenReturn(source);
-        when(sourceReference.getTable()).thenReturn(table);
+        when(sourceReference.getSource()).thenReturn(SOURCE);
+        when(sourceReference.getTable()).thenReturn(TABLE);
 
         underTest.handleValidation(spark, inputDf, sourceReference, misMatchingSchema, STRUCTURED_LOAD).collectAsList();
 
         List<Row> expectedInvalid = Arrays.asList(
-                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, schemaMisMatchMsg),
-                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, schemaMisMatchMsg)
+                RowFactory.create(1, "2023-11-13 10:49:28.000000", "D", "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(2, "2023-11-13 10:49:28.000000", "D", null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(3, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(4, null, "I", "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(5, null, null, "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(6, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(7, null, null, null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, null, "U", "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", "U", null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, "2023-11-13 10:49:29.000000", null, null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, null, "U", null, CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG),
+                RowFactory.create(null, null, null, "data", CHECKPOINT_COL_VALUE, SCHEMA_MIS_MATCH_MSG)
         );
 
-        verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(source), eq(table), eq(STRUCTURED_LOAD));
+        verify(violationService, times(1)).handleViolation(any(), argumentCaptor.capture(), eq(SOURCE), eq(TABLE), eq(STRUCTURED_LOAD));
 
         List<Row> result = argumentCaptor.getValue().collectAsList();
         assertEquals(expectedInvalid.size(), result.size());
@@ -443,8 +442,8 @@ class ValidationServiceTest extends BaseSparkTest {
         when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
         when(sourceReference.getPrimaryKey()).thenReturn(primaryKey);
         when(primaryKey.getKeyColumnNames()).thenReturn(Collections.singletonList(PRIMARY_KEY_COLUMN));
-        when(sourceReference.getSource()).thenReturn(source);
-        when(sourceReference.getTable()).thenReturn(table);
+        when(sourceReference.getSource()).thenReturn(SOURCE);
+        when(sourceReference.getTable()).thenReturn(TABLE);
 
         doThrow(new DataStorageException(""))
                 .when(violationService)

--- a/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
+++ b/src/test/java/uk/gov/justice/digital/test/MinimalTestData.java
@@ -42,11 +42,24 @@ public class MinimalTestData {
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
     });
 
+    public static final StructType SCHEMA_WITHOUT_METADATA_FIELDS_NON_NULLABLE_DATA_COLUMN = new StructType(new StructField[]{
+            new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(DATA_COLUMN, DataTypes.StringType, false, Metadata.empty()),
+    });
+
     public static final StructType TEST_DATA_SCHEMA_NON_NULLABLE_COLUMNS = new StructType(new StructField[]{
             new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()),
             new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
             new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
             new StructField(DATA_COLUMN, DataTypes.StringType, true, Metadata.empty()),
+            new StructField(CHECKPOINT_COL, DataTypes.StringType, false, Metadata.empty())
+    });
+
+    public static final StructType TEST_DATA_SCHEMA_NON_NULLABLE_DATA_COLUMN = new StructType(new StructField[]{
+            new StructField(PRIMARY_KEY_COLUMN, DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(TIMESTAMP, DataTypes.StringType, false, Metadata.empty()),
+            new StructField(OPERATION, DataTypes.StringType, false, Metadata.empty()),
+            new StructField(DATA_COLUMN, DataTypes.StringType, false, Metadata.empty()),
             new StructField(CHECKPOINT_COL, DataTypes.StringType, false, Metadata.empty())
     });
     public static Encoder<Row> encoder = RowEncoder.apply(TEST_DATA_SCHEMA);


### PR DESCRIPTION
When the DMS processes deletes from Oracle it includes the body of the deleted row in the record. DMS with Postgres does not do this by default (only including the primary key columns and metadata columns added by DMS) and requires configuration on the database to do so.

This PR prevents deletes that do not include the body of the deleted row from failing validation and being sent to violations so that they can be processed normally.

To do this it:
- Only validates that required columns in the schema are included for operations which aren't a Delete
  - However, it still checks that primary key columns are included for Deletes as these are still required
- Adds an extra validation that the Operation column is not null