### PR TITLE
DPR2-1702: Add reconciliation tolerance to current state table counts reconciliation

### DIFF
--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -162,6 +162,10 @@ public class JobArguments {
     static final String RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS = "dpr.reconciliation.fail.job.if.checks.fail";
     static final String RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH = "dpr.reconciliation.report.results.to.cloudwatch";
     static final String RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE = "dpr.reconciliation.cloudwatch.metrics.namespace";
+    static final String RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE = "dpr.reconciliation.changedatacounts.tolerance.percentage";
+    static final double RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE_DEFAULT = 0.0;
+    static final String RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE = "dpr.reconciliation.changedatacounts.tolerance.absolute";
+    static final long RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT = 0L;
 
     private final Map<String, String> config;
 
@@ -542,6 +546,14 @@ public class JobArguments {
 
     public String getReconciliationCloudwatchMetricsNamespace() {
         return getArgument(RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE);
+    }
+
+    public double getReconciliationChangeDataCountsTolerancePercentage() {
+        return getArgument(RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE, RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE_DEFAULT);
+    }
+
+    public long getReconciliationChangeDataCountsToleranceAbsolute() {
+        return getArgument(RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -162,8 +162,8 @@ public class JobArguments {
     static final String RECONCILIATION_FAIL_JOB_IF_CHECKS_FAILS = "dpr.reconciliation.fail.job.if.checks.fail";
     static final String RECONCILIATION_REPORT_RESULTS_TO_CLOUDWATCH = "dpr.reconciliation.report.results.to.cloudwatch";
     static final String RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE = "dpr.reconciliation.cloudwatch.metrics.namespace";
-    static final String RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE = "dpr.reconciliation.changedatacounts.tolerance.percentage";
-    static final double RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE_DEFAULT = 0.0;
+    static final String RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE = "dpr.reconciliation.changedatacounts.tolerance.relative.percentage";
+    static final double RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE_DEFAULT = 0.0;
     static final String RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE = "dpr.reconciliation.changedatacounts.tolerance.absolute";
     static final long RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT = 0L;
 
@@ -548,8 +548,8 @@ public class JobArguments {
         return getArgument(RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE);
     }
 
-    public double getReconciliationChangeDataCountsTolerancePercentage() {
-        return getArgument(RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE, RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_PERCENTAGE_DEFAULT);
+    public double getReconciliationChangeDataCountsToleranceRelativePercentage() {
+        return getArgument(RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE_DEFAULT);
     }
 
     public long getReconciliationChangeDataCountsToleranceAbsolute() {

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
@@ -79,7 +79,7 @@ public class CurrentStateCountService {
         Long operationalDataStoreCount = getOperationalDataStoreCount(sourceReference, operationalDataStoreFullTableName);
 
         logger.info("Finished current state counts across data stores for table {}.{}", sourceName, tableName);
-        double relativeTolerance = jobArguments.getReconciliationChangeDataCountsTolerancePercentage();
+        double relativeTolerance = jobArguments.getReconciliationChangeDataCountsToleranceRelativePercentage();
         long absoluteTolerance = jobArguments.getReconciliationChangeDataCountsToleranceAbsolute();
 
         return new CurrentStateTableCount(relativeTolerance, absoluteTolerance, sourceDataStoreCount, structuredCount, curatedCount, operationalDataStoreCount);

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
@@ -79,8 +79,10 @@ public class CurrentStateCountService {
         Long operationalDataStoreCount = getOperationalDataStoreCount(sourceReference, operationalDataStoreFullTableName);
 
         logger.info("Finished current state counts across data stores for table {}.{}", sourceName, tableName);
+        double relativeTolerance = jobArguments.getReconciliationChangeDataCountsTolerancePercentage();
+        long absoluteTolerance = jobArguments.getReconciliationChangeDataCountsToleranceAbsolute();
 
-        return new CurrentStateTableCount(sourceDataStoreCount, structuredCount, curatedCount, operationalDataStoreCount);
+        return new CurrentStateTableCount(relativeTolerance, absoluteTolerance, sourceDataStoreCount, structuredCount, curatedCount, operationalDataStoreCount);
     }
 
     private long getSourceDataStoreCount(String tableName) {

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationTolerance.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationTolerance.java
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import static java.lang.Math.abs;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+
+
+public class ReconciliationTolerance {
+
+    /**
+     * Determines if the provided values are equal with the allowed tolerances.
+     * @param value1 The 1st value to compare
+     * @param value2 The 2nd value to compare
+     * @param absoluteTolerance The tolerance allowed, expressed as an absolute value which must be non-negative.
+     *                          E.g. If the values are 1 and 3 then an absoluteTolerance of 1
+     * @param relativeTolerance The tolerance allowed, relative to the greater of the two values, expressed as a
+     *                          percentage between 0.0 and 1.0.
+     * @return True if the values are equal within the tolerances, otherwise false.
+     */
+    public static boolean equalWithTolerance(long value1, long value2, long absoluteTolerance, double relativeTolerance) {
+        if (value1 < 0 || value2 < 0) {
+            throw new IllegalArgumentException(format("Values must be positive. Actual values: %s, %s", value1, value2));
+        }
+        if (absoluteTolerance < 0) {
+            throw new IllegalArgumentException("Absolute tolerance must be non-negative");
+        }
+        if (relativeTolerance < 0 || relativeTolerance > 1 || Double.isNaN(relativeTolerance)) {
+            throw new IllegalArgumentException("Percentage must be between 0.0 and 1.0. Actual value: " + relativeTolerance);
+        }
+        // Take the largest between the absolute tolerance and the relative tolerance applied to the largest value
+        double allowedDifference = max(absoluteTolerance, max(value1, value2) * relativeTolerance);
+        long difference = abs(value1 - value2);
+        return difference <= allowedDifference;
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationTolerance.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationTolerance.java
@@ -7,6 +7,9 @@ import static java.lang.String.format;
 
 public class ReconciliationTolerance {
 
+    private ReconciliationTolerance() {
+    }
+
     /**
      * Determines if the provided values are equal with the allowed tolerances.
      * @param value1 The 1st value to compare

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationTolerance.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationTolerance.java
@@ -22,7 +22,7 @@ public class ReconciliationTolerance {
      */
     public static boolean equalWithTolerance(long value1, long value2, long absoluteTolerance, double relativeTolerance) {
         if (value1 < 0 || value2 < 0) {
-            throw new IllegalArgumentException(format("Values must be positive. Actual values: %s, %s", value1, value2));
+            throw new IllegalArgumentException(format("Values must be non-negative. Actual values: %s, %s", value1, value2));
         }
         if (absoluteTolerance < 0) {
             throw new IllegalArgumentException("Absolute tolerance must be non-negative");

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTableCount.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTableCount.java
@@ -2,26 +2,35 @@ package uk.gov.justice.digital.service.datareconciliation.model;
 
 import lombok.Data;
 
+import static uk.gov.justice.digital.service.datareconciliation.ReconciliationTolerance.equalWithTolerance;
+
 /**
  * Represents the results of running the total counts data reconciliation for a single "current state" table in DataHub
  * replicated across multiple datastores
  */
 @Data
 public class CurrentStateTableCount {
+    private final double relativeTolerance;
+    private final long absoluteTolerance;
+
     private final long dataSourceCount;
     private final long structuredCount;
     private final long curatedCount;
     // A null value indicates that there is no Operational DataStore count
     private final Long operationalDataStoreCount;
 
-    public CurrentStateTableCount(long dataSourceCount, long structuredCount, long curatedCount, Long operationalDataStoreCount) {
+    public CurrentStateTableCount(double relativeTolerance, long absoluteTolerance, long dataSourceCount, long structuredCount, long curatedCount, Long operationalDataStoreCount) {
+        this.relativeTolerance = relativeTolerance;
+        this.absoluteTolerance = absoluteTolerance;
         this.dataSourceCount = dataSourceCount;
         this.structuredCount = structuredCount;
         this.curatedCount = curatedCount;
         this.operationalDataStoreCount = operationalDataStoreCount;
     }
 
-    public CurrentStateTableCount(long dataSourceCount, long structuredCount, long curatedCount) {
+    public CurrentStateTableCount(double relativeTolerance, long absoluteTolerance, long dataSourceCount, long structuredCount, long curatedCount) {
+        this.relativeTolerance = relativeTolerance;
+        this.absoluteTolerance = absoluteTolerance;
         this.dataSourceCount = dataSourceCount;
         this.structuredCount = structuredCount;
         this.curatedCount = curatedCount;
@@ -29,6 +38,14 @@ public class CurrentStateTableCount {
     }
 
     public boolean countsMatch() {
+        boolean structuredMatchesCurated = equalWithTolerance(structuredCount, curatedCount, absoluteTolerance, relativeTolerance);
+        boolean dataSourceMatchesCurated = equalWithTolerance(dataSourceCount, curatedCount, absoluteTolerance, relativeTolerance);
+        boolean operationalDataStoreSkippedOrMatchesCurated = operationalDataStoreCount == null || equalWithTolerance(operationalDataStoreCount, curatedCount, absoluteTolerance, relativeTolerance);
+
+        return structuredMatchesCurated && dataSourceMatchesCurated && operationalDataStoreSkippedOrMatchesCurated;
+    }
+
+    private boolean countsExactMatch() {
         boolean structuredMatchesCurated = structuredCount == curatedCount;
         boolean dataSourceMatchesCurated = dataSourceCount == curatedCount;
         boolean operationalDataStoreSkippedOrMatchesCurated = operationalDataStoreCount == null || operationalDataStoreCount == curatedCount;
@@ -37,10 +54,17 @@ public class CurrentStateTableCount {
     }
 
     public String summary() {
+        String matchMessage;
+        if (countsExactMatch()) {
+            matchMessage = "MATCH";
+        } else if (countsMatch()) {
+            matchMessage = "MATCH (within tolerance)";
+        } else {
+            matchMessage = "MISMATCH";
+        }
         return "Data Source: " + dataSourceCount + ", Structured Zone: " + structuredCount + ", Curated Zone: " + curatedCount
                 +", Operational DataStore: " + (operationalDataStoreCount == null ? "skipped": operationalDataStoreCount) +
-                (countsMatch() ? "\t - MATCH" : "\t - MISMATCH");
+                "\t - " + matchMessage;
     }
-
 
 }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
@@ -108,11 +108,11 @@ class CurrentStateCountServiceTest {
         CurrentStateTotalCounts results =
                 (CurrentStateTotalCounts) underTest.currentStateCounts(sparkSession, Arrays.asList(sourceReference1, sourceReference2));
 
-        CurrentStateTableCount expectedTable1Counts = new CurrentStateTableCount(1L, 1L, 1L, 1L);
+        CurrentStateTableCount expectedTable1Counts = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
         CurrentStateTableCount table1Result = results.get("source.table");
         assertEquals(expectedTable1Counts, table1Result);
 
-        CurrentStateTableCount expectedTable2Counts = new CurrentStateTableCount(4L, 3L, 2L, 1L);
+        CurrentStateTableCount expectedTable2Counts = new CurrentStateTableCount(0.0, 0L, 4L, 3L, 2L, 1L);
         CurrentStateTableCount table2Result = results.get("source.table2");
         assertEquals(expectedTable2Counts, table2Result);
     }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationToleranceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationToleranceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.service.datareconciliation;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.gov.justice.digital.service.datareconciliation.ReconciliationTolerance.equalWithTolerance;
@@ -181,6 +183,38 @@ class ReconciliationToleranceTest {
 
         boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
         assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "-1,-1",
+            "-1,0",
+            "-1,1",
+            "0,-1",
+            "1,-1"
+    })
+    void shouldThrowForNegativeValues(long value1, long value2) {
+        assertThrows(IllegalArgumentException.class, () -> equalWithTolerance(value1, value2, 0L, 0.0));
+    }
+
+    @Test
+    void shouldThrowForNegativeAbsoluteTolerance() {
+        assertThrows(IllegalArgumentException.class, () -> equalWithTolerance(1, 1, -1L, 0.0));
+    }
+
+    @Test
+    void shouldThrowForNegativeRelativeTolerance() {
+        assertThrows(IllegalArgumentException.class, () -> equalWithTolerance(1, 1, 0L, -0.01));
+    }
+
+    @Test
+    void shouldThrowForRelativeToleranceGreaterThan1() {
+        assertThrows(IllegalArgumentException.class, () -> equalWithTolerance(1, 1, 0L, 1.01));
+    }
+
+    @Test
+    void shouldThrowForNaNRelativeTolerance() {
+        assertThrows(IllegalArgumentException.class, () -> equalWithTolerance(1, 1, 0L, Double.NaN));
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationToleranceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/ReconciliationToleranceTest.java
@@ -1,0 +1,186 @@
+package uk.gov.justice.digital.service.datareconciliation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.justice.digital.service.datareconciliation.ReconciliationTolerance.equalWithTolerance;
+
+class ReconciliationToleranceTest {
+
+    @Test
+    void exactMatchWithNoToleranceShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 10;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void absoluteToleranceOf1Allows1Difference() {
+        long value1 = 100;
+        long value2 = 99;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void absoluteToleranceOf1DoesNotAllow2Difference() {
+        long value1 = 100;
+        long value2 = 98;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertFalse(result);
+    }
+
+    @Test
+    void relativeToleranceOf1PercentAllows1PercentDifference() {
+        long value1 = 100;
+        long value2 = 99;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.01;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void relativeToleranceOf1PercentDoesNotAllow2PercentDifference() {
+        long value1 = 100;
+        long value2 = 98;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.01;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertFalse(result);
+    }
+
+    @Test
+    void matchWithinAbsoluteToleranceShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 9;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void matchOutsideAbsoluteToleranceShouldGiveFalse() {
+        long value1 = 10;
+        long value2 = 8;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertFalse(result);
+    }
+
+    @Test
+    void matchWithinRelativeToleranceShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 9;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.1;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void matchOutsideRelativeToleranceShouldGiveFalse() {
+        long value1 = 10;
+        long value2 = 8;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.1;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertFalse(result);
+    }
+
+    @Test
+    void matchOutsideRelativeAndAbsoluteTolerancesShouldGiveFalse() {
+        long value1 = 10;
+        long value2 = 8;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.1;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertFalse(result);
+    }
+
+    @Test
+    void matchWithinRelativeToleranceButOutsideAbsoluteToleranceShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 8;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.5;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void matchWithinAbsoluteToleranceButOutsideRelativeToleranceShouldGiveTrue() {
+        long value1 = 100;
+        long value2 = 80;
+        long absoluteTolerance = 20;
+        double relativeTolerance = 0.01;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void nonExactMatchWithNoToleranceShouldGiveFalse() {
+        long value1 = 10;
+        long value2 = 9;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertFalse(result);
+    }
+
+    @Test
+    void exactMatchWithAbsoluteToleranceShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 10;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.0;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void exactMatchWithRelativeToleranceShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 10;
+        long absoluteTolerance = 0;
+        double relativeTolerance = 0.05;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+    @Test
+    void exactMatchWithBothTolerancesShouldGiveTrue() {
+        long value1 = 10;
+        long value2 = 10;
+        long absoluteTolerance = 1;
+        double relativeTolerance = 0.05;
+
+        boolean result = equalWithTolerance(value1, value2, absoluteTolerance, relativeTolerance);
+        assertTrue(result);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTableCountTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTableCountTest.java
@@ -32,78 +32,78 @@ class CurrentStateTableCountTest {
 
     @Test
     void shouldGiveMatchForCountsThatMatch() {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(1L, 1L, 1L, 1L);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
         assertTrue(underTest.countsMatch());
     }
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
     void shouldGiveNoMatchForCountsThatDoNotMatch(long nomisCount, long structuredCount, long curatedCount, long odsCount) {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(nomisCount, structuredCount, curatedCount, odsCount);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, nomisCount, structuredCount, curatedCount, odsCount);
         assertFalse(underTest.countsMatch());
     }
 
     @Test
     void shouldGiveMatchForCountsThatMatchWithDisabledODS() {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(1L, 1L, 1L);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L);
         assertTrue(underTest.countsMatch());
     }
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatchDisabledOds")
     void shouldGiveNoMatchForCountsThatDoNotMatchWithDisabledODS(long nomisCount, long structuredCount, long curatedCount) {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(nomisCount, structuredCount, curatedCount);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, nomisCount, structuredCount, curatedCount);
         assertFalse(underTest.countsMatch());
     }
 
     @Test
     void shouldProvideSummaryWhenCountsMatch() {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(1L, 1L, 1L, 1L);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
         String expected = "Data Source: 1, Structured Zone: 1, Curated Zone: 1, Operational DataStore: 1	 - MATCH";
         assertEquals(expected, underTest.summary());
     }
 
     @Test
     void shouldProvideSummaryWhenCountsMatchWithDisabledODS() {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(1L, 1L, 1L);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L);
         String expected = "Data Source: 1, Structured Zone: 1, Curated Zone: 1, Operational DataStore: skipped	 - MATCH";
         assertEquals(expected, underTest.summary());
     }
 
     @Test
     void shouldProvideSummaryWhenCountsDoNotMatch() {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(1L, 2L, 1L, 1L);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, 1L, 2L, 1L, 1L);
         String expected = "Data Source: 1, Structured Zone: 2, Curated Zone: 1, Operational DataStore: 1	 - MISMATCH";
         assertEquals(expected, underTest.summary());
     }
 
     @Test
     void shouldProvideSummaryWhenCountsDoNotMatchWithDisabledODS() {
-        CurrentStateTableCount underTest = new CurrentStateTableCount(1L, 2L, 3L);
+        CurrentStateTableCount underTest = new CurrentStateTableCount(0.0, 0L, 1L, 2L, 3L);
         String expected = "Data Source: 1, Structured Zone: 2, Curated Zone: 3, Operational DataStore: skipped	 - MISMATCH";
         assertEquals(expected, underTest.summary());
     }
 
     @Test
     void shouldBeEqualToAnotherWithSameValues() {
-        CurrentStateTableCount underTest1 = new CurrentStateTableCount(1L, 1L, 1L, 1L);
-        CurrentStateTableCount underTest2 = new CurrentStateTableCount(1L, 1L, 1L, 1L);
+        CurrentStateTableCount underTest1 = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
+        CurrentStateTableCount underTest2 = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
 
         assertEquals(underTest1, underTest2);
     }
 
     @Test
     void shouldBeEqualToAnotherWithSameValuesNoODSCount() {
-        CurrentStateTableCount underTest1 = new CurrentStateTableCount(1L, 1L, 1L);
-        CurrentStateTableCount underTest2 = new CurrentStateTableCount(1L, 1L, 1L);
+        CurrentStateTableCount underTest1 = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L);
+        CurrentStateTableCount underTest2 = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L);
 
         assertEquals(underTest1, underTest2);
     }
 
     @Test
     void shouldNotBeEqualToAnotherWithDifferentValues() {
-        CurrentStateTableCount underTest1 = new CurrentStateTableCount(1L, 1L, 1L, 1L);
-        CurrentStateTableCount underTest2 = new CurrentStateTableCount(1L, 1L, 1L);
+        CurrentStateTableCount underTest1 = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
+        CurrentStateTableCount underTest2 = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L);
 
         assertNotEquals(underTest1, underTest2);
     }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTotalCountsTest.java
@@ -14,8 +14,8 @@ class CurrentStateTotalCountsTest {
     void shouldBeFailureIfAnyResultHasMismatchedCounts() {
         // Exhaustive testing of different cases is included in the tests for CurrentStateTableCount
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
-        underTest.put("table1", new CurrentStateTableCount(1L, 1L, 1L, 1L));
-        underTest.put("table2", new CurrentStateTableCount(999L, 1L, 1L, 1L));
+        underTest.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
+        underTest.put("table2", new CurrentStateTableCount(0.0, 0L, 999L, 1L, 1L, 1L));
 
         assertFalse(underTest.isSuccess());
     }
@@ -23,8 +23,8 @@ class CurrentStateTotalCountsTest {
     @Test
     void shouldBeSuccessIfAllResultsHaveMatchedCounts() {
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
-        underTest.put("table1", new CurrentStateTableCount(1L, 1L, 1L, 1L));
-        underTest.put("table2", new CurrentStateTableCount(2L, 2L, 2L));
+        underTest.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
+        underTest.put("table2", new CurrentStateTableCount(0.0, 0L, 2L, 2L, 2L));
 
         assertTrue(underTest.isSuccess());
     }
@@ -38,8 +38,8 @@ class CurrentStateTotalCountsTest {
     @Test
     void shouldSummariseResultsIfTheyDoNotMatch() {
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
-        underTest.put("table1", new CurrentStateTableCount(1L, 1L, 1L, 1L));
-        underTest.put("table2", new CurrentStateTableCount(2L, 2L, 1L));
+        underTest.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
+        underTest.put("table2", new CurrentStateTableCount(0.0, 0L, 2L, 2L, 1L));
 
         String expected = "Current State Total Counts DO NOT MATCH:\n" +
                 "For table table2:\n" +
@@ -52,8 +52,8 @@ class CurrentStateTotalCountsTest {
     @Test
     void shouldSummariseResultsIfTheyMatch() {
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
-        underTest.put("table1", new CurrentStateTableCount(1L, 1L, 1L, 1L));
-        underTest.put("table2", new CurrentStateTableCount(2L, 2L, 2L));
+        underTest.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
+        underTest.put("table2", new CurrentStateTableCount(0.0, 0L, 2L, 2L, 2L));
 
         String expected = "Current State Total Counts MATCH:\n" +
                 "For table table2:\n" +
@@ -70,7 +70,7 @@ class CurrentStateTotalCountsTest {
         CurrentStateTotalCounts underTest = new CurrentStateTotalCounts();
         assertNull(underTest.get(tableName));
 
-        CurrentStateTableCount currentStateTableCount = new CurrentStateTableCount(1L, 1L, 1L, 1L);
+        CurrentStateTableCount currentStateTableCount = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
         underTest.put(tableName, currentStateTableCount);
 
         assertEquals(currentStateTableCount, underTest.get(tableName));
@@ -83,8 +83,8 @@ class CurrentStateTotalCountsTest {
         CurrentStateTotalCounts underTest1 = new CurrentStateTotalCounts();
         CurrentStateTotalCounts underTest2 = new CurrentStateTotalCounts();
 
-        underTest1.put(tableName, new CurrentStateTableCount(1L, 1L, 1L, 1L));
-        underTest2.put(tableName, new CurrentStateTableCount(1L, 1L, 1L, 1L));
+        underTest1.put(tableName, new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
+        underTest2.put(tableName, new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
 
         assertEquals(underTest1, underTest2);
     }
@@ -96,8 +96,8 @@ class CurrentStateTotalCountsTest {
         CurrentStateTotalCounts underTest1 = new CurrentStateTotalCounts();
         CurrentStateTotalCounts underTest2 = new CurrentStateTotalCounts();
 
-        underTest1.put(tableName, new CurrentStateTableCount(1L, 1L, 1L, 1L));
-        underTest2.put(tableName, new CurrentStateTableCount(2L, 1L, 1L, 1L));
+        underTest1.put(tableName, new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L));
+        underTest2.put(tableName, new CurrentStateTableCount(0.0, 0L, 2L, 1L, 1L, 1L));
 
         assertNotEquals(underTest1, underTest2);
     }
@@ -108,7 +108,7 @@ class CurrentStateTotalCountsTest {
         CurrentStateTotalCounts underTest1 = new CurrentStateTotalCounts();
         CurrentStateTotalCounts underTest2 = new CurrentStateTotalCounts();
 
-        CurrentStateTableCount count = new CurrentStateTableCount(1L, 1L, 1L, 1L);
+        CurrentStateTableCount count = new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L, 1L);
         underTest1.put("table1", count);
         underTest2.put("table2", count);
 

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
@@ -23,8 +23,8 @@ class DataReconciliationResultsTest {
 
     @BeforeAll
     static void setUpSharedTestData() {
-        matchingCurrentStateTotalCounts.put("table1", new CurrentStateTableCount(1L, 1L, 1L));
-        notMatchingCurrentStateTotalCounts.put("table1", new CurrentStateTableCount(1L, 2L, 3L));
+        matchingCurrentStateTotalCounts.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L));
+        notMatchingCurrentStateTotalCounts.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 2L, 3L));
         changeDataTableCountMap1.put("table1", new ChangeDataTableCount(1L, 1L, 1L));
         changeDataTableCountMap2.put("table1", new ChangeDataTableCount(1L, 2L, 1L));
     }


### PR DESCRIPTION
- Adds a configurable absolute tolerance and a relative percentage tolerance for the current_state_counts reconciliation check. You can choose to use one or the other, both or neither.
- Setting a tolerance means the values do not have to match exactly and can be slightly different. This is useful because often during CDC processing timing issues in the data flowing between systems will result in counts being slightly different. E.g. A data point is registered in DSM but not committed to S3 yet.
- Both tolerance settings default to zero which preserves the current behaviour of not allowing any tolerance and requiring exact matches in counts to pass reconciliation.
- Set with `dpr.reconciliation.changedatacounts.tolerance.absolute` and `dpr.reconciliation.changedatacounts.tolerance.relative.percentage` respectively.
- Equality with tolerance is calculated as `abs(value1 - value2) <= max(absoluteTolerance, max(value1, value2) * relativeTolerance)`

Further details:

- Absolute tolerance means the difference between the values being compared has to be <= to the absolute tolerance.
- E.g. An absolute tolerance set to 1 would result in failed reconciliation if we compare a count of 100 and 102, whereas an absolute tolerance of 2 would result in passed reconciliation.
- Absolute tolerance must be non-negative.
- Relative percentage tolerance means applying the percentage to the largest of the two values being compared to convert it to an absolute tolerance. So it is relative to the largest of the two values being compared.
- A relative percentage tolerance set to 0.01 (i.e. 1%) would result in failed reconciliation if we compare a count of 100 and 98, whereas a relative percentage tolerance set to 0.02 (i.e. 2%) would result in passed reconciliation.
- Relative percentage tolerance must be between 0.00 and 1.0 inclusive.
- When both tolerances are set the largest of the two is used only, e.g. if absolute tolerance = 1 and relative percentage tolerance = 0.02 then comparing values of 100 and 98 would use only the relative percentage tolerance and would result in passed reconciliation.