### PR TITLE
DPR2-1702: Add tolerance to change data counts reconciliation

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -96,8 +96,10 @@ class JobArgumentsIntegrationTest {
             { JobArguments.RECONCILIATION_DATASOURCE_GLUE_CONNECTION_NAME, "my-connection" },
             { JobArguments.RECONCILIATION_DATASOURCE_SOURCE_SCHEMA_NAME, "OMS_OWNER" },
             { JobArguments.RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE, "SomeNamespace" },
-            { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, "0.02" },
-            { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, "12" },
+            { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, "0.02" },
+            { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, "12" },
+            { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, "0.01" },
+            { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, "5" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -161,6 +163,8 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.RECONCILIATION_DATASOURCE_GLUE_CONNECTION_NAME, validArguments.getReconciliationDataSourceGlueConnectionName() },
                 { JobArguments.RECONCILIATION_DATASOURCE_SOURCE_SCHEMA_NAME, validArguments.getReconciliationDataSourceSourceSchemaName() },
                 { JobArguments.RECONCILIATION_CLOUDWATCH_METRICS_NAMESPACE, validArguments.getReconciliationCloudwatchMetricsNamespace() },
+                { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, Double.toString(validArguments.getReconciliationCurrentStateCountsToleranceRelativePercentage()) },
+                { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationCurrentStateCountsToleranceAbsolute()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, Double.toString(validArguments.getReconciliationChangeDataCountsToleranceRelativePercentage()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationChangeDataCountsToleranceAbsolute()) },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
@@ -679,6 +683,22 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(0L, jobArguments.getReconciliationChangeDataCountsToleranceAbsolute());
+    }
+
+    @Test
+    void getReconciliationCurrentStateCountsToleranceRelativePercentageShouldDefaultToZero() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(0.0, jobArguments.getReconciliationCurrentStateCountsToleranceRelativePercentage());
+    }
+
+    @Test
+    void getReconciliationCurrentStateCountsToleranceAbsoluteShouldDefaultToZero() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(0L, jobArguments.getReconciliationCurrentStateCountsToleranceAbsolute());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -166,6 +166,10 @@ public class JobArguments {
     static final double RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE_DEFAULT = 0.0;
     static final String RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE = "dpr.reconciliation.changedatacounts.tolerance.absolute";
     static final long RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT = 0L;
+    static final String RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE = "dpr.reconciliation.currentstatecounts.tolerance.relative.percentage";
+    static final double RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE_DEFAULT = 0.0;
+    static final String RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE = "dpr.reconciliation.currentstatecounts.tolerance.absolute";
+    static final long RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT = 0L;
 
     private final Map<String, String> config;
 
@@ -554,6 +558,14 @@ public class JobArguments {
 
     public long getReconciliationChangeDataCountsToleranceAbsolute() {
         return getArgument(RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT);
+    }
+
+    public double getReconciliationCurrentStateCountsToleranceRelativePercentage() {
+        return getArgument(RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE_DEFAULT);
+    }
+
+    public long getReconciliationCurrentStateCountsToleranceAbsolute() {
+        return getArgument(RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountService.java
@@ -79,8 +79,8 @@ public class CurrentStateCountService {
         Long operationalDataStoreCount = getOperationalDataStoreCount(sourceReference, operationalDataStoreFullTableName);
 
         logger.info("Finished current state counts across data stores for table {}.{}", sourceName, tableName);
-        double relativeTolerance = jobArguments.getReconciliationChangeDataCountsToleranceRelativePercentage();
-        long absoluteTolerance = jobArguments.getReconciliationChangeDataCountsToleranceAbsolute();
+        double relativeTolerance = jobArguments.getReconciliationCurrentStateCountsToleranceRelativePercentage();
+        long absoluteTolerance = jobArguments.getReconciliationCurrentStateCountsToleranceAbsolute();
 
         return new CurrentStateTableCount(relativeTolerance, absoluteTolerance, sourceDataStoreCount, structuredCount, curatedCount, operationalDataStoreCount);
     }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/RawChangeDataCountService.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/RawChangeDataCountService.java
@@ -61,7 +61,10 @@ public class RawChangeDataCountService {
     }
 
     private ChangeDataTableCount changeDataCountsForTable(SparkSession sparkSession, SourceReference sourceReference, String s3Path) {
-        ChangeDataTableCount result = new ChangeDataTableCount();
+        double relativeTolerance = jobArguments.getReconciliationChangeDataCountsToleranceRelativePercentage();
+        long absoluteTolerance = jobArguments.getReconciliationChangeDataCountsToleranceAbsolute();
+
+        ChangeDataTableCount result = new ChangeDataTableCount(relativeTolerance, absoluteTolerance);
 
         String rawTablePath = tablePath(s3Path, sourceReference.getSource(), sourceReference.getTable());
         try {

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCount.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCount.java
@@ -42,17 +42,23 @@ public class ChangeDataTableCount {
         );
     }
 
-    // Defines our own notion of equality that doesn't include tolerances
+    // Defines our own notion of exact equality that disregards unequal tolerances
     public boolean countsEqual(ChangeDataTableCount other) {
+        if (other == null) {
+            return false;
+        }
         return this.insertCount == other.insertCount &&
                 this.updateCount == other.updateCount &&
                 this.deleteCount == other.deleteCount;
     }
 
-    // Defines equality within tolerance
+    // Defines equality within tolerance, disregarding unequal tolerances, and using this object's tolerances
     public boolean countsEqualWithinTolerance(ChangeDataTableCount other) {
-        return equalWithTolerance(this.insertCount, other.insertCount, absoluteTolerance, relativeTolerance) &&
-                equalWithTolerance(this.updateCount, other.updateCount, absoluteTolerance, relativeTolerance) &&
-                equalWithTolerance(this.deleteCount, other.deleteCount, absoluteTolerance, relativeTolerance);
+        if (other == null) {
+            return false;
+        }
+        return equalWithTolerance(this.insertCount, other.insertCount, this.absoluteTolerance, this.relativeTolerance) &&
+                equalWithTolerance(this.updateCount, other.updateCount, this.absoluteTolerance, this.relativeTolerance) &&
+                equalWithTolerance(this.deleteCount, other.deleteCount, this.absoluteTolerance, this.relativeTolerance);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCount.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCount.java
@@ -2,18 +2,27 @@ package uk.gov.justice.digital.service.datareconciliation.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
+
+import static uk.gov.justice.digital.service.datareconciliation.ReconciliationTolerance.equalWithTolerance;
 
 /**
  * Change data counts - i.e. counts of insert, update and delete operations.
  */
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
 public class ChangeDataTableCount {
+
+    private final double relativeTolerance;
+    private final long absoluteTolerance;
+
     private long insertCount = 0L;
     private long updateCount = 0L;
     private long deleteCount = 0L;
+
+    public ChangeDataTableCount(double relativeTolerance, long absoluteTolerance) {
+        this.relativeTolerance = relativeTolerance;
+        this.absoluteTolerance = absoluteTolerance;
+    }
 
     @Override
     public String toString() {
@@ -21,10 +30,29 @@ public class ChangeDataTableCount {
     }
 
     public ChangeDataTableCount combineCounts(ChangeDataTableCount other) {
+        if (this.relativeTolerance != other.relativeTolerance || this.absoluteTolerance != other.absoluteTolerance) {
+            throw new IllegalArgumentException("Cannot combine counts with different tolerances");
+        }
         return new ChangeDataTableCount(
+                other.getRelativeTolerance(),
+                other.getAbsoluteTolerance(),
                 insertCount + other.getInsertCount(),
                 updateCount + other.getUpdateCount(),
                 deleteCount + other.getDeleteCount()
         );
+    }
+
+    // Defines our own notion of equality that doesn't include tolerances
+    public boolean countsEqual(ChangeDataTableCount other) {
+        return this.insertCount == other.insertCount &&
+                this.updateCount == other.updateCount &&
+                this.deleteCount == other.deleteCount;
+    }
+
+    // Defines equality within tolerance
+    public boolean countsEqualWithinTolerance(ChangeDataTableCount other) {
+        return equalWithTolerance(this.insertCount, other.insertCount, absoluteTolerance, relativeTolerance) &&
+                equalWithTolerance(this.updateCount, other.updateCount, absoluteTolerance, relativeTolerance) &&
+                equalWithTolerance(this.deleteCount, other.deleteCount, absoluteTolerance, relativeTolerance);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
@@ -21,14 +21,16 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
 
     @Override
     public boolean isSuccess() {
-        return sameTables() && rawCountsMatchDmsCounts();
+        return sameTables() && rawCountsMatchDmsCountsWithinTolerance();
     }
 
     @Override
     public String summary() {
         StringBuilder sb = new StringBuilder("Change Data Total Counts ");
-        if (isSuccess()) {
+        if (sameTables() && rawCountsExactMatchDmsCounts()) {
             sb.append("MATCH:\n\n");
+        } else if (isSuccess()) {
+            sb.append("MATCH (within tolerance):\n\n");
         } else {
             sb.append("DO NOT MATCH:\n\n");
         }
@@ -69,13 +71,23 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
         return sb.toString();
     }
 
-    private boolean rawCountsMatchDmsCounts() {
+    private boolean rawCountsMatchDmsCountsWithinTolerance() {
         return rawZoneCounts.entrySet().stream().allMatch(entry -> {
             String tableName = entry.getKey();
             ChangeDataTableCount rawCount = entry.getValue();
             ChangeDataTableCount dmsCount = dmsCounts.get(tableName);
             ChangeDataTableCount dmsAppliedCount = dmsAppliedCounts.get(tableName);
-            return rawCount.equals(dmsCount) && dmsCount.equals(dmsAppliedCount);
+            return rawCount.countsEqualWithinTolerance(dmsCount) && dmsCount.countsEqualWithinTolerance(dmsAppliedCount);
+        });
+    }
+
+    private boolean rawCountsExactMatchDmsCounts() {
+        return rawZoneCounts.entrySet().stream().allMatch(entry -> {
+            String tableName = entry.getKey();
+            ChangeDataTableCount rawCount = entry.getValue();
+            ChangeDataTableCount dmsCount = dmsCounts.get(tableName);
+            ChangeDataTableCount dmsAppliedCount = dmsAppliedCounts.get(tableName);
+            return rawCount.countsEqual(dmsCount) && dmsCount.countsEqual(dmsAppliedCount);
         });
     }
 

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCounts.java
@@ -47,6 +47,8 @@ public class ChangeDataTotalCounts implements DataReconciliationResult {
             sb.append("For table ").append(tableName);
             if (dmsCount != null && dmsCount.equals(dmsAppliedCount) && dmsCount.equals(rawCount)) {
                 sb.append(" MATCH:\n");
+            } else if (dmsCount != null && dmsCount.countsEqualWithinTolerance(dmsAppliedCount) && dmsCount.countsEqualWithinTolerance(rawCount)) {
+                sb.append(" MATCH (within tolerance):\n");
             } else {
                 sb.append(" DOES NOT MATCH:\n");
             }

--- a/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTableCount.java
+++ b/src/main/java/uk/gov/justice/digital/service/datareconciliation/model/CurrentStateTableCount.java
@@ -16,7 +16,8 @@ public class CurrentStateTableCount {
     private final long dataSourceCount;
     private final long structuredCount;
     private final long curatedCount;
-    // A null value indicates that there is no Operational DataStore count
+    // A null value indicates that there is no Operational DataStore count because this table is not stored in the
+    // Operational Data Store whereas it would have a value of zero if there was an issue reading the count.
     private final Long operationalDataStoreCount;
 
     public CurrentStateTableCount(double relativeTolerance, long absoluteTolerance, long dataSourceCount, long structuredCount, long curatedCount, Long operationalDataStoreCount) {

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/ChangeDataCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/ChangeDataCountServiceTest.java
@@ -47,12 +47,12 @@ class ChangeDataCountServiceTest {
     void setUp() {
         Map<String, ChangeDataTableCount> dmsChangeDataCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedChangeDataCounts = new HashMap<>();
-        dmsChangeDataCounts.put("table", new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedChangeDataCounts.put("table", new ChangeDataTableCount(1L, 2L, 3L));
+        dmsChangeDataCounts.put("table", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedChangeDataCounts.put("table", new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L));
         dmsChangeDataCountsPair = new DmsChangeDataCountsPair(dmsChangeDataCounts, dmsAppliedChangeDataCounts);
 
         rawChangeDataCounts = new HashMap<>();
-        rawChangeDataCounts.put("table", new ChangeDataTableCount(1L, 1L, 1L));
+        rawChangeDataCounts.put("table", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         sourceReferences = Collections.singletonList(sourceReference);
     }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/CurrentStateCountServiceTest.java
@@ -264,4 +264,23 @@ class CurrentStateCountServiceTest {
         assertEquals(0L, result.getOperationalDataStoreCount());
     }
 
+    @Test
+    void shouldPopulateTolerancesInCurrentStateTableCount() {
+        double relativeTolerance = 0.15;
+        long absoluteTolerance = 7L;
+
+        when(reconciliationDataSourceService.getTableRowCount("table")).thenReturn(3L);
+        when(structured1.count()).thenReturn(2L);
+        when(curated1.count()).thenReturn(1L);
+        when(operationalDataStoreService.isEnabled()).thenReturn(false);
+
+        when(jobArguments.getReconciliationCurrentStateCountsToleranceRelativePercentage()).thenReturn(relativeTolerance);
+        when(jobArguments.getReconciliationCurrentStateCountsToleranceAbsolute()).thenReturn(absoluteTolerance);
+
+        CurrentStateTableCount result = underTest.currentStateCountForTable(sparkSession, sourceReference1);
+
+        assertEquals(relativeTolerance, result.getRelativeTolerance());
+        assertEquals(absoluteTolerance, result.getAbsoluteTolerance());
+    }
+
 }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/DmsChangeDataCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/DmsChangeDataCountServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.dms.DmsClient;
+import uk.gov.justice.digital.config.JobArguments;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.DmsClientException;
 import uk.gov.justice.digital.service.datareconciliation.model.ChangeDataTableCount;
@@ -94,6 +95,8 @@ class DmsChangeDataCountServiceTest {
 
     @Mock
     private DmsClient dmsClient;
+    @Mock
+    private JobArguments jobArguments;
 
     @InjectMocks
     private DmsChangeDataCountService underTest;
@@ -101,16 +104,16 @@ class DmsChangeDataCountServiceTest {
     @BeforeAll
     static void beforeAll() {
         expectedDmsChangeDataCounts.put("source.table1", new ChangeDataTableCount(
-                101L, 3L, 5L
+                0.0, 0L, 101L, 3L, 5L
         ));
         expectedDmsChangeDataCounts.put("source.table2", new ChangeDataTableCount(
-                107L, 9L, 11L
+                0.0, 0L, 107L, 9L, 11L
         ));
         expectedDmsAppliedChangeDataCounts.put("source.table1", new ChangeDataTableCount(
-                102L, 4L, 6L
+                0.0, 0L, 102L, 4L, 6L
         ));
         expectedDmsAppliedChangeDataCounts.put("source.table2", new ChangeDataTableCount(
-                108L, 10L, 12L
+                0.0, 0L, 108L, 10L, 12L
         ));
     }
 

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/DmsChangeDataCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/DmsChangeDataCountServiceTest.java
@@ -134,6 +134,48 @@ class DmsChangeDataCountServiceTest {
     }
 
     @Test
+    void shouldPopulateTolerancesInChangeDataCounts() {
+        double relativeTolerance = 0.15;
+        long absoluteTolerance = 7L;
+
+        List<SourceReference> sourceReferences = Arrays.asList(sourceReference1, sourceReference2);
+        List<TableStatistics> dmsTableStatistics = Arrays.asList(tableStats1, tableStats2);
+
+        when(dmsClient.getReplicationTaskTableStatistics(DMS_TASK_ID)).thenReturn(dmsTableStatistics);
+        when(jobArguments.getReconciliationChangeDataCountsToleranceRelativePercentage()).thenReturn(relativeTolerance);
+        when(jobArguments.getReconciliationChangeDataCountsToleranceAbsolute()).thenReturn(absoluteTolerance);
+
+        DmsChangeDataCountsPair results = underTest.dmsChangeDataCounts(sourceReferences, DMS_TASK_ID);
+        ChangeDataTableCount table1Count = results.getDmsChangeDataCounts().get("source.table1");
+        ChangeDataTableCount table2Count = results.getDmsChangeDataCounts().get("source.table2");
+        assertEquals(relativeTolerance, table1Count.getRelativeTolerance());
+        assertEquals(absoluteTolerance, table1Count.getAbsoluteTolerance());
+        assertEquals(relativeTolerance, table2Count.getRelativeTolerance());
+        assertEquals(absoluteTolerance, table2Count.getAbsoluteTolerance());
+    }
+
+    @Test
+    void shouldPopulateTolerancesInAppliedChangeDataCounts() {
+        double relativeTolerance = 0.15;
+        long absoluteTolerance = 7L;
+
+        List<SourceReference> sourceReferences = Arrays.asList(sourceReference1, sourceReference2);
+        List<TableStatistics> dmsTableStatistics = Arrays.asList(tableStats1, tableStats2);
+
+        when(dmsClient.getReplicationTaskTableStatistics(DMS_TASK_ID)).thenReturn(dmsTableStatistics);
+        when(jobArguments.getReconciliationChangeDataCountsToleranceRelativePercentage()).thenReturn(relativeTolerance);
+        when(jobArguments.getReconciliationChangeDataCountsToleranceAbsolute()).thenReturn(absoluteTolerance);
+
+        DmsChangeDataCountsPair results = underTest.dmsChangeDataCounts(sourceReferences, DMS_TASK_ID);
+        ChangeDataTableCount table1Count = results.getDmsAppliedChangeDataCounts().get("source.table1");
+        ChangeDataTableCount table2Count = results.getDmsAppliedChangeDataCounts().get("source.table2");
+        assertEquals(relativeTolerance, table1Count.getRelativeTolerance());
+        assertEquals(absoluteTolerance, table1Count.getAbsoluteTolerance());
+        assertEquals(relativeTolerance, table2Count.getRelativeTolerance());
+        assertEquals(absoluteTolerance, table2Count.getAbsoluteTolerance());
+    }
+
+    @Test
     void shouldIgnoreTableStatisticsWithoutCorrespondingSourceReference() {
 
         List<SourceReference> sourceReferences = Arrays.asList(sourceReference1, sourceReference2);

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/RawChangeDataCountServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/RawChangeDataCountServiceTest.java
@@ -84,8 +84,8 @@ class RawChangeDataCountServiceTest extends BaseSparkTest {
         Map<String, ChangeDataTableCount> result = underTest.changeDataCounts(spark, sourceReferences);
 
         Map<String, ChangeDataTableCount> expectedResult = new HashMap<>();
-        expectedResult.put("source.table1", new ChangeDataTableCount(6L, 1L, 1L));
-        expectedResult.put("source.table2", new ChangeDataTableCount(6L, 6L, 6L));
+        expectedResult.put("source.table1", new ChangeDataTableCount(0.0, 0L, 6L, 1L, 1L));
+        expectedResult.put("source.table2", new ChangeDataTableCount(0.0, 0L, 6L, 6L, 6L));
 
         assertEquals(expectedResult, result);
 
@@ -114,7 +114,7 @@ class RawChangeDataCountServiceTest extends BaseSparkTest {
         Map<String, ChangeDataTableCount> result = underTest.changeDataCounts(spark, sourceReferences);
 
         Map<String, ChangeDataTableCount> expectedResult = new HashMap<>();
-        expectedResult.put("source.table1", new ChangeDataTableCount(0L, 0L, 0L));
+        expectedResult.put("source.table1", new ChangeDataTableCount(0.0, 0L, 0L, 0L, 0L));
 
         assertEquals(expectedResult, result);
     }
@@ -131,7 +131,7 @@ class RawChangeDataCountServiceTest extends BaseSparkTest {
         Map<String, ChangeDataTableCount> result = underTest.changeDataCounts(spark, sourceReferences);
 
         Map<String, ChangeDataTableCount> expectedResult = new HashMap<>();
-        expectedResult.put("source.table1", new ChangeDataTableCount(6L, 0L, 0L));
+        expectedResult.put("source.table1", new ChangeDataTableCount(0.0, 0L, 6L, 0L, 0L));
 
         assertEquals(expectedResult, result);
     }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCountTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCountTest.java
@@ -2,12 +2,16 @@ package uk.gov.justice.digital.service.datareconciliation.model;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ChangeDataTableCountTest {
 
@@ -22,6 +26,176 @@ class ChangeDataTableCountTest {
                 new Object[]{1L, 2L, 2L, 1L, 1L, 1L},
                 new Object[]{2L, 2L, 2L, 1L, 1L, 1L}
         );
+    }
+
+    @Test
+    void countsEqualShouldBeEqualIfCountsMatch() {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+
+        assertTrue(underTest1.countsEqual(underTest2));
+    }
+
+    @Test
+    void countsEqualShouldNotBeEqualIfOtherIsNull() {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+
+        assertFalse(underTest1.countsEqual(null));
+    }
+
+    @Test
+    void countsEqualShouldIgnoreDifferencesInTolerancesWhenCalculatingEquality() {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.1, 1L, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.2, 2L, 1L, 2L, 3L);
+
+        assertTrue(underTest1.countsEqual(underTest2));
+    }
+
+    @ParameterizedTest
+    @MethodSource("countsThatDoNotMatch")
+    void countsEqualShouldNotBeEqualIfCountsDoNotMatch(
+            long insertCount1, long updateCount1, long deleteCount1, long insertCount2, long updateCount2, long deleteCount2
+    ) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, insertCount1, updateCount1, deleteCount1);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.0, 0L, insertCount2, updateCount2, deleteCount2);
+        assertFalse(underTest1.countsEqual(underTest2));
+    }
+
+    @Test
+    void countsEqualWithinToleranceShouldBeEqualIfCountsMatchExactly() {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+
+        assertTrue(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @Test
+    void countsEqualWithinToleranceShouldNotBeEqualIfOtherIsNull() {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+
+        assertFalse(underTest1.countsEqualWithinTolerance(null));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,100",
+            "0.0,1,100,100",
+            "0.1,0,100,100",
+            "0.1,1,100,100",
+            "0.0,1,100,99",
+            "0.01,0,100,99",
+            "0.01,1,100,99",
+            "0.0,1,99,100",
+            "0.01,0,99,100",
+            "0.01,1,99,100",
+            "0.10,1,90,100",
+            "0.01,10,90,100",
+    })
+    void countsEqualWithinToleranceShouldBeEqualIfInsertCountsAreWithinTolerance(double relativeTolerance, long absoluteTolerance, long insertCount1, long insertCount2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, insertCount1, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, insertCount2, 2L, 3L);
+
+        assertTrue(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,100",
+            "0.0,1,100,100",
+            "0.1,0,100,100",
+            "0.1,1,100,100",
+            "0.0,1,100,99",
+            "0.01,0,100,99",
+            "0.01,1,100,99",
+            "0.0,1,99,100",
+            "0.01,0,99,100",
+            "0.01,1,99,100",
+            "0.10,1,90,100",
+            "0.01,10,90,100",
+    })
+    void countsEqualWithinToleranceShouldBeEqualIfUpdateCountsAreWithinTolerance(double relativeTolerance, long absoluteTolerance, long updateCount1, long updateCount2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, updateCount1, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, updateCount2, 3L);
+
+        assertTrue(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,100",
+            "0.0,1,100,100",
+            "0.1,0,100,100",
+            "0.1,1,100,100",
+            "0.0,1,100,99",
+            "0.01,0,100,99",
+            "0.01,1,100,99",
+            "0.0,1,99,100",
+            "0.01,0,99,100",
+            "0.01,1,99,100",
+            "0.10,1,90,100",
+            "0.01,10,90,100",
+    })
+    void countsEqualWithinToleranceShouldBeEqualIfDeleteCountsAreWithinTolerance(double relativeTolerance, long absoluteTolerance, long deleteCount1, long deleteCount2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 2L, deleteCount1);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 2L, deleteCount2);
+
+        assertTrue(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,99",
+            "0.0,0,99,100",
+            "0.0,1,100,98",
+            "0.0,1,98,100",
+            "0.01,0,98,100",
+            "0.01,0,100,98",
+    })
+    void countsEqualWithinToleranceShouldNotBeEqualIfInsertCountsAreOutsideTolerance(double relativeTolerance, long absoluteTolerance, long insertCount1, long insertCount2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, insertCount1, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, insertCount2, 2L, 3L);
+
+        assertFalse(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,99",
+            "0.0,0,99,100",
+            "0.0,1,100,98",
+            "0.0,1,98,100",
+            "0.01,0,98,100",
+            "0.01,0,100,98",
+    })
+    void countsEqualWithinToleranceShouldNotBeEqualIfUpdateCountsAreOutsideTolerance(double relativeTolerance, long absoluteTolerance, long updateCount1, long updateCount2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, updateCount1, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, updateCount2, 3L);
+
+        assertFalse(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,99",
+            "0.0,0,99,100",
+            "0.0,1,100,98",
+            "0.0,1,98,100",
+            "0.01,0,98,100",
+            "0.01,0,100,98",
+    })
+    void countsEqualWithinToleranceShouldNotBeEqualIfDeleteCountsAreOutsideTolerance(double relativeTolerance, long absoluteTolerance, long deleteCount1, long deleteCount2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 2L, deleteCount1);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 2L, deleteCount2);
+
+        assertFalse(underTest1.countsEqualWithinTolerance(underTest2));
+    }
+
+    @Test
+    void countsEqualWithinToleranceShouldIgnoreDifferencesInTolerances() {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.1, 1L, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.2, 2L, 1L, 2L, 3L);
+
+        assertTrue(underTest1.countsEqualWithinTolerance(underTest2));
     }
 
     @Test
@@ -70,6 +244,20 @@ class ChangeDataTableCountTest {
         assertEquals(3L, combined.getInsertCount());
         assertEquals(5L, combined.getUpdateCount());
         assertEquals(7L, combined.getDeleteCount());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.01,0.0,0,0",
+            "0.0,0.01,0,0",
+            "0.0,0.0,1,0",
+            "0.0,0.0,0,1",
+    })
+    void combineCountsShouldThrowIfTolerancesDoNotMatch(double relativeTolerance1, double relativeTolerance2, long absoluteTolerance1, long absoluteTolerance2) {
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(relativeTolerance1, absoluteTolerance1, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(relativeTolerance2, absoluteTolerance2, 2L, 3L, 4L);
+
+        assertThrows(IllegalArgumentException.class, () -> underTest1.combineCounts(underTest2));
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCountTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTableCountTest.java
@@ -26,8 +26,8 @@ class ChangeDataTableCountTest {
 
     @Test
     void shouldBeEqualIfCountsMatch() {
-        ChangeDataTableCount underTest1 = new ChangeDataTableCount(1L, 2L, 3L);
-        ChangeDataTableCount underTest2 = new ChangeDataTableCount(1L, 2L, 3L);
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
 
         assertEquals(underTest1, underTest2);
     }
@@ -37,14 +37,14 @@ class ChangeDataTableCountTest {
     void shouldNotBeEqualIfCountsDoNotMatch(
             long insertCount1, long updateCount1, long deleteCount1, long insertCount2, long updateCount2, long deleteCount2
     ) {
-        ChangeDataTableCount underTest1 = new ChangeDataTableCount(insertCount1, updateCount1, deleteCount1);
-        ChangeDataTableCount underTest2 = new ChangeDataTableCount(insertCount2, updateCount2, deleteCount2);
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, insertCount1, updateCount1, deleteCount1);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.0, 0L, insertCount2, updateCount2, deleteCount2);
         assertNotEquals(underTest1, underTest2);
     }
 
     @Test
     void shouldDefaultToZeroCounts() {
-        ChangeDataTableCount underTest = new ChangeDataTableCount();
+        ChangeDataTableCount underTest = new ChangeDataTableCount(0.0, 0L);
         assertEquals(0L, underTest.getInsertCount());
         assertEquals(0L, underTest.getUpdateCount());
         assertEquals(0L, underTest.getDeleteCount());
@@ -52,7 +52,7 @@ class ChangeDataTableCountTest {
 
     @Test
     void toStringShouldBeReadable() {
-        ChangeDataTableCount underTest = new ChangeDataTableCount();
+        ChangeDataTableCount underTest = new ChangeDataTableCount(0.0, 0L);
         underTest.setInsertCount(1L);
         underTest.setUpdateCount(2L);
         underTest.setDeleteCount(3L);
@@ -62,8 +62,8 @@ class ChangeDataTableCountTest {
 
     @Test
     void shouldCombineCounts() {
-        ChangeDataTableCount underTest1 = new ChangeDataTableCount(1L, 2L, 3L);
-        ChangeDataTableCount underTest2 = new ChangeDataTableCount(2L, 3L, 4L);
+        ChangeDataTableCount underTest1 = new ChangeDataTableCount(0.0, 0L, 1L, 2L, 3L);
+        ChangeDataTableCount underTest2 = new ChangeDataTableCount(0.0, 0L, 2L, 3L, 4L);
 
         ChangeDataTableCount combined = underTest1.combineCounts(underTest2);
 

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.service.datareconciliation.model;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.HashMap;
@@ -37,8 +38,176 @@ class ChangeDataTotalCountsTest {
     }
 
     @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,100,100",
+            "0.01,0,99,100,100",
+            "0.01,0,100,99,100",
+            "0.01,0,100,100,99",
+            "0.01,0,100,99,99",
+            "0.01,0,99,100,99",
+            "0.01,0,99,99,100",
+            "0.0,1,100,100,99",
+            "0.0,1,100,99,99",
+            "0.0,1,99,100,99",
+            "0.0,1,99,99,100",
+    })
+    void shouldBeSuccessForInsertCountsWithinTolerance(double relativeTolerance, long absoluteTolerance, long rawInsertCount, long dmsInsertCount, long dmsAppliedInsertCount) {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, rawInsertCount, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, dmsInsertCount, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, dmsAppliedInsertCount, 1L, 1L));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+        assertTrue(underTest.isSuccess());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,100,100",
+            "0.01,0,99,100,100",
+            "0.01,0,100,99,100",
+            "0.01,0,100,100,99",
+            "0.01,0,100,99,99",
+            "0.01,0,99,100,99",
+            "0.01,0,99,99,100",
+            "0.0,1,100,100,99",
+            "0.0,1,100,99,99",
+            "0.0,1,99,100,99",
+            "0.0,1,99,99,100",
+    })
+    void shouldBeSuccessForUpdateCountsWithinTolerance(double relativeTolerance, long absoluteTolerance, long rawUpdateCount, long dmsUpdateCount, long dmsAppliedUpdateCount) {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, rawUpdateCount, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, dmsUpdateCount, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, dmsAppliedUpdateCount, 1L));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+        assertTrue(underTest.isSuccess());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,100,100,100",
+            "0.01,0,99,100,100",
+            "0.01,0,100,99,100",
+            "0.01,0,100,100,99",
+            "0.01,0,100,99,99",
+            "0.01,0,99,100,99",
+            "0.01,0,99,99,100",
+            "0.0,1,100,100,99",
+            "0.0,1,100,99,99",
+            "0.0,1,99,100,99",
+            "0.0,1,99,99,100",
+    })
+    void shouldBeSuccessForDeleteCountsWithinTolerance(double relativeTolerance, long absoluteTolerance, long rawDeleteCount, long dmsDeleteCount, long dmsAppliedDeleteCount) {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 1L, rawDeleteCount));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 1L, dmsDeleteCount));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 1L, dmsAppliedDeleteCount));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+        assertTrue(underTest.isSuccess());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,99,100,100",
+            "0.0,0,100,99,100",
+            "0.0,0,100,100,99",
+            "0.01,0,98,100,100",
+            "0.01,0,100,98,100",
+            "0.01,0,100,100,98",
+            "0.01,0,100,98,98",
+            "0.01,0,98,100,98",
+            "0.01,0,98,98,100",
+            "0.0,1,100,100,98",
+            "0.0,1,100,98,98",
+            "0.0,1,98,100,98",
+            "0.0,1,98,98,100",
+    })
+    void shouldBeFailureForInsertCountsOutsideTolerance(double relativeTolerance, long absoluteTolerance, long rawInsertCount, long dmsInsertCount, long dmsAppliedInsertCount) {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, rawInsertCount, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, dmsInsertCount, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, dmsAppliedInsertCount, 1L, 1L));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+        assertFalse(underTest.isSuccess());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,99,100,100",
+            "0.0,0,100,99,100",
+            "0.0,0,100,100,99",
+            "0.01,0,98,100,100",
+            "0.01,0,100,98,100",
+            "0.01,0,100,100,98",
+            "0.01,0,100,98,98",
+            "0.01,0,98,100,98",
+            "0.01,0,98,98,100",
+            "0.0,1,100,100,98",
+            "0.0,1,100,98,98",
+            "0.0,1,98,100,98",
+            "0.0,1,98,98,100",
+    })
+    void shouldBeFailureForUpdateCountsOutsideTolerance(double relativeTolerance, long absoluteTolerance, long rawUpdateCount, long dmsUpdateCount, long dmsAppliedUpdateCount) {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, rawUpdateCount, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, dmsUpdateCount, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, dmsAppliedUpdateCount, 1L));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+        assertFalse(underTest.isSuccess());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.0,0,99,100,100",
+            "0.0,0,100,99,100",
+            "0.0,0,100,100,99",
+            "0.01,0,98,100,100",
+            "0.01,0,100,98,100",
+            "0.01,0,100,100,98",
+            "0.01,0,100,98,98",
+            "0.01,0,98,100,98",
+            "0.01,0,98,98,100",
+            "0.0,1,100,100,98",
+            "0.0,1,100,98,98",
+            "0.0,1,98,100,98",
+            "0.0,1,98,98,100",
+    })
+    void shouldBeFailureForDeleteCountsOutsideTolerance(double relativeTolerance, long absoluteTolerance, long rawDeleteCount, long dmsDeleteCount, long dmsAppliedDeleteCount) {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 1L, rawDeleteCount));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 1L, dmsDeleteCount));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(relativeTolerance, absoluteTolerance, 1L, 1L, dmsAppliedDeleteCount));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+        assertFalse(underTest.isSuccess());
+    }
+
+    @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
-    void shouldBeFailureForDifferentInsertCounts(long rawInsertCount, long dmsInsertCount, long dmsAppliedInsertCount) {
+    void shouldBeFailureForDifferentInsertCountsWithZeroTolerance(long rawInsertCount, long dmsInsertCount, long dmsAppliedInsertCount) {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -53,7 +222,7 @@ class ChangeDataTotalCountsTest {
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
-    void shouldBeFailureForDifferentUpdateCounts(long rawUpdateCount, long dmsUpdateCount, long dmsAppliedUpdateCount) {
+    void shouldBeFailureForDifferentUpdateCountsWithZeroTolerance(long rawUpdateCount, long dmsUpdateCount, long dmsAppliedUpdateCount) {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -68,7 +237,7 @@ class ChangeDataTotalCountsTest {
 
     @ParameterizedTest
     @MethodSource("countsThatDoNotMatch")
-    void shouldBeFailureForDifferentDeleteCounts(long rawDeleteCount, long dmsDeleteCount, long dmsAppliedDeleteCount) {
+    void shouldBeFailureForDifferentDeleteCountsWithZeroTolerance(long rawDeleteCount, long dmsDeleteCount, long dmsAppliedDeleteCount) {
         Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
@@ -126,6 +295,28 @@ class ChangeDataTotalCountsTest {
                 "For table table1 MATCH:\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - Raw\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS\n" +
+                "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS Applied\n";
+        String actual = underTest.summary();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldGiveSummaryWhenMatchWithinTolerance() {
+        Map<String, ChangeDataTableCount> rawCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
+        Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
+
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 1L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 1L, 2L, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+
+        ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
+
+        String expected = "Change Data Total Counts MATCH (within tolerance):\n" +
+                "\n" +
+                "For table table1 MATCH (within tolerance):\n" +
+                "\tInserts: 1, Updates: 1, Deletes: 1\t - Raw\n" +
+                "\tInserts: 2, Updates: 1, Deletes: 1\t - DMS\n" +
                 "\tInserts: 1, Updates: 1, Deletes: 1\t - DMS Applied\n";
         String actual = underTest.summary();
         assertEquals(expected, actual);

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/ChangeDataTotalCountsTest.java
@@ -28,9 +28,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
         assertTrue(underTest.isSuccess());
@@ -43,9 +43,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(rawInsertCount, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(dmsInsertCount, 1L, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(dmsAppliedInsertCount, 1L, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, rawInsertCount, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, dmsInsertCount, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, dmsAppliedInsertCount, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
         assertFalse(underTest.isSuccess());
@@ -58,9 +58,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, rawUpdateCount, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, dmsUpdateCount, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, dmsAppliedUpdateCount, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, rawUpdateCount, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, dmsUpdateCount, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, dmsAppliedUpdateCount, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
         assertFalse(underTest.isSuccess());
@@ -73,9 +73,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, rawDeleteCount));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, dmsDeleteCount));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, dmsAppliedDeleteCount));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, rawDeleteCount));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, dmsDeleteCount));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, dmsAppliedDeleteCount));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
         assertFalse(underTest.isSuccess());
@@ -87,9 +87,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put("different table", new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put("different table", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
         assertFalse(underTest.isSuccess());
@@ -101,9 +101,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedCounts.put("different table", new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedCounts.put("different table", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
         assertFalse(underTest.isSuccess());
@@ -115,9 +115,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
 
@@ -137,9 +137,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 2L, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 3L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 2L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 3L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
 
@@ -159,9 +159,9 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put("different table", new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put("different table", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
 
@@ -186,10 +186,10 @@ class ChangeDataTotalCountsTest {
         Map<String, ChangeDataTableCount> dmsCounts = new HashMap<>();
         Map<String, ChangeDataTableCount> dmsAppliedCounts = new HashMap<>();
 
-        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        rawCounts.put("table2", new ChangeDataTableCount(1L, 1L, 1L));
-        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(1L, 1L, 1L));
-        dmsAppliedCounts.put("different table", new ChangeDataTableCount(1L, 1L, 1L));
+        rawCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        rawCounts.put("table2", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsCounts.put(TABLE_NAME, new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        dmsAppliedCounts.put("different table", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
 
         ChangeDataTotalCounts underTest = new ChangeDataTotalCounts(rawCounts, dmsCounts, dmsAppliedCounts);
 

--- a/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/datareconciliation/model/DataReconciliationResultsTest.java
@@ -25,8 +25,8 @@ class DataReconciliationResultsTest {
     static void setUpSharedTestData() {
         matchingCurrentStateTotalCounts.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 1L, 1L));
         notMatchingCurrentStateTotalCounts.put("table1", new CurrentStateTableCount(0.0, 0L, 1L, 2L, 3L));
-        changeDataTableCountMap1.put("table1", new ChangeDataTableCount(1L, 1L, 1L));
-        changeDataTableCountMap2.put("table1", new ChangeDataTableCount(1L, 2L, 1L));
+        changeDataTableCountMap1.put("table1", new ChangeDataTableCount(0.0, 0L, 1L, 1L, 1L));
+        changeDataTableCountMap2.put("table1", new ChangeDataTableCount(0.0, 0L, 1L, 2L, 1L));
     }
 
     @Test


### PR DESCRIPTION
Adds configurable tolerance for the change data counts reconciliation check. For background see https://github.com/ministryofjustice/digital-prison-reporting-jobs/pull/358 for details of how tolerance works in the context of another data reconciliation check