### PR TITLE
DPR2-1684: Ignore already archived files

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -35,6 +35,7 @@ import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST
 import static uk.gov.justice.digital.config.JobArguments.RECONCILIATION_CHECKS_TO_RUN_DEFAULT;
 import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_RAW_FILE_RETENTION_PERIOD_AMOUNT;
+import static uk.gov.justice.digital.config.JobArguments.DEFAULT_ARCHIVED_FILES_CHECK_PERIOD_AMOUNT;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CHANGE_DATA_COUNTS;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.CURRENT_STATE_COUNTS;
 import static uk.gov.justice.digital.service.datareconciliation.model.ReconciliationCheck.PRIMARY_KEY_RECONCILIATION;
@@ -401,6 +402,59 @@ class JobArgumentsIntegrationTest {
         args.put(JobArguments.RAW_FILE_RETENTION_PERIOD_UNIT, unsupportedUnit);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertThrows(IllegalArgumentException.class, jobArguments::getRawFileRetentionPeriod);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "1, 1", "0, 0", "12345, 12345", "0123, 123" })
+    public void shouldGetArchivedFilesCheckPeriodInDaysWhenNoUnitIsProvided(String input, long expected) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.put(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_AMOUNT, input);
+        args.remove(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_UNIT);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(Duration.of(expected, ChronoUnit.DAYS), jobArguments.getArchivedFilesCheckDuration());
+    }
+
+    @Test
+    public void shouldDefaultArchivedFilesCheckPeriodToTwoDays() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_AMOUNT);
+        args.remove(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_UNIT);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(Duration.of(2L, ChronoUnit.DAYS), jobArguments.getArchivedFilesCheckDuration());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "minutes", "hours", "days" })
+    public void shouldGetArchivedFilesCheckPeriodInTheProvidedUnit(String durationUnit) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_AMOUNT);
+        args.put(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_UNIT, durationUnit);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(Duration.of(DEFAULT_ARCHIVED_FILES_CHECK_PERIOD_AMOUNT, ChronoUnit.valueOf(durationUnit.toUpperCase())), jobArguments.getArchivedFilesCheckDuration());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "nanos",
+            "micros",
+            "millis",
+            "seconds",
+            "HalfDays",
+            "Weeks",
+            "Months",
+            "Years",
+            "Decades",
+            "Centuries",
+            "Millennia",
+            "Eras",
+            "Forever"
+    })
+    public void shouldFailToGetArchivedFilesCheckPeriodWhenGivenUnsupportedUnit(String unsupportedUnit) {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_AMOUNT);
+        args.put(JobArguments.ARCHIVED_FILES_CHECK_PERIOD_UNIT, unsupportedUnit);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertThrows(IllegalArgumentException.class, jobArguments::getArchivedFilesCheckDuration);
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3ObjectClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3ObjectClient.java
@@ -6,7 +6,8 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.justice.digital.common.ListObjectsConfig;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
+import uk.gov.justice.digital.datahub.model.ListObjectsConfig;
 import uk.gov.justice.digital.config.JobArguments;
 
 import javax.inject.Inject;
@@ -33,7 +34,7 @@ public class S3ObjectClient {
         this.maxObjectsPerPage = jobArguments.getMaxObjectsPerPage();
     }
 
-    public List<String> getObjectsOlderThan(
+    public List<FileLastModifiedDate> getObjectsOlderThan(
             String bucket,
             String folder,
             Pattern fileNameMatchRegex,
@@ -45,7 +46,7 @@ public class S3ObjectClient {
         return listObjects(fileNameMatchRegex, listObjectConfig, clock, request);
     }
 
-    public List<String> getObjectsNewerThan(
+    public List<FileLastModifiedDate> getObjectsNewerThan(
             String bucket,
             String folder,
             Pattern fileNameMatchRegex,
@@ -57,8 +58,8 @@ public class S3ObjectClient {
         return listObjects(fileNameMatchRegex, listObjectConfig, clock, request);
     }
 
-    private List<String> listObjects(Pattern fileNameMatchRegex, ListObjectsConfig config, Clock clock, ListObjectsRequest request) {
-        List<String> objectPaths = new LinkedList<>();
+    private List<FileLastModifiedDate> listObjects(Pattern fileNameMatchRegex, ListObjectsConfig config, Clock clock, ListObjectsRequest request) {
+        List<FileLastModifiedDate> objectPaths = new LinkedList<>();
         ObjectListing objectList;
         do {
             objectList = s3.listObjects(request);
@@ -74,7 +75,7 @@ public class S3ObjectClient {
                 if (!summaryKey.endsWith(DELIMITER) && fileNameMatches) {
                     if (config.isWithinPeriod(lastModifiedDateTime)) {
                         logger.debug("Adding {}", summaryKey);
-                        objectPaths.add(summaryKey);
+                        objectPaths.add(new FileLastModifiedDate(summaryKey, lastModifiedDateTime));
                     } else if (config.exitWhenOutsidePeriod()) {
                         // The CDC files are ordered by their modified date-time.
                         // When listing objects which occur later than the given date-time we can exit on encountering the first item with an earlier date-time

--- a/src/main/java/uk/gov/justice/digital/client/s3/S3ObjectClient.java
+++ b/src/main/java/uk/gov/justice/digital/client/s3/S3ObjectClient.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.common.ListObjectsConfig;
 import uk.gov.justice.digital.config.JobArguments;
 
 import javax.inject.Inject;
@@ -32,24 +33,31 @@ public class S3ObjectClient {
         this.maxObjectsPerPage = jobArguments.getMaxObjectsPerPage();
     }
 
-    public List<String> getObjectsOlderThan(String bucket, Pattern fileNameRegex, Duration retentionPeriod, Clock clock) {
-        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withMaxKeys(maxObjectsPerPage);
-        return listObjects(fileNameRegex, retentionPeriod, clock, request);
-    }
-
     public List<String> getObjectsOlderThan(
             String bucket,
             String folder,
             Pattern fileNameMatchRegex,
-            Duration retentionPeriod,
+            Duration period,
             Clock clock
     ) {
         ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withPrefix(folder).withMaxKeys(maxObjectsPerPage);
-        return listObjects(fileNameMatchRegex, retentionPeriod, clock, request);
+        ListObjectsConfig listObjectConfig = new ListObjectsConfig(ListObjectsConfig.ObjectModifiedDateTime.EARLIER, period, clock);
+        return listObjects(fileNameMatchRegex, listObjectConfig, clock, request);
     }
 
-    private List<String> listObjects(Pattern fileNameMatchRegex, Duration retentionPeriod, Clock clock, ListObjectsRequest request) {
-        LocalDateTime currentDate = LocalDateTime.now(clock);
+    public List<String> getObjectsNewerThan(
+            String bucket,
+            String folder,
+            Pattern fileNameMatchRegex,
+            Duration period,
+            Clock clock
+    ) {
+        ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucket).withPrefix(folder).withMaxKeys(maxObjectsPerPage);
+        ListObjectsConfig listObjectConfig = new ListObjectsConfig(ListObjectsConfig.ObjectModifiedDateTime.ON_OR_LATER, period, clock);
+        return listObjects(fileNameMatchRegex, listObjectConfig, clock, request);
+    }
+
+    private List<String> listObjects(Pattern fileNameMatchRegex, ListObjectsConfig config, Clock clock, ListObjectsRequest request) {
         List<String> objectPaths = new LinkedList<>();
         ObjectListing objectList;
         do {
@@ -58,17 +66,22 @@ public class S3ObjectClient {
             logger.info("Listed a total of {} objects", objectSummaries.size());
             for (S3ObjectSummary summary : objectSummaries) {
 
-                LocalDateTime lastModifiedDate = summary.getLastModified().toInstant().atZone(clock.getZone()).toLocalDateTime();
-                boolean isBeforeRetentionPeriod = lastModifiedDate.isBefore(currentDate.minus(retentionPeriod));
-
                 String summaryKey = summary.getKey();
                 logger.debug("Listed {}", summaryKey);
 
                 boolean fileNameMatches = fileNameMatchRegex.matcher(summaryKey).matches();
-
-                if (!summaryKey.endsWith(DELIMITER) && fileNameMatches && isBeforeRetentionPeriod) {
-                    logger.debug("Adding {}", summaryKey);
-                    objectPaths.add(summaryKey);
+                LocalDateTime lastModifiedDateTime = summary.getLastModified().toInstant().atZone(clock.getZone()).toLocalDateTime();
+                if (!summaryKey.endsWith(DELIMITER) && fileNameMatches) {
+                    if (config.isWithinPeriod(lastModifiedDateTime)) {
+                        logger.debug("Adding {}", summaryKey);
+                        objectPaths.add(summaryKey);
+                    } else if (config.exitWhenOutsidePeriod()) {
+                        // The CDC files are ordered by their modified date-time.
+                        // When listing objects which occur later than the given date-time we can exit on encountering the first item with an earlier date-time
+                        // This avoids searching though all the items.
+                        logger.debug("Exiting on encountering file {} which is outside period of interest", summaryKey);
+                        return objectPaths;
+                    }
                 }
             }
             request.setMarker(objectList.getNextMarker());
@@ -78,7 +91,7 @@ public class S3ObjectClient {
     }
 
     public void copyObject(String sourceKey, String destinationKey, String sourceBucket, String destinationBucket) {
-        logger.info("Copying {}", sourceKey);
+        logger.info("Copying {} to {}", sourceKey, destinationKey);
         s3.copyObject(sourceBucket, sourceKey, destinationBucket, destinationKey);
     }
 

--- a/src/main/java/uk/gov/justice/digital/common/ListObjectsConfig.java
+++ b/src/main/java/uk/gov/justice/digital/common/ListObjectsConfig.java
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.common;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public class ListObjectsConfig {
+
+    public enum ObjectModifiedDateTime {
+        EARLIER,
+        LATER,
+        ON_OR_EARLIER,
+        ON_OR_LATER
+    }
+
+    public final Duration period;
+    public final ObjectModifiedDateTime objectModifiedDateTime;
+    public final Clock clock;
+
+    public ListObjectsConfig(ObjectModifiedDateTime objectModifiedDateTime, Duration period, Clock clock) {
+        this.objectModifiedDateTime = objectModifiedDateTime;
+        this.period = period;
+        this.clock = clock;
+    }
+
+    public boolean isWithinPeriod(LocalDateTime modifiedDateTime) {
+        LocalDateTime currentDateTime = LocalDateTime.now(clock);
+        switch (this.objectModifiedDateTime) {
+            case EARLIER:
+                return modifiedDateTime.isBefore(currentDateTime.minus(period));
+            case LATER:
+                return modifiedDateTime.isAfter(currentDateTime.minus(period));
+            case ON_OR_LATER:
+                return modifiedDateTime.isEqual(currentDateTime.minus(period)) || modifiedDateTime.isAfter(currentDateTime.minus(period));
+            case ON_OR_EARLIER:
+                return modifiedDateTime.isEqual(currentDateTime.minus(period)) || modifiedDateTime.isBefore(currentDateTime.minus(period));
+        }
+        return false;
+    }
+
+    public boolean exitWhenOutsidePeriod() {
+        return this.objectModifiedDateTime == ObjectModifiedDateTime.LATER || this.objectModifiedDateTime == ObjectModifiedDateTime.ON_OR_LATER;
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -175,6 +175,11 @@ public class JobArguments {
     public static final String RAW_FILE_RETENTION_PERIOD_UNIT = "dpr.raw.file.retention.period.unit";
     static final String DEFAULT_RAW_FILE_RETENTION_PERIOD_UNIT = "days";
 
+    public static final String ARCHIVED_FILES_CHECK_PERIOD_AMOUNT = "dpr.archived.files.check.period.amount";
+    public static final Long DEFAULT_ARCHIVED_FILES_CHECK_PERIOD_AMOUNT = 2L;
+    public static final String ARCHIVED_FILES_CHECK_PERIOD_UNIT = "dpr.archived.files.check.period.unit";
+    static final String DEFAULT_ARCHIVED_FILES_CHECK_PERIOD_UNIT = "days";
+
     private final Map<String, String> config;
 
     @Inject
@@ -414,14 +419,21 @@ public class JobArguments {
         long retentionAmount = getArgument(FILE_TRANSFER_RETENTION_PERIOD_AMOUNT, DEFAULT_FILE_TRANSFER_RETENTION_PERIOD_AMOUNT);
         String retentionUnit = getArgument(FILE_TRANSFER_RETENTION_PERIOD_UNIT, DEFAULT_FILE_TRANSFER_RETENTION_PERIOD_UNIT);
 
-        return getRetentionPeriod(retentionUnit, retentionAmount, FILE_TRANSFER_RETENTION_PERIOD_UNIT);
+        return convertToPeriod(retentionUnit, retentionAmount, FILE_TRANSFER_RETENTION_PERIOD_UNIT);
     }
 
     public Duration getRawFileRetentionPeriod() {
         long retentionAmount = getArgument(RAW_FILE_RETENTION_PERIOD_AMOUNT, DEFAULT_RAW_FILE_RETENTION_PERIOD_AMOUNT);
         String retentionUnit = getArgument(RAW_FILE_RETENTION_PERIOD_UNIT, DEFAULT_RAW_FILE_RETENTION_PERIOD_UNIT);
 
-        return getRetentionPeriod(retentionUnit, retentionAmount, RAW_FILE_RETENTION_PERIOD_UNIT);
+        return convertToPeriod(retentionUnit, retentionAmount, RAW_FILE_RETENTION_PERIOD_UNIT);
+    }
+
+    public Duration getArchivedFilesCheckDuration() {
+        long archivePeriodAmount = getArgument(ARCHIVED_FILES_CHECK_PERIOD_AMOUNT, DEFAULT_ARCHIVED_FILES_CHECK_PERIOD_AMOUNT);
+        String archivePeriodUnit = getArgument(ARCHIVED_FILES_CHECK_PERIOD_UNIT, DEFAULT_ARCHIVED_FILES_CHECK_PERIOD_UNIT);
+
+        return convertToPeriod(archivePeriodUnit, archivePeriodAmount, ARCHIVED_FILES_CHECK_PERIOD_UNIT);
     }
 
     public boolean getFileTransferDeleteCopiedFilesFlag() {
@@ -651,7 +663,7 @@ public class JobArguments {
         return prefix;
     }
 
-    private static Duration getRetentionPeriod(String retentionUnit, long retentionAmount, String argumentKey) {
+    private static Duration convertToPeriod(String retentionUnit, long retentionAmount, String argumentKey) {
         switch (retentionUnit.toLowerCase()) {
             case "minutes":
                 return Duration.of(retentionAmount, ChronoUnit.MINUTES);

--- a/src/main/java/uk/gov/justice/digital/datahub/model/FileLastModifiedDate.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/FileLastModifiedDate.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.datahub.model;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+public class FileLastModifiedDate {
+
+    public final String key;
+    public final LocalDateTime lastModifiedDateTime;
+
+    public FileLastModifiedDate(String key, LocalDateTime lastModifiedDateTime) {
+        this.key = key;
+        this.lastModifiedDateTime = lastModifiedDateTime;
+    }
+
+    public FileLastModifiedDate(String key) {
+        this.key = key;
+        this.lastModifiedDateTime = LocalDateTime.now(Clock.systemUTC());
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/datahub/model/ListObjectsConfig.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/ListObjectsConfig.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.common;
+package uk.gov.justice.digital.datahub.model;
 
 import java.time.Clock;
 import java.time.Duration;

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -68,7 +68,7 @@ public class S3DataDeletionJob implements Runnable {
 
         for (String bucketToDeleteFilesFrom : bucketsToDeleteFilesFrom) {
             List<String> listedFiles = s3FileService
-                    .listFilesForConfig(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedFileNameRegex, Duration.ZERO);
+                    .listFilesBeforePeriod(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedFileNameRegex, Duration.ZERO);
 
             logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
             failedObjects = s3FileService.deleteObjects(listedFiles, bucketToDeleteFilesFrom);

--- a/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3DataDeletionJob.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Job that deletes s3 files from a list of bucket(s).
@@ -68,9 +69,12 @@ public class S3DataDeletionJob implements Runnable {
 
         for (String bucketToDeleteFilesFrom : bucketsToDeleteFilesFrom) {
             List<String> listedFiles = s3FileService
-                    .listFilesBeforePeriod(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedFileNameRegex, Duration.ZERO);
+                    .listFilesBeforePeriod(bucketToDeleteFilesFrom, sourcePrefix, configuredTables, allowedFileNameRegex, Duration.ZERO)
+                    .stream()
+                    .map(x -> x.key)
+                    .collect(Collectors.toList());
 
-            logger.info("Deleting S3 objects from {} ", bucketToDeleteFilesFrom);
+            logger.info("Deleting S3 objects from {}", bucketToDeleteFilesFrom);
             failedObjects = s3FileService.deleteObjects(listedFiles, bucketToDeleteFilesFrom);
         }
 

--- a/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
@@ -72,7 +72,7 @@ public class S3FileTransferJob implements Runnable {
             // When config is provided, only files belonging to the configured tables are archived
             ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                     .getConfiguredTables(optionalConfigKey.get());
-            objectKeys.addAll(s3FileService.listFilesForConfig(sourceBucket, sourcePrefix, configuredTables, allowedFileNameRegex, retentionPeriod));
+            objectKeys.addAll(s3FileService.listFilesBeforePeriod(sourceBucket, sourcePrefix, configuredTables, allowedFileNameRegex, retentionPeriod));
         } else {
             // When no config is provided, all files in s3 bucket are archived
             logger.info("Listing files in S3 source location: {}", sourceBucket);

--- a/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/S3FileTransferJob.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Job that moves/copies s3 files from a source bucket to a destination bucket.
@@ -72,11 +73,19 @@ public class S3FileTransferJob implements Runnable {
             // When config is provided, only files belonging to the configured tables are archived
             ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                     .getConfiguredTables(optionalConfigKey.get());
-            objectKeys.addAll(s3FileService.listFilesBeforePeriod(sourceBucket, sourcePrefix, configuredTables, allowedFileNameRegex, retentionPeriod));
+            List<String> fileKeys = s3FileService.listFilesBeforePeriod(sourceBucket, sourcePrefix, configuredTables, allowedFileNameRegex, retentionPeriod)
+                    .stream()
+                    .map(x -> x.key)
+                    .collect(Collectors.toList());
+            objectKeys.addAll(fileKeys);
         } else {
             // When no config is provided, all files in s3 bucket are archived
             logger.info("Listing files in S3 source location: {}", sourceBucket);
-            objectKeys.addAll(s3FileService.listFiles(sourceBucket, sourcePrefix, allowedFileNameRegex, retentionPeriod));
+            List<String> fileKeys = s3FileService.listFiles(sourceBucket, sourcePrefix, allowedFileNameRegex, retentionPeriod)
+                    .stream()
+                    .map(x -> x.key)
+                    .collect(Collectors.toList());
+            objectKeys.addAll(fileKeys);
         }
 
         logger.info("Processing S3 objects older than {} from {} to {}", retentionPeriod, sourceBucket, destinationBucket);

--- a/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
@@ -101,7 +101,7 @@ public class UnprocessedRawFilesCheckJob implements Runnable {
 
         logger.info("Listing files in raw bucket");
         List<String> rawFiles = s3FileService
-                .listFilesForConfig(rawBucket, "", configuredTables, fileNameRegex, Duration.ZERO);
+                .listFilesBeforePeriod(rawBucket, "", configuredTables, fileNameRegex, Duration.ZERO);
 
         return committedFiles.containsAll(rawFiles);
     }

--- a/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJob.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Job that checks if all raw files have been processed.
@@ -101,7 +102,10 @@ public class UnprocessedRawFilesCheckJob implements Runnable {
 
         logger.info("Listing files in raw bucket");
         List<String> rawFiles = s3FileService
-                .listFilesBeforePeriod(rawBucket, "", configuredTables, fileNameRegex, Duration.ZERO);
+                .listFilesBeforePeriod(rawBucket, "", configuredTables, fileNameRegex, Duration.ZERO)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         return committedFiles.containsAll(rawFiles);
     }

--- a/src/main/java/uk/gov/justice/digital/service/CheckpointReaderService.java
+++ b/src/main/java/uk/gov/justice/digital/service/CheckpointReaderService.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.client.s3.S3CheckpointReaderClient;
 import uk.gov.justice.digital.client.s3.S3ObjectClient;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -51,7 +52,7 @@ public class CheckpointReaderService {
             String checkpointPath = getQueryCheckpointPath(matcher.group(2), configuredTable.left, configuredTable.right) + "/sources/0/";
 
             logger.info("Reading committed files from {}", checkpointPath);
-            List<String> checkpointFiles = s3ObjectClient.getObjectsOlderThan(
+            List<FileLastModifiedDate> checkpointFiles = s3ObjectClient.getObjectsOlderThan(
                     checkpointBucket,
                     checkpointPath,
                     matchAllFiles,

--- a/src/main/java/uk/gov/justice/digital/service/S3FileService.java
+++ b/src/main/java/uk/gov/justice/digital/service/S3FileService.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.client.s3.S3ObjectClient;
 import uk.gov.justice.digital.common.retry.RetryConfig;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -32,7 +33,7 @@ public class S3FileService {
     private final S3ObjectClient s3Client;
     private final Clock clock;
     private final RetryPolicy<Void> voidRetryPolicy;
-    private final RetryPolicy<List<String>> retryPolicy;
+    private final RetryPolicy<List<FileLastModifiedDate>> retryPolicy;
 
     @Inject
     public S3FileService(
@@ -47,11 +48,11 @@ public class S3FileService {
         this.retryPolicy = buildRetryPolicy(retryConfig, AmazonS3Exception.class);
     }
 
-    public List<String> listFiles(String bucket, String sourcePrefix, Pattern fileNameMatchRegex, Duration retentionPeriod) {
+    public List<FileLastModifiedDate> listFiles(String bucket, String sourcePrefix, Pattern fileNameMatchRegex, Duration retentionPeriod) {
         return Failsafe.with(retryPolicy).get(() -> s3Client.getObjectsOlderThan(bucket, sourcePrefix, fileNameMatchRegex, retentionPeriod, clock));
     }
 
-    public List<String> listFilesBeforePeriod(
+    public List<FileLastModifiedDate> listFilesBeforePeriod(
             String sourceBucket,
             String sourcePrefix,
             ImmutableSet<ImmutablePair<String, String>> configuredTables,
@@ -63,7 +64,7 @@ public class S3FileService {
                 .collect(Collectors.toList());
     }
 
-    public List<String> listFilesAfterPeriod(
+    public List<FileLastModifiedDate> listFilesAfterPeriod(
             String sourceBucket,
             String sourcePrefix,
             ImmutableSet<ImmutablePair<String, String>> configuredTables,
@@ -124,7 +125,7 @@ public class S3FileService {
         return failedObjects;
     }
 
-    private List<String> listFilesBeforePeriod(
+    private List<FileLastModifiedDate> listFilesBeforePeriod(
             String sourceBucket,
             String sourcePrefix,
             Pattern fileNameMatchRegex,
@@ -144,7 +145,7 @@ public class S3FileService {
         ));
     }
 
-    private List<String> listFilesAfterPeriod(
+    private List<FileLastModifiedDate> listFilesAfterPeriod(
             String sourceBucket,
             String sourcePrefix,
             Pattern fileNameMatchRegex,

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3CheckpointReaderClientTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -49,10 +50,10 @@ class S3CheckpointReaderClientTest {
 
     @Test
     void shouldRetrieveCommittedFilesFromCheckpointFiles() {
-        List<String> checkpointFiles = new ArrayList<>();
-        checkpointFiles.add("checkpoint-path/2");
-        checkpointFiles.add("checkpoint-path/1");
-        checkpointFiles.add("checkpoint-path/0.compact");
+        List<FileLastModifiedDate> checkpointFiles = new ArrayList<>();
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/2"));
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/1"));
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/0.compact"));
 
         when(mockS3Client.getObjectAsString(CHECKPOINT_BUCKET, "checkpoint-path/2")).thenReturn(CHECKPOINT_FILE_2);
         when(mockS3Client.getObjectAsString(CHECKPOINT_BUCKET, "checkpoint-path/1")).thenReturn(CHECKPOINT_FILE_1);
@@ -73,9 +74,9 @@ class S3CheckpointReaderClientTest {
 
     @Test
     void shouldIgnoreTempFilesFromCheckpointFilesList() {
-        List<String> checkpointFiles = new ArrayList<>();
-        checkpointFiles.add("checkpoint-path/2");
-        checkpointFiles.add("checkpoint-path/0.tmp");
+        List<FileLastModifiedDate> checkpointFiles = new ArrayList<>();
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/2"));
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/0.tmp"));
 
         when(mockS3Client.getObjectAsString(CHECKPOINT_BUCKET, "checkpoint-path/2")).thenReturn(CHECKPOINT_FILE_2);
 
@@ -91,11 +92,11 @@ class S3CheckpointReaderClientTest {
 
     @Test
     void shouldIgnoreCheckpointFilesWithNameHavingLowerNaturalOrderThanTheMostRecentCompactFile() {
-        List<String> checkpointFiles = new ArrayList<>();
-        checkpointFiles.add("checkpoint-path/0"); // this file has name with lower natural order than the compact file and will be ignored
-        checkpointFiles.add("checkpoint-path/8");
-        checkpointFiles.add("checkpoint-path/9.compact");
-        checkpointFiles.add("checkpoint-path/10"); // 10 is after 9.compact and should also be processed
+        List<FileLastModifiedDate> checkpointFiles = new ArrayList<>();
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/0")); // this file has name with lower natural order than the compact file and will be ignored
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/8"));
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/9.compact"));
+        checkpointFiles.add(new FileLastModifiedDate("checkpoint-path/10")); // 10 is after 9.compact and should also be processed
 
         when(mockS3Client.getObjectAsString(CHECKPOINT_BUCKET, "checkpoint-path/10")).thenReturn(CHECKPOINT_FILE_2);
         when(mockS3Client.getObjectAsString(CHECKPOINT_BUCKET, "checkpoint-path/9.compact")).thenReturn(CHECKPOINT_FILE_1);

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3ClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3ClientTest.java
@@ -61,6 +61,7 @@ class S3ClientTest {
     private static final Duration oneHourPeriod = Duration.of(1L, ChronoUnit.HOURS);
 
     private S3ObjectClient underTest;
+
     @BeforeEach
     public void setUp() {
         reset(mockS3ClientProvider, mockS3Client, mockObjectListing, mockJobArgs);
@@ -119,7 +120,10 @@ class S3ClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
@@ -155,7 +159,10 @@ class S3ClientTest {
 
         givenMultiPageObjectListingSucceeds(firstPageSummaries, secondPageSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, parquetFileRegex, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, parquetFileRegex, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
@@ -187,7 +194,10 @@ class S3ClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, matchAllFiles, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, matchAllFiles, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
@@ -222,7 +232,10 @@ class S3ClientTest {
 
         givenObjectListingSucceeds(allObjectSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
@@ -249,7 +262,10 @@ class S3ClientTest {
         lastModifiedDate.setTime(fixedDateTime.plusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
@@ -285,7 +301,10 @@ class S3ClientTest {
 
         givenMultiPageObjectListingSucceeds(firstPageSummaries, secondPageSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, parquetFileRegex, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, parquetFileRegex, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
@@ -317,7 +336,10 @@ class S3ClientTest {
         lastModifiedDate.setTime(fixedDateTime.plusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, matchAllFiles, zeroDayPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, matchAllFiles, zeroDayPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
@@ -354,7 +376,10 @@ class S3ClientTest {
         when(mockObjectListing.getObjectSummaries()).thenReturn(allObjectSummaries);
         when(mockS3Client.listObjects(listObjectsRequestCaptor.capture())).thenReturn(mockObjectListing);
 
-        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, oneHourPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, oneHourPeriod, fixedClock)
+                .stream()
+                .map(x -> x.key)
+                .collect(Collectors.toList());
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));

--- a/src/test/java/uk/gov/justice/digital/client/s3/S3ClientTest.java
+++ b/src/test/java/uk/gov/justice/digital/client/s3/S3ClientTest.java
@@ -38,7 +38,7 @@ import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static uk.gov.justice.digital.common.RegexPatterns.jsonOrParquetFileRegex;
 
 @ExtendWith(MockitoExtension.class)
-public class S3FileTransferClientTest {
+class S3ClientTest {
 
     @Mock
     S3ClientProvider mockS3ClientProvider;
@@ -55,8 +55,10 @@ public class S3FileTransferClientTest {
     private static final String DESTINATION_KEY = "test-destination-key";
     private static final String SOURCE_BUCKET = "test-source-bucket";
     private static final String DESTINATION_BUCKET = "test-destination-bucket";
+    private static final String TEST_FOLDER = "test-folder";
     private static final Integer MAX_OBJECTS_PER_PAGE = 10;
-    private static final Duration zeroDayRetentionPeriod = Duration.of(0L, ChronoUnit.DAYS);
+    private static final Duration zeroDayPeriod = Duration.of(0L, ChronoUnit.DAYS);
+    private static final Duration oneHourPeriod = Duration.of(1L, ChronoUnit.HOURS);
 
     private S3ObjectClient underTest;
     @BeforeEach
@@ -69,35 +71,35 @@ public class S3FileTransferClientTest {
     }
 
     @Test
-    public void copyObjectShouldDeleteObjects() {
+    void copyObjectShouldDeleteObjects() {
         underTest.copyObject(SOURCE_KEY, DESTINATION_KEY, SOURCE_BUCKET, DESTINATION_BUCKET);
 
         verify(mockS3Client, times(1)).copyObject(SOURCE_BUCKET, SOURCE_KEY, DESTINATION_BUCKET, DESTINATION_KEY);
     }
 
     @Test
-    public void copyObjectShouldFailWhenClientThrowsAnException() {
+    void copyObjectShouldFailWhenClientThrowsAnException() {
         doThrow(new RuntimeException("client exception")).when(mockS3Client).copyObject(any(), any(), any(), any());
 
         assertThrows(RuntimeException.class, () -> underTest.copyObject(SOURCE_KEY, DESTINATION_KEY, SOURCE_BUCKET, DESTINATION_BUCKET));
     }
 
     @Test
-    public void deleteObjectShouldDeleteObjects() {
+    void deleteObjectShouldDeleteObjects() {
         underTest.deleteObject(SOURCE_KEY, SOURCE_BUCKET);
 
         verify(mockS3Client, times(1)).deleteObject(SOURCE_BUCKET, SOURCE_KEY);
     }
 
     @Test
-    public void deleteObjectShouldFailWhenClientThrowsAnException() {
+    void deleteObjectShouldFailWhenClientThrowsAnException() {
         doThrow(new RuntimeException("client exception")).when(mockS3Client).deleteObject(any(), any());
 
         assertThrows(RuntimeException.class, () -> underTest.deleteObject(SOURCE_KEY, SOURCE_BUCKET));
     }
 
     @Test
-    public void getObjectsOlderThanShouldReturnListOfObjectsMatchingAllowedExtensions() {
+    void getObjectsOlderThanShouldReturnListOfObjectsMatchingAllowedExtensionsWithinGivenFolderPrefix() {
         ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
                 ImmutablePair.of("file1", ".txt"),
                 ImmutablePair.of("file2", ".parquet"),
@@ -117,16 +119,17 @@ public class S3FileTransferClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, jsonOrParquetFileRegex, zeroDayRetentionPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock);
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(listObjectsRequest.getMaxKeys(), is(equalTo(MAX_OBJECTS_PER_PAGE)));
+        assertThat(listObjectsRequest.getPrefix(), is(equalTo(TEST_FOLDER)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
     }
 
     @Test
-    public void getObjectsOlderThanShouldReturnListOfObjectsMatchingAllowedExtensionsWhenObjectsListExceedsOnePage() {
+    void getObjectsOlderThanShouldReturnListOfObjectsMatchingAllowedExtensionsWhenObjectsListExceedsOnePage() {
         ImmutableSet<ImmutablePair<String, String>> firstSetOfObjectKeys = ImmutableSet.of(
                 ImmutablePair.of("file1", ".txt"),
                 ImmutablePair.of("file2", ".parquet"),
@@ -152,16 +155,17 @@ public class S3FileTransferClientTest {
 
         givenMultiPageObjectListingSucceeds(firstPageSummaries, secondPageSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, parquetFileRegex, zeroDayRetentionPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, parquetFileRegex, zeroDayPeriod, fixedClock);
 
         ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
         assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(listObjectsRequest.getMaxKeys(), is(equalTo(MAX_OBJECTS_PER_PAGE)));
+        assertThat(listObjectsRequest.getPrefix(), is(equalTo(TEST_FOLDER)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
     }
 
     @Test
-    public void getObjectsOlderThanShouldReturnListOfAllObjectsWhenGivenWildCardExtension() {
+    void getObjectsOlderThanShouldReturnListOfAllObjectsWhenGivenWildCardExtension() {
         ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
                 ImmutablePair.of("file1", ".txt"),
                 ImmutablePair.of("file2", ".parquet"),
@@ -183,14 +187,14 @@ public class S3FileTransferClientTest {
         lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, matchAllFiles, zeroDayRetentionPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, matchAllFiles, zeroDayPeriod, fixedClock);
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
     }
 
     @Test
-    public void getObjectsOlderThanShouldReturnListOfObjectsOlderThanSpecifiedNumberOfRetentionDays() {
+    void getObjectsOlderThanShouldReturnListOfObjectsOlderThanSpecifiedPeriod() {
         ImmutableSet<ImmutablePair<String, String>> recentObjectKeys = ImmutableSet.of(
                 ImmutablePair.of("file1", ".parquet"),
                 ImmutablePair.of("file2", ".parquet"),
@@ -218,30 +222,142 @@ public class S3FileTransferClientTest {
 
         givenObjectListingSucceeds(allObjectSummaries);
 
-        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, jsonOrParquetFileRegex, zeroDayRetentionPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsOlderThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock);
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
         assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
     }
 
     @Test
-    public void getObjectsOlderThanShouldListObjectsWithinGivenFolderPrefix() {
-        String folder = "test-folder";
-
+    void getObjectsNewerThanShouldReturnListOfObjectsMatchingAllowedExtensionsWithinGivenFolderPrefix() {
         ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
-                ImmutablePair.of("file1", ".parquet"),
+                ImmutablePair.of("file1", ".txt"),
                 ImmutablePair.of("file2", ".parquet"),
-                ImmutablePair.of("file6", ".parquet")
+                ImmutablePair.of("file3", ".json"),
+                ImmutablePair.of("file4", ".jpg"),
+                ImmutablePair.of("file5", ".JSON"),
+                ImmutablePair.of("file6", ".PARQUET")
         );
 
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file2.parquet");
+        expectedObjectKeys.add("file6.PARQUET");
+        expectedObjectKeys.add("file3.json");
+        expectedObjectKeys.add("file5.JSON");
+
         Date lastModifiedDate = new Date();
-        lastModifiedDate.setTime(fixedDateTime.minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+        lastModifiedDate.setTime(fixedDateTime.plusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
         givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
 
-        underTest.getObjectsOlderThan(SOURCE_BUCKET, folder, jsonOrParquetFileRegex, zeroDayRetentionPeriod, fixedClock);
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, zeroDayPeriod, fixedClock);
+
+        ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
+        assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(listObjectsRequest.getMaxKeys(), is(equalTo(MAX_OBJECTS_PER_PAGE)));
+        assertThat(listObjectsRequest.getPrefix(), is(equalTo(TEST_FOLDER)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
+    }
+
+    @Test
+    void getObjectsNewerThanShouldReturnListOfObjectsMatchingAllowedExtensionsWhenObjectsListExceedsOnePage() {
+        ImmutableSet<ImmutablePair<String, String>> firstSetOfObjectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".txt"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file3", ".json"),
+                ImmutablePair.of("file6", ".PARQUET")
+        );
+
+        ImmutableSet<ImmutablePair<String, String>> secondSetOfObjectKeys = ImmutableSet.of(
+                ImmutablePair.of("file7", ".txt"),
+                ImmutablePair.of("file8", ".parquet"),
+                ImmutablePair.of("file9", ".json")
+        );
+
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file2.parquet");
+        expectedObjectKeys.add("file6.PARQUET");
+        expectedObjectKeys.add("file8.parquet");
+
+        Date lastModifiedDate = new Date();
+        lastModifiedDate.setTime(fixedDateTime.plusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+        List<S3ObjectSummary> firstPageSummaries = createObjectSummaries(firstSetOfObjectKeys, lastModifiedDate);
+        List<S3ObjectSummary> secondPageSummaries = createObjectSummaries(secondSetOfObjectKeys, lastModifiedDate);
+
+        givenMultiPageObjectListingSucceeds(firstPageSummaries, secondPageSummaries);
+
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, parquetFileRegex, zeroDayPeriod, fixedClock);
+
+        ListObjectsRequest listObjectsRequest = listObjectsRequestCaptor.getValue();
+        assertThat(listObjectsRequest.getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(listObjectsRequest.getMaxKeys(), is(equalTo(MAX_OBJECTS_PER_PAGE)));
+        assertThat(listObjectsRequest.getPrefix(), is(equalTo(TEST_FOLDER)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
+    }
+
+    @Test
+    void getObjectsNewerThanShouldReturnListOfAllObjectsWhenGivenWildCardExtension() {
+        ImmutableSet<ImmutablePair<String, String>> objectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".txt"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file3", ".json"),
+                ImmutablePair.of("file4", ".jpg"),
+                ImmutablePair.of("file5", ".JSON"),
+                ImmutablePair.of("file6", ".PARQUET")
+        );
+
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file1.txt");
+        expectedObjectKeys.add("file2.parquet");
+        expectedObjectKeys.add("file3.json");
+        expectedObjectKeys.add("file4.jpg");
+        expectedObjectKeys.add("file5.JSON");
+        expectedObjectKeys.add("file6.PARQUET");
+
+        Date lastModifiedDate = new Date();
+        lastModifiedDate.setTime(fixedDateTime.plusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+        givenObjectListingSucceeds(createObjectSummaries(objectKeys, lastModifiedDate));
+
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, matchAllFiles, zeroDayPeriod, fixedClock);
 
         assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
-        assertThat(listObjectsRequestCaptor.getValue().getPrefix(), is(equalTo(folder)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
+    }
+
+    @Test
+    void getObjectsNewerThanShouldReturnListOfObjectsNewerThanSpecifiedPeriod() {
+        ImmutableSet<ImmutablePair<String, String>> recentObjectKeys = ImmutableSet.of(
+                ImmutablePair.of("file1", ".parquet"),
+                ImmutablePair.of("file2", ".parquet"),
+                ImmutablePair.of("file3", ".parquet")
+        );
+
+        ImmutableSet<ImmutablePair<String, String>> oldObjectKeys = ImmutableSet.of(
+                ImmutablePair.of("file4", ".parquet"),
+                ImmutablePair.of("file5", ".parquet")
+        );
+
+        List<String> expectedObjectKeys = new ArrayList<>();
+        expectedObjectKeys.add("file1.parquet");
+        expectedObjectKeys.add("file2.parquet");
+        expectedObjectKeys.add("file3.parquet");
+
+        Date recentLastModifiedDate = new Date();
+        recentLastModifiedDate.setTime(fixedDateTime.minusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        Date oldLastModifiedDate = new Date();
+        oldLastModifiedDate.setTime(fixedDateTime.minusHours(1).minusNanos(1).toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        List<S3ObjectSummary> recentObjectSummaries = createObjectSummaries(recentObjectKeys, recentLastModifiedDate);
+        List<S3ObjectSummary> oldObjectSummaries = createObjectSummaries(oldObjectKeys, oldLastModifiedDate);
+        List<S3ObjectSummary> allObjectSummaries = Stream.concat(recentObjectSummaries.stream(), oldObjectSummaries.stream()).collect(Collectors.toList());
+
+        when(mockObjectListing.getObjectSummaries()).thenReturn(allObjectSummaries);
+        when(mockS3Client.listObjects(listObjectsRequestCaptor.capture())).thenReturn(mockObjectListing);
+
+        List<String> returnedObjectKeys = underTest.getObjectsNewerThan(SOURCE_BUCKET, TEST_FOLDER, jsonOrParquetFileRegex, oneHourPeriod, fixedClock);
+
+        assertThat(listObjectsRequestCaptor.getValue().getBucketName(), is(equalTo(SOURCE_BUCKET)));
+        assertThat(returnedObjectKeys, containsInAnyOrder(expectedObjectKeys.toArray()));
     }
 
     @NotNull

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 import uk.gov.justice.digital.exception.ConfigServiceException;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
@@ -22,6 +23,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -89,7 +91,7 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
                 eq(configuredTables),
                 eq(parquetFileRegex),
                 eq(Duration.ZERO)
-        )).thenReturn(objectsToDelete);
+        )).thenReturn(objectsToDelete.stream().map(FileLastModifiedDate::new).collect(Collectors.toList()));
 
         when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture()))
                 .thenReturn(Collections.emptySet());
@@ -134,7 +136,7 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
                 eq(configuredTables),
                 eq(parquetFileRegex),
                 eq(Duration.ZERO)
-        )).thenReturn(objectsToDelete);
+        )).thenReturn(objectsToDelete.stream().map(FileLastModifiedDate::new).collect(Collectors.toList()));
 
         when(mockS3FileService.deleteObjects(eq(objectsToDelete), deleteObjectsBucketCaptor.capture())).thenReturn(failedFiles);
 

--- a/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3DataDeletionJobTest.java
@@ -83,7 +83,7 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
         when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(
+        when(mockS3FileService.listFilesBeforePeriod(
                 listObjectsBucketCaptor.capture(),
                 eq(SOURCE_PREFIX),
                 eq(configuredTables),
@@ -128,7 +128,7 @@ public class S3DataDeletionJobTest extends BaseSparkTest {
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
         when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
-        when(mockS3FileService.listFilesForConfig(
+        when(mockS3FileService.listFilesBeforePeriod(
                 listObjectsBucketCaptor.capture(),
                 eq(SOURCE_PREFIX),
                 eq(configuredTables),

--- a/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 import uk.gov.justice.digital.exception.ConfigServiceException;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
@@ -22,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -85,7 +87,7 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
         when(mockS3FileService.listFilesBeforePeriod(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
-                .thenReturn(objectsToMove);
+                .thenReturn(objectsToMove.stream().map(FileLastModifiedDate::new).collect(Collectors.toList()));
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
                 .thenReturn(Collections.emptySet());
@@ -110,7 +112,7 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockJobArguments.getAllowedS3FileNameRegex()).thenReturn(parquetFileRegex);
 
         when(mockS3FileService.listFiles(SOURCE_BUCKET, SOURCE_PREFIX, parquetFileRegex, retentionPeriod))
-                .thenReturn(objectsToMove);
+                .thenReturn(objectsToMove.stream().map(FileLastModifiedDate::new).collect(Collectors.toList()));
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
                 .thenReturn(Collections.emptySet());
@@ -145,7 +147,7 @@ public class S3FileTransferJobTest extends BaseSparkTest {
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
         when(mockS3FileService.listFilesBeforePeriod(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
-                .thenReturn(objectsToMove);
+                .thenReturn(objectsToMove.stream().map(FileLastModifiedDate::new).collect(Collectors.toList()));
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
                 .thenReturn(failedFiles);

--- a/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/S3FileTransferJobTest.java
@@ -84,7 +84,7 @@ public class S3FileTransferJobTest extends BaseSparkTest {
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
+        when(mockS3FileService.listFilesBeforePeriod(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))
@@ -144,7 +144,7 @@ public class S3FileTransferJobTest extends BaseSparkTest {
 
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
 
-        when(mockS3FileService.listFilesForConfig(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
+        when(mockS3FileService.listFilesBeforePeriod(SOURCE_BUCKET, SOURCE_PREFIX, configuredTables, parquetFileRegex, retentionPeriod))
                 .thenReturn(objectsToMove);
 
         when(mockS3FileService.copyObjects(objectsToMove, SOURCE_BUCKET, SOURCE_PREFIX, DESTINATION_BUCKET, DESTINATION_PREFIX, true))

--- a/src/test/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJobTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 import uk.gov.justice.digital.service.CheckpointReaderService;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.S3FileService;
@@ -61,11 +62,11 @@ class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
         ImmutablePair<String, String> configuredTable2 = ImmutablePair.of("source", "table-2");
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(configuredTable1, configuredTable2);
 
-        List<String> rawFiles = new ArrayList<>();
-        rawFiles.add(COMMITTED_FILE_1);
-        rawFiles.add(COMMITTED_FILE_2);
-        rawFiles.add(COMMITTED_FILE_3);
-        rawFiles.add(COMMITTED_FILE_4);
+        List<FileLastModifiedDate> rawFiles = new ArrayList<>();
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_1));
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_2));
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_3));
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_4));
 
         Set<String> committedFilesTable1 = new HashSet<>();
         committedFilesTable1.add(COMMITTED_FILE_1);
@@ -96,12 +97,12 @@ class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
         ImmutablePair<String, String> configuredTable2 = ImmutablePair.of("source", "table-2");
         ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(configuredTable1, configuredTable2);
 
-        List<String> rawFiles = new ArrayList<>();
-        rawFiles.add(COMMITTED_FILE_1);
-        rawFiles.add(COMMITTED_FILE_2);
-        rawFiles.add(COMMITTED_FILE_3);
-        rawFiles.add(COMMITTED_FILE_4);
-        rawFiles.add(UNCOMMITTED_FILE);
+        List<FileLastModifiedDate> rawFiles = new ArrayList<>();
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_1));
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_2));
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_3));
+        rawFiles.add(new FileLastModifiedDate(COMMITTED_FILE_4));
+        rawFiles.add(new FileLastModifiedDate(UNCOMMITTED_FILE));
 
         Set<String> committedFilesTable1 = new HashSet<>();
         committedFilesTable1.add(COMMITTED_FILE_1);

--- a/src/test/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/UnprocessedRawFilesCheckJobTest.java
@@ -84,7 +84,7 @@ class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
         when(mockConfigService.getConfiguredTables(CONFIG_KEY)).thenReturn(configuredTables);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable1)).thenReturn(committedFilesTable1);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable2)).thenReturn(committedFilesTable2);
-        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
+        when(mockS3Service.listFilesBeforePeriod(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
                 .thenReturn(rawFiles);
 
         assertDoesNotThrow(() -> underTest.run());
@@ -120,7 +120,7 @@ class UnprocessedRawFilesCheckJobTest extends BaseSparkTest {
         when(mockConfigService.getConfiguredTables(CONFIG_KEY)).thenReturn(configuredTables);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable1)).thenReturn(committedFilesTable1);
         when(mockCheckpointReaderService.getCommittedFilesForTable(configuredTable2)).thenReturn(committedFilesTable2);
-        when(mockS3Service.listFilesForConfig(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
+        when(mockS3Service.listFilesBeforePeriod(SOURCE_BUCKET, "", configuredTables, parquetFileRegex, Duration.ZERO))
                 .thenReturn(rawFiles);
 
         assertEquals(1, SystemLambda.catchSystemExit(() -> underTest.run()));

--- a/src/test/java/uk/gov/justice/digital/service/CheckpointReaderServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/CheckpointReaderServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.s3.S3CheckpointReaderClient;
 import uk.gov.justice.digital.client.s3.S3ObjectClient;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.FileLastModifiedDate;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -72,11 +73,11 @@ class CheckpointReaderServiceTest {
         ImmutablePair<String, String> configuredTable = ImmutablePair.of("schema_1", "table_1");
         String checkpointFolder = CHECKPOINT_FOLDER + "DataHubCdcJob/Datahub_CDC_" + configuredTable.left + "." + configuredTable.right + "/sources/0/";
 
-        List<String> checkpointFiles = new ArrayList<>();
-        checkpointFiles.add(checkpointFolder + "checkpoint-file-2");
-        checkpointFiles.add(checkpointFolder + "checkpoint-file-3");
-        checkpointFiles.add(checkpointFolder + "checkpoint-file-0.compact");
-        checkpointFiles.add(checkpointFolder + "checkpoint-file-1");
+        List<FileLastModifiedDate> checkpointFiles = new ArrayList<>();
+        checkpointFiles.add(new FileLastModifiedDate(checkpointFolder + "checkpoint-file-2"));
+        checkpointFiles.add(new FileLastModifiedDate(checkpointFolder + "checkpoint-file-3"));
+        checkpointFiles.add(new FileLastModifiedDate(checkpointFolder + "checkpoint-file-0.compact"));
+        checkpointFiles.add(new FileLastModifiedDate(checkpointFolder + "checkpoint-file-1"));
 
         Set<String> expectedCommittedFiles = new HashSet<>();
         expectedCommittedFiles.add("committed-file-1");


### PR DESCRIPTION
The archive job:
1. Archives raw files which have not been previously archived
2. Deletes all raw files which have been committed to the checkpoint and are older than 2 days (configurable)

To avoid wasting cost on re-archiving already archived files, the raw files are checked to ensure they do not have an existing key in the list of most recent archived files up until the last 2 days (configurable)