### PR TITLE
DPR2-1884: Create PostgresLoadGeneratorJob

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -103,6 +103,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, "12" },
             { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, "0.01" },
             { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, "5" },
+            { JobArguments.SECRET_ID, "test_secret_id" },
             { JobArguments.ADJUST_SPARK_MEMORY, "true" },
             { JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE, "50000" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
@@ -173,6 +174,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationCurrentStateCountsToleranceAbsolute()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, Double.toString(validArguments.getReconciliationChangeDataCountsToleranceRelativePercentage()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationChangeDataCountsToleranceAbsolute()) },
+                { JobArguments.SECRET_ID, validArguments.getSecretId() },
                 { JobArguments.ADJUST_SPARK_MEMORY, validArguments.adjustSparkMemory() },
                 { JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE, Integer.toString(validArguments.getSparkSqlMaxRecordsPerFile()) },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
@@ -776,6 +778,46 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.ADJUST_SPARK_MEMORY);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertFalse(jobArguments.adjustSparkMemory());
+    }
+
+    @Test
+    void getTestDataTableNameShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.TEST_DATA_TABLE_NAME);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals("test_table", jobArguments.getTestDataTableName());
+    }
+
+    @Test
+    void getTestDataBatchSizeShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.TEST_DATA_BATCH_SIZE);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(5, jobArguments.getTestDataBatchSize());
+    }
+
+    @Test
+    void getTestDataParallelismShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.TEST_DATA_PARALLELISM);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(1, jobArguments.getTestDataParallelism());
+    }
+
+    @Test
+    void getTestDataInterBatchDelayMillisShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.TEST_DATA_INTER_BATCH_DELAY);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(1000, jobArguments.getTestDataInterBatchDelayMillis());
+    }
+
+    @Test
+    void getRunDurationMillisShouldUseDefaultWhenNotProvided() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.TEST_DATA_RUN_DURATION_MILLIS);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(3600000, jobArguments.getRunDurationMillis());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/it/java/uk/gov/justice/digital/job/generator/PostgresLoadGeneratorJobTest.java
+++ b/src/it/java/uk/gov/justice/digital/job/generator/PostgresLoadGeneratorJobTest.java
@@ -1,0 +1,155 @@
+package uk.gov.justice.digital.job.generator;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.secretsmanager.SecretsManagerClient;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.generator.PostgresSecrets;
+import uk.gov.justice.digital.test.InMemoryOperationalDataStore;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PostgresLoadGeneratorJobTest extends BaseSparkTest {
+
+    private static final InMemoryOperationalDataStore dataStore = new InMemoryOperationalDataStore();
+
+    private static final String TEST_SECRET_ID = "test-secret-id";
+    private static final String TEST_TABLE = "local_test_table";
+
+    private static Connection connection;
+
+    @Mock
+    private JobArguments mockJobArguments;
+    @Mock
+    private SecretsManagerClient mockSecretsManagerClient;
+    @Mock
+    private PostgresSecrets mockPostgresSecrets;
+
+    private PostgresLoadGeneratorJob underTest;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        dataStore.start();
+        connection = dataStore.getJdbcConnection();
+        createTable();
+    }
+
+    @AfterAll
+    static void afterAll() throws SQLException {
+        connection.close();
+        dataStore.stop();
+    }
+
+    @BeforeEach
+    public void setup() throws SQLException {
+        truncateTable();
+        reset(mockSecretsManagerClient);
+
+        when(mockJobArguments.getSecretId()).thenReturn(TEST_SECRET_ID);
+        when(mockJobArguments.getTestDataTableName()).thenReturn(TEST_TABLE);
+
+        when(mockPostgresSecrets.getJdbcUrl()).thenReturn(dataStore.getJdbcUrl());
+        when(mockPostgresSecrets.getUsername()).thenReturn(dataStore.getUsername());
+        when(mockPostgresSecrets.getPassword()).thenReturn(dataStore.getPassword());
+
+        when(mockSecretsManagerClient.getSecret(TEST_SECRET_ID, PostgresSecrets.class)).thenReturn(mockPostgresSecrets);
+
+        underTest = new PostgresLoadGeneratorJob(mockJobArguments, mockSecretsManagerClient);
+    }
+
+    @Test
+    void shouldInsertSingleRecord() throws SQLException {
+        when(mockJobArguments.getTestDataParallelism()).thenReturn(1);
+        when(mockJobArguments.getTestDataBatchSize()).thenReturn(1);
+        when(mockJobArguments.getRunDurationMillis()).thenReturn(20L);
+        when(mockJobArguments.getTestDataInterBatchDelayMillis()).thenReturn(20L);
+
+        underTest.run();
+
+        assertEquals(1, countRecords());
+    }
+
+    @Test
+    void shouldInsertMultipleRecordsWhenGivenIncreasedBatchSize() throws SQLException {
+        when(mockJobArguments.getTestDataParallelism()).thenReturn(1);
+        when(mockJobArguments.getTestDataBatchSize()).thenReturn(2);
+        when(mockJobArguments.getRunDurationMillis()).thenReturn(20L);
+        when(mockJobArguments.getTestDataInterBatchDelayMillis()).thenReturn(20L);
+
+        underTest.run();
+
+        assertEquals(2, countRecords());
+    }
+
+    @Test
+    void shouldInsertMultipleRecordsGivenIncreasedParallelism() throws SQLException {
+        when(mockJobArguments.getTestDataParallelism()).thenReturn(2);
+        when(mockJobArguments.getTestDataBatchSize()).thenReturn(1);
+        when(mockJobArguments.getRunDurationMillis()).thenReturn(20L);
+        when(mockJobArguments.getTestDataInterBatchDelayMillis()).thenReturn(20L);
+
+        underTest.run();
+
+        assertEquals(2, countRecords());
+    }
+
+    @Test
+    void shouldInsertMultipleRecordsGivenIncreasedParallelismAndBatchSize() throws SQLException {
+        when(mockJobArguments.getTestDataParallelism()).thenReturn(2);
+        when(mockJobArguments.getTestDataBatchSize()).thenReturn(2);
+        when(mockJobArguments.getRunDurationMillis()).thenReturn(20L);
+        when(mockJobArguments.getTestDataInterBatchDelayMillis()).thenReturn(20L);
+
+        underTest.run();
+
+        assertEquals(4, countRecords());
+    }
+
+    @Test
+    void shouldInsertMultipleRecordsGivenIncreasedRunDuration() throws SQLException {
+        when(mockJobArguments.getTestDataParallelism()).thenReturn(2);
+        when(mockJobArguments.getTestDataBatchSize()).thenReturn(2);
+        when(mockJobArguments.getRunDurationMillis()).thenReturn(200L);
+        when(mockJobArguments.getTestDataInterBatchDelayMillis()).thenReturn(20L);
+
+        underTest.run();
+
+        assertThat(countRecords(), greaterThan(4L));
+    }
+
+    private static void createTable() throws SQLException {
+        Statement statement = connection.createStatement();
+        statement.execute("CREATE SEQUENCE id_seq");
+        statement.execute(format("CREATE TABLE IF NOT EXISTS %s (id INTEGER DEFAULT NEXTVAL('id_seq'), data VARCHAR)", TEST_TABLE));
+    }
+
+    private static void truncateTable() throws SQLException {
+        Statement statement = connection.createStatement();
+        statement.execute(format("TRUNCATE TABLE %s", TEST_TABLE));
+    }
+
+    private static long countRecords() throws SQLException {
+        Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery(format("SELECT COUNT(*) FROM %s", TEST_TABLE));
+        result.next();
+        return result.getLong(1);
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -190,6 +190,8 @@ public class JobArguments {
     static final int DEFAULT_TEST_DATA_PARALLELISM = 1;
     static final String TEST_DATA_INTER_BATCH_DELAY = "dpr.test.data.inter.batch.delay.millis";
     static final long DEFAULT_TEST_DATA_INTER_BATCH_DELAY_MILLIS = 1000;
+    static final String TEST_DATA_TABLE_NAME = "dpr.test.data.table.name";
+    static final String DEFAULT_TEST_DATA_TABLE_NAME = "test_table";
     static final String TEST_DATA_RUN_DURATION_MILLIS = "dpr.test.data.run.duration.millis";
     static final long DEFAULT_TEST_DATA_RUN_DURATION_MILLIS = 3600000; // 1 hour
     public static final String ADJUST_SPARK_MEMORY = "dpr.adjust.spark.memory";
@@ -603,6 +605,10 @@ public class JobArguments {
         return config.get(SECRET_ID);
     }
 
+    public String getTestDataTableName() {
+        return getArgument(TEST_DATA_TABLE_NAME, DEFAULT_TEST_DATA_TABLE_NAME);
+    }
+
     public int getTestDataBatchSize() {
         return getArgument(TEST_DATA_BATCH_SIZE, DEFAULT_TEST_DATA_BATCH_SIZE);
     }
@@ -615,7 +621,7 @@ public class JobArguments {
         return getArgument(TEST_DATA_INTER_BATCH_DELAY, DEFAULT_TEST_DATA_INTER_BATCH_DELAY_MILLIS);
     }
 
-    public long getRunDuration() {
+    public long getRunDurationMillis() {
         return getArgument(TEST_DATA_RUN_DURATION_MILLIS, DEFAULT_TEST_DATA_RUN_DURATION_MILLIS);
     }
 

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -183,6 +183,15 @@ public class JobArguments {
     public static final Long DEFAULT_RAW_FILE_RETENTION_PERIOD_AMOUNT = 2L;
     public static final String RAW_FILE_RETENTION_PERIOD_UNIT = "dpr.raw.file.retention.period.unit";
     static final String DEFAULT_RAW_FILE_RETENTION_PERIOD_UNIT = "days";
+    static final String SECRET_ID = "dpr.test.database.secret.id";
+    static final String TEST_DATA_BATCH_SIZE = "dpr.test.data.batch.size";
+    static final int DEFAULT_TEST_DATA_BATCH_SIZE = 5;
+    static final String TEST_DATA_PARALLELISM = "dpr.test.data.parallelism";
+    static final int DEFAULT_TEST_DATA_PARALLELISM = 1;
+    static final String TEST_DATA_INTER_BATCH_DELAY = "dpr.test.data.inter.batch.delay.millis";
+    static final long DEFAULT_TEST_DATA_INTER_BATCH_DELAY_MILLIS = 1000;
+    static final String TEST_DATA_RUN_DURATION_MILLIS = "dpr.test.data.run.duration.millis";
+    static final long DEFAULT_TEST_DATA_RUN_DURATION_MILLIS = 3600000; // 1 hour
     public static final String ADJUST_SPARK_MEMORY = "dpr.adjust.spark.memory";
     private final Map<String, String> config;
 
@@ -590,6 +599,26 @@ public class JobArguments {
         return getArgument(RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT);
     }
 
+    public String getSecretId() {
+        return config.get(SECRET_ID);
+    }
+
+    public int getTestDataBatchSize() {
+        return getArgument(TEST_DATA_BATCH_SIZE, DEFAULT_TEST_DATA_BATCH_SIZE);
+    }
+
+    public int getTestDataParallelism() {
+        return getArgument(TEST_DATA_PARALLELISM, DEFAULT_TEST_DATA_PARALLELISM);
+    }
+
+    public long getTestDataInterBatchDelayMillis() {
+        return getArgument(TEST_DATA_INTER_BATCH_DELAY, DEFAULT_TEST_DATA_INTER_BATCH_DELAY_MILLIS);
+    }
+
+    public long getRunDuration() {
+        return getArgument(TEST_DATA_RUN_DURATION_MILLIS, DEFAULT_TEST_DATA_RUN_DURATION_MILLIS);
+    }
+
     public boolean adjustSparkMemory() {
         return getArgument(ADJUST_SPARK_MEMORY, false);
     }
@@ -632,6 +661,14 @@ public class JobArguments {
         return Optional
                 .ofNullable(config.get(argumentName))
                 .map(Boolean::parseBoolean)
+                .orElse(defaultValue);
+    }
+
+    @SuppressWarnings("unused")
+    private short getArgument(String argumentName, short defaultValue) {
+        return Optional
+                .ofNullable(config.get(argumentName))
+                .map(Short::parseShort)
                 .orElse(defaultValue);
     }
 

--- a/src/main/java/uk/gov/justice/digital/datahub/model/generator/DataGenerationConfig.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/generator/DataGenerationConfig.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.datahub.model.generator;
+
+import java.util.Objects;
+
+public class DataGenerationConfig {
+    int batchSize;
+    int parallelism;
+    long interBatchDelay;
+    long runDuration;
+
+    public DataGenerationConfig(int batchSize, int parallelism, long interBatchDelay, long runDuration) {
+        this.batchSize = batchSize;
+        this.parallelism = parallelism;
+        this.interBatchDelay = interBatchDelay;
+        this.runDuration = runDuration;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getParallelism() {
+        return parallelism;
+    }
+
+    public long getInterBatchDelay() {
+        return interBatchDelay;
+    }
+
+    public long getRunDuration() {
+        return runDuration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DataGenerationConfig)) return false;
+        DataGenerationConfig that = (DataGenerationConfig) o;
+        return batchSize == that.batchSize && parallelism == that.parallelism && interBatchDelay == that.interBatchDelay && runDuration == that.runDuration;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(batchSize, parallelism, interBatchDelay, runDuration);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/datahub/model/generator/PostgresSecrets.java
+++ b/src/main/java/uk/gov/justice/digital/datahub/model/generator/PostgresSecrets.java
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.datahub.model.generator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class PostgresSecrets {
+    private String dbName;
+    private String heartbeatEndpoint;
+    private String password;
+    private String port;
+    private String username;
+
+    public String getDatabaseName() {
+        return dbName;
+    }
+
+    public String getHeartbeatEndpoint() {
+        return heartbeatEndpoint;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getJdbcUrl() {
+        return "jdbc:postgresql://" + getHeartbeatEndpoint() + ":" + getPort() + "/" + getDatabaseName();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/generator/PostgresLoadGeneratorJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/generator/PostgresLoadGeneratorJob.java
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.job.generator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.client.secretsmanager.SecretsManagerClient;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.datahub.model.generator.DataGenerationConfig;
+import uk.gov.justice.digital.datahub.model.generator.PostgresSecrets;
+import uk.gov.justice.digital.job.HiveTableCreationJob;
+import uk.gov.justice.digital.job.PicocliMicronautExecutor;
+
+import javax.inject.Inject;
+import java.sql.*;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static picocli.CommandLine.Command;
+
+@Command(name = "PostgresLoadGeneratorJob")
+public class PostgresLoadGeneratorJob implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(PostgresLoadGeneratorJob.class);
+
+    JobArguments arguments;
+    private final SecretsManagerClient secretsManagerClient;
+
+    @Inject
+    public PostgresLoadGeneratorJob(
+            JobArguments arguments,
+            SecretsManagerClient secretsManagerClient
+    ) {
+        this.arguments = arguments;
+        this.secretsManagerClient = secretsManagerClient;
+    }
+
+    public static void main(String[] args) {
+        PicocliMicronautExecutor.execute(PostgresLoadGeneratorJob.class, args);
+    }
+
+    @Override
+    public void run() {
+        try {
+            logger.info("PostgresLoadGeneratorJob running");
+            String secretId = arguments.getSecretId();
+            int batchSize = arguments.getTestDataBatchSize();
+            int parallelism = arguments.getTestDataParallelism();
+            long interBatchDelay = arguments.getTestDataInterBatchDelayMillis();
+            long runDuration = arguments.getRunDuration();
+
+            Class.forName("org.postgresql.Driver");
+            PostgresSecrets credentials = secretsManagerClient.getSecret(secretId, PostgresSecrets.class);
+            DataGenerationConfig runConfig = new DataGenerationConfig(batchSize, parallelism, interBatchDelay, runDuration);
+            generateTestData(credentials, runConfig);
+
+            logger.info("PostgresLoadGeneratorJob finished");
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+    }
+
+    public void generateTestData(PostgresSecrets credentials, DataGenerationConfig runConfig) throws SQLException, InterruptedException {
+        Connection connection = null;
+        PreparedStatement statement = null;
+        long startTime = System.currentTimeMillis();
+
+        try {
+            logger.debug("Connecting to {}", credentials.getJdbcUrl());
+            connection = DriverManager.getConnection(credentials.getJdbcUrl(), credentials.getUsername(), credentials.getPassword());
+            connection.setAutoCommit(false);
+
+            while (System.currentTimeMillis() - startTime < runConfig.getRunDuration()) {
+                for (int i = 1; i <= runConfig.getParallelism(); i++) {
+                    String insertSql = "INSERT INTO test_table(data) VALUES (?) ON CONFLICT (id) DO UPDATE SET data = ?";
+                    statement = connection.prepareStatement(insertSql);
+                    for (int j = 1; j <= runConfig.getBatchSize(); j++) {
+                        String data = UUID.randomUUID().toString();
+                        statement.setString(1, data);
+                        statement.setString(2, data);
+
+                        statement.addBatch();
+                        logger.debug("Added record {} to batch batch: {}", j, i);
+                    }
+
+                    int[] results = statement.executeBatch();
+                    logger.info("Total records inserted: {}", Arrays.stream(results).sum());
+                    connection.commit();
+                    TimeUnit.MILLISECONDS.sleep(runConfig.getInterBatchDelay());
+                }
+            }
+        } catch (SQLException | InterruptedException e) {
+            if (statement != null) statement.close();
+            if (connection != null) connection.close();
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
This is a Glue job which was created for testing purposes to insert records into a Postgres instance.
The job takes the arguments below:

- `dpr.test.database.secret.id`: The identity of the secrets containing the connection to the database
- `dpr.test.data.batch.size`: The number of records to be inserted in one query
- `dpr.test.data.parallelism`: The minimum number of batches to be written 
- `dpr.test.data.inter.batch.delay.millis`: The amount of delay between each batch execution
- `dpr.test.data.run.duration.millis`: The total run duration of the job invocation
