### PR TITLE
DPR2-1774: Configure spark memory using worker type

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -101,6 +101,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, "12" },
             { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, "0.01" },
             { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, "5" },
+            { JobArguments.ADJUST_SPARK_MEMORY, "true" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -168,6 +169,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationCurrentStateCountsToleranceAbsolute()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, Double.toString(validArguments.getReconciliationChangeDataCountsToleranceRelativePercentage()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationChangeDataCountsToleranceAbsolute()) },
+                { JobArguments.ADJUST_SPARK_MEMORY, validArguments.adjustSparkMemory() },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -753,6 +755,14 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertEquals(0L, jobArguments.getReconciliationCurrentStateCountsToleranceAbsolute());
+    }
+
+    @Test
+    void adjustSparkMemoryShouldDefaultToFalse() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.ADJUST_SPARK_MEMORY);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertFalse(jobArguments.adjustSparkMemory());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubBatchJobE2ESmokeIT.java
@@ -65,6 +65,8 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
     @Mock
     private JobArguments arguments;
     @Mock
+    private JobProperties properties;
+    @Mock
     private SourceReferenceService sourceReferenceService;
     @Mock
     private ConfigService configService;
@@ -144,6 +146,8 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         givenRetrySettingsAreConfigured(arguments);
         when(arguments.getOperationalDataStoreJdbcBatchSize()).thenReturn(OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT);
         when(arguments.getOperationalDataStoreGlueConnectionName()).thenReturn("operational-datastore-connection-name");
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
     }
 
     private void whenTheJobRuns() {
@@ -152,7 +156,6 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
 
     private void givenDependenciesAreInjected() {
         // Manually creating dependencies because Micronaut test injection is not working
-        JobProperties properties = new JobProperties();
         SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
         TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(arguments, configService);
         DataStorageService storageService = new DataStorageService(arguments);
@@ -164,7 +167,7 @@ class DataHubBatchJobE2ESmokeIT extends E2ETestBase {
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
         OperationalDataStoreRepository operationalDataStoreRepository =
-                new OperationalDataStoreRepository(arguments, connectionDetailsService, sparkSessionProvider);
+                new OperationalDataStoreRepository(arguments, properties, connectionDetailsService, sparkSessionProvider);
         OperationalDataStoreDataAccessService operationalDataStoreDataAccessService =
                 new OperationalDataStoreDataAccessService(arguments, connectionDetailsService, connectionPoolProvider, operationalDataStoreRepository);
         OperationalDataStoreService operationalDataStoreService =

--- a/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/DataHubCdcJobE2ESmokeIT.java
@@ -73,6 +73,8 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
     @Mock
     private JobArguments arguments;
     @Mock
+    private JobProperties properties;
+    @Mock
     private SourceReferenceService sourceReferenceService;
     @Mock
     private ConfigService configService;
@@ -189,6 +191,8 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
         when(arguments.getOperationalDataStoreJdbcBatchSize()).thenReturn(OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT);
         when(arguments.streamingJobMaxFilePerTrigger()).thenReturn(STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER);
         when(arguments.getOperationalDataStoreGlueConnectionName()).thenReturn("operational-datastore-connection-name");
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
     }
 
     private void whenTheJobRuns() {
@@ -211,7 +215,7 @@ public class DataHubCdcJobE2ESmokeIT extends E2ETestBase {
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
         OperationalDataStoreRepository operationalDataStoreRepository =
-                new OperationalDataStoreRepository(arguments, connectionDetailsService, sparkSessionProvider);
+                new OperationalDataStoreRepository(arguments, properties, connectionDetailsService, sparkSessionProvider);
         OperationalDataStoreDataAccessService operationalDataStoreDataAccessService =
                 new OperationalDataStoreDataAccessService(arguments, connectionDetailsService, connectionPoolProvider, operationalDataStoreRepository);
         OperationalDataStoreService operationalDataStoreService =

--- a/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/batchprocessing/BatchProcessorIT.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.DataStorageService;
@@ -57,6 +58,8 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
 
     @Mock
     private JobArguments arguments;
+    @Mock
+    private JobProperties properties;
     @Mock
     private SourceReference sourceReference;
     @Mock
@@ -271,6 +274,8 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         givenRetrySettingsAreConfigured(arguments);
         when(arguments.getOperationalDataStoreJdbcBatchSize()).thenReturn(OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT);
         when(arguments.getOperationalDataStoreGlueConnectionName()).thenReturn("operational-datastore-connection");
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
     }
 
     private void givenS3BatchProcessorDependenciesAreInjected() {
@@ -284,7 +289,7 @@ class BatchProcessorIT extends BaseMinimalDataIntegrationTest {
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
         OperationalDataStoreRepository operationalDataStoreRepository =
-                new OperationalDataStoreRepository(arguments, connectionDetailsService, sparkSessionProvider);
+                new OperationalDataStoreRepository(arguments, properties, connectionDetailsService, sparkSessionProvider);
         OperationalDataStoreDataAccessService operationalDataStoreDataAccessService =
                 new OperationalDataStoreDataAccessService(arguments, connectionDetailsService, connectionPoolProvider, operationalDataStoreRepository);
         OperationalDataStoreService operationalDataStoreService =

--- a/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/cdc/TableStreamingQueryIT.java
@@ -20,6 +20,7 @@ import scala.Option;
 import scala.collection.Seq;
 import uk.gov.justice.digital.client.s3.S3DataProvider;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.exception.NoSchemaNoDataException;
 import uk.gov.justice.digital.job.batchprocessing.CdcBatchProcessor;
@@ -86,6 +87,8 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
 
     @Mock
     private JobArguments arguments;
+    @Mock
+    private JobProperties properties;
     @Mock
     private S3DataProvider dataProvider;
     @Mock
@@ -403,6 +406,8 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         when(arguments.getBroadcastTimeoutSeconds()).thenReturn(DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS);
         lenient().when(arguments.getOperationalDataStoreJdbcBatchSize()).thenReturn(OPERATIONAL_DATA_STORE_JDBC_BATCH_SIZE_DEFAULT);
         when(arguments.getOperationalDataStoreGlueConnectionName()).thenReturn("operational-datastore-connection-name");
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
     }
 
     private void givenAMatchingSchema() {
@@ -504,7 +509,7 @@ public class TableStreamingQueryIT extends BaseMinimalDataIntegrationTest {
         OperationalDataStoreTransformation operationalDataStoreTransformation = new OperationalDataStoreTransformation();
         ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
         OperationalDataStoreRepository operationalDataStoreRepository =
-                new OperationalDataStoreRepository(arguments, connectionDetailsService, sparkSessionProvider);
+                new OperationalDataStoreRepository(arguments, properties, connectionDetailsService, sparkSessionProvider);
         OperationalDataStoreDataAccessService operationalDataStoreDataAccessService =
                 new OperationalDataStoreDataAccessService(arguments, connectionDetailsService, connectionPoolProvider, operationalDataStoreRepository);
         OperationalDataStoreService operationalDataStoreService =

--- a/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/operationaldatastore/OperationalDataStoreServiceIntegrationTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.SourceReference;
 import uk.gov.justice.digital.provider.ConnectionPoolProvider;
 import uk.gov.justice.digital.service.JDBCGlueConnectionDetailsService;
@@ -73,6 +74,8 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
     private SourceReference sourceReference;
     @Mock
     private JobArguments jobArguments;
+    @Mock
+    private JobProperties properties;
 
     private OperationalDataStoreService underTest;
 
@@ -114,6 +117,8 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
         destinationTableName = operationalDataStoreTableName(inputSchemaName, inputTableName);
         destinationTableNameWithSchema = operationalDataStoreTableNameWithSchema(namespace, inputSchemaName, inputTableName);
         when(jobArguments.getOperationalDataStoreLoadingSchemaName()).thenReturn(loadingSchemaName);
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
 
         givenSchemaExists(configurationSchema, testQueryConnection);
         givenSchemaExists(loadingSchemaName, testQueryConnection);
@@ -125,7 +130,7 @@ public class OperationalDataStoreServiceIntegrationTest extends BaseSparkTest {
 
         ConnectionPoolProvider connectionPoolProvider = new ConnectionPoolProvider();
         OperationalDataStoreRepository operationalDataStoreRepository =
-                new OperationalDataStoreRepository(jobArguments, mockConnectionDetailsService, sparkSessionProvider);
+                new OperationalDataStoreRepository(jobArguments, properties, mockConnectionDetailsService, sparkSessionProvider);
         underTest = new OperationalDataStoreServiceImpl(
                 jobArguments,
                 new OperationalDataStoreTransformation(),

--- a/src/it/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreRepositoryIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreRepositoryIntegrationTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.DataHubOperationalDataStoreManagedTable;
 import uk.gov.justice.digital.service.JDBCGlueConnectionDetailsService;
 import uk.gov.justice.digital.test.InMemoryOperationalDataStore;
@@ -32,6 +33,8 @@ public class OperationalDataStoreRepositoryIntegrationTest extends BaseSparkTest
     @Mock
     private JobArguments jobArguments;
     @Mock
+    private JobProperties properties;
+    @Mock
     private JDBCGlueConnectionDetailsService connectionDetailsService;
 
     private OperationalDataStoreRepository underTest;
@@ -52,7 +55,10 @@ public class OperationalDataStoreRepositoryIntegrationTest extends BaseSparkTest
     void setUp() {
         givenDatastoreCredentials(connectionDetailsService, operationalDataStore);
         when(jobArguments.getOperationalDataStoreGlueConnectionName()).thenReturn("operational-datastore-connection-name");
-        underTest = new OperationalDataStoreRepository(jobArguments, connectionDetailsService, sparkSessionProvider);
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
+
+        underTest = new OperationalDataStoreRepository(jobArguments, properties, connectionDetailsService, sparkSessionProvider);
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -175,6 +175,7 @@ public class JobArguments {
     public static final Long DEFAULT_RAW_FILE_RETENTION_PERIOD_AMOUNT = 2L;
     public static final String RAW_FILE_RETENTION_PERIOD_UNIT = "dpr.raw.file.retention.period.unit";
     static final String DEFAULT_RAW_FILE_RETENTION_PERIOD_UNIT = "days";
+    public static final String ADJUST_SPARK_MEMORY = "dpr.adjust.spark.memory";
     private final Map<String, String> config;
 
     @Inject
@@ -571,6 +572,10 @@ public class JobArguments {
 
     public long getReconciliationCurrentStateCountsToleranceAbsolute() {
         return getArgument(RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE, RECONCILIATION_CURRENT_STATE_COUNTS_TOLERANCE_ABSOLUTE_DEFAULT);
+    }
+
+    public boolean adjustSparkMemory() {
+        return getArgument(ADJUST_SPARK_MEMORY, false);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/config/JobProperties.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobProperties.java
@@ -1,18 +1,38 @@
 package uk.gov.justice.digital.config;
 
 import javax.inject.Singleton;
+import java.util.Map;
 import java.util.Optional;
 
 @Singleton
 public class JobProperties {
 
     public static final String SPARK_JOB_NAME_PROPERTY = "spark.glue.JOB_NAME";
+    public static final String SPARK_DRIVER_MEMORY_PROPERTY = "spark.driver.memory";
+    public static final String SPARK_EXECUTOR_MEMORY_PROPERTY = "spark.executor.memory";
 
     public String getSparkJobName() {
-        return Optional
-            .ofNullable(System.getProperty(SPARK_JOB_NAME_PROPERTY))
-            .orElseThrow(() -> new IllegalStateException("Property " + SPARK_JOB_NAME_PROPERTY + " not set"));
+        return getString(SPARK_JOB_NAME_PROPERTY);
     }
 
+    public String getSparkDriverMemory() {
+        return getString(SPARK_DRIVER_MEMORY_PROPERTY);
+    }
+
+    public String getSparkExecutorMemory() {
+        return getString(SPARK_EXECUTOR_MEMORY_PROPERTY);
+    }
+
+    private static String getString(String propertyKey) {
+        return Optional
+                .ofNullable(System.getProperty(propertyKey))
+                .orElseThrow(() -> new IllegalStateException("Property " + propertyKey + " not set"));
+    }
+
+    public JobProperties(Map<String, String> config) {
+        config.forEach(System::setProperty);
+    }
+
+    public JobProperties() {}
 
 }

--- a/src/main/java/uk/gov/justice/digital/job/DataHubCdcJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/DataHubCdcJob.java
@@ -73,14 +73,14 @@ public class DataHubCdcJob implements Runnable {
             if (runLocal) {
                 logger.info("Running locally");
                 SparkConf sparkConf = new SparkConf().setAppName("DataHubCdcJob local").setMaster("local[*]");
-                SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(sparkConf, arguments);
+                SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(sparkConf, arguments, properties);
                 if (arguments.cleanCdcCheckpoint()) recreateCheckpoint(spark, checkpointLocation);
                 runJob(spark);
                 waitUntilQueryTerminates(spark);
             } else {
                 logger.info("Running in Glue");
                 String jobName = properties.getSparkJobName();
-                GlueContext glueContext = sparkSessionProvider.createGlueContext(jobName, arguments);
+                GlueContext glueContext = sparkSessionProvider.createGlueContext(jobName, arguments, properties);
                 SparkSession spark = glueContext.getSparkSession();
                 if (arguments.cleanCdcCheckpoint()) recreateCheckpoint(spark, checkpointLocation);
                 Job.init(jobName, glueContext, arguments.getConfig());

--- a/src/main/java/uk/gov/justice/digital/job/SparkJobRunner.java
+++ b/src/main/java/uk/gov/justice/digital/job/SparkJobRunner.java
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.job;
+
+import com.amazonaws.services.glue.util.Job;
+import lombok.val;
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
+
+import java.util.function.Consumer;
+
+import static uk.gov.justice.digital.config.JobProperties.SPARK_JOB_NAME_PROPERTY;
+
+public class SparkJobRunner {
+
+    public static void run(
+            String jobLabel,
+            JobArguments jobArguments,
+            JobProperties jobProperties,
+            SparkSessionProvider sparkSessionProvider,
+            Logger logger,
+            Consumer<SparkSession> runJob
+    ) {
+        logger.info("Running {}", jobLabel);
+        try {
+            boolean runLocal = System.getProperty(SPARK_JOB_NAME_PROPERTY) == null;
+            if (runLocal) {
+                logger.info("Running {} locally", jobLabel);
+                SparkConf sparkConf = new SparkConf().setAppName(jobLabel + " local").setMaster("local[*]");
+                SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(sparkConf, jobArguments, jobProperties);
+                runJob.accept(spark);
+            } else {
+                logger.info("Running {} in Glue", jobLabel);
+                String jobName = jobProperties.getSparkJobName();
+                val glueContext = sparkSessionProvider.createGlueContext(jobName, jobArguments, jobProperties);
+                Job.init(jobName, glueContext, jobArguments.getConfig());
+                SparkSession spark = glueContext.getSparkSession();
+                runJob.accept(spark);
+                Job.commit();
+            }
+        } catch (Exception e) {
+            logger.error("Caught exception during job run", e);
+            System.exit(1);
+        }
+
+        logger.info("{} completed successfully", jobLabel);
+    }
+
+    private SparkJobRunner() {}
+}

--- a/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/SwitchHiveTableJob.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.HiveTableService;
@@ -24,18 +25,21 @@ public class SwitchHiveTableJob implements Runnable {
     private final HiveTableService hiveTableService;
     private final SparkSessionProvider sparkSessionProvider;
     private final JobArguments jobArguments;
+    private final JobProperties jobProperties;
 
     @Inject
     public SwitchHiveTableJob(
             ConfigService configService,
             HiveTableService hiveTableService,
             SparkSessionProvider sparkSessionProvider,
-            JobArguments jobArguments
+            JobArguments jobArguments,
+            JobProperties jobProperties
     ) {
         this.configService = configService;
         this.hiveTableService = hiveTableService;
         this.sparkSessionProvider = sparkSessionProvider;
         this.jobArguments = jobArguments;
+        this.jobProperties = jobProperties;
     }
 
     public static void main(String[] args) {
@@ -46,7 +50,7 @@ public class SwitchHiveTableJob implements Runnable {
     public void run() {
         try {
             logger.info("SwitchHiveTableJob running");
-            SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(jobArguments);
+            SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(jobArguments, jobProperties);
 
             ImmutableSet<ImmutablePair<String, String>> configuredTables = configService
                     .getConfiguredTables(jobArguments.getConfigKey());

--- a/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/VacuumJob.java
@@ -6,6 +6,7 @@ import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.MaintenanceService;
@@ -31,18 +32,21 @@ public class VacuumJob implements Runnable {
     private final ConfigService configService;
     private final SparkSessionProvider sparkSessionProvider;
     private final JobArguments jobArguments;
+    private final JobProperties properties;
 
     @Inject
     public VacuumJob(
             MaintenanceService maintenanceService,
             ConfigService configService,
             SparkSessionProvider sparkSessionProvider,
-            JobArguments jobArguments
+            JobArguments jobArguments,
+            JobProperties properties
     ) {
         this.maintenanceService = maintenanceService;
         this.configService = configService;
         this.sparkSessionProvider = sparkSessionProvider;
         this.jobArguments = jobArguments;
+        this.properties = properties;
     }
 
     public static void main(String[] args) {
@@ -51,25 +55,19 @@ public class VacuumJob implements Runnable {
 
     @Override
     public void run() {
-        try {
-            logger.info("Vacuum running");
-            SparkSession spark = sparkSessionProvider.getConfiguredSparkSession(jobArguments);
+        SparkJobRunner.run("VacuumJob", jobArguments, properties, sparkSessionProvider, logger, this::runJob);
+    }
 
-            String rootPath = jobArguments.getMaintenanceTablesRootPath();
-            int maxDepth = jobArguments.getMaintenanceListTableRecurseMaxDepth();
-            Optional<String> optionalConfigKey = jobArguments.getOptionalConfigKey();
+    private void runJob(SparkSession sparkSession) {
+        String rootPath = jobArguments.getMaintenanceTablesRootPath();
+        int maxDepth = jobArguments.getMaintenanceListTableRecurseMaxDepth();
+        Optional<String> optionalConfigKey = jobArguments.getOptionalConfigKey();
 
-            if (optionalConfigKey.isPresent()) {
-                ImmutableSet<ImmutablePair<String, String>> configuredTables = configService.getConfiguredTables(optionalConfigKey.get());
-                configuredTables.forEach(table -> maintenanceService.vacuumDeltaTables(spark, format("%s%s", ensureEndsWithSlash(rootPath), table.right), 0));
-            } else {
-                maintenanceService.vacuumDeltaTables(spark, ensureEndsWithSlash(rootPath), maxDepth);
-            }
-
-            logger.info("Vacuum finished");
-        } catch (Exception e) {
-            logger.error("Caught exception during job run", e);
-            System.exit(1);
+        if (optionalConfigKey.isPresent()) {
+            ImmutableSet<ImmutablePair<String, String>> configuredTables = configService.getConfiguredTables(optionalConfigKey.get());
+            configuredTables.forEach(table -> maintenanceService.vacuumDeltaTables(sparkSession, format("%s%s", ensureEndsWithSlash(rootPath), table.right), 0));
+        } else {
+            maintenanceService.vacuumDeltaTables(sparkSession, ensureEndsWithSlash(rootPath), maxDepth);
         }
     }
 }

--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreRepository.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreRepository.java
@@ -8,6 +8,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.datahub.model.DataHubOperationalDataStoreManagedTable;
 import uk.gov.justice.digital.datahub.model.JDBCGlueConnectionDetails;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
@@ -31,11 +32,12 @@ public class OperationalDataStoreRepository {
     @Inject
     public OperationalDataStoreRepository(
             JobArguments jobArguments,
+            JobProperties properties,
             JDBCGlueConnectionDetailsService connectionDetailsService,
             SparkSessionProvider sparkSessionProvider
     ) {
         this.jobArguments = jobArguments;
-        this.sparkSession = sparkSessionProvider.getConfiguredSparkSession(jobArguments);
+        this.sparkSession = sparkSessionProvider.getConfiguredSparkSession(jobArguments, properties);
         String connectionName = jobArguments.getOperationalDataStoreGlueConnectionName();
         JDBCGlueConnectionDetails connectionDetails = connectionDetailsService.getConnectionDetails(connectionName);
         jdbcUrl = connectionDetails.getUrl();

--- a/src/test/java/uk/gov/justice/digital/config/BaseSparkTest.java
+++ b/src/test/java/uk/gov/justice/digital/config/BaseSparkTest.java
@@ -47,7 +47,8 @@ public class BaseSparkTest {
 
 	private static SparkSession createSparkSession() {
 		JobArguments arguments = new JobArguments(ImmutableMap.of(LOG_LEVEL, "info"));
-		return spark = sparkSessionProvider.getConfiguredSparkSession(sparkTestConfiguration, arguments);
+		JobProperties properties = new JobProperties(ImmutableMap.of("spark.driver.memory", "2g", "spark.executor.memory", "2g"));
+		return spark = sparkSessionProvider.getConfiguredSparkSession(sparkTestConfiguration, arguments, properties);
 	}
 
 	@BeforeAll

--- a/src/test/java/uk/gov/justice/digital/config/JobPropertiesTest.java
+++ b/src/test/java/uk/gov/justice/digital/config/JobPropertiesTest.java
@@ -6,32 +6,60 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.justice.digital.config.JobProperties.*;
 
 class JobPropertiesTest {
 
-    private static final String SPARK_JOB_NAME_KEY = "spark.glue.JOB_NAME";
     private static final String SPARK_JOB_NAME = "SomeTestJob";
+    private static final String DRIVER_MEMORY = "1g";
+    private static final String EXECUTOR_MEMORY = "2g";
 
     private static final JobProperties underTest = new JobProperties();
 
     @BeforeEach
     public void setupProperties() {
-        System.setProperty(SPARK_JOB_NAME_KEY, SPARK_JOB_NAME);
+        System.setProperty(SPARK_JOB_NAME_PROPERTY, SPARK_JOB_NAME);
+        System.setProperty(SPARK_DRIVER_MEMORY_PROPERTY, DRIVER_MEMORY);
+        System.setProperty(SPARK_EXECUTOR_MEMORY_PROPERTY, EXECUTOR_MEMORY);
     }
 
     @AfterEach
     public void cleanupProperties() {
-        System.clearProperty(SPARK_JOB_NAME_KEY);
+        System.clearProperty(SPARK_JOB_NAME_PROPERTY);
+        System.clearProperty(SPARK_DRIVER_MEMORY_PROPERTY);
+        System.clearProperty(SPARK_EXECUTOR_MEMORY_PROPERTY);
     }
 
     @Test
-    public void shouldReturnJobNameWhenPropertySet() {
+    void shouldReturnJobNameWhenPropertySet() {
         assertEquals(SPARK_JOB_NAME, underTest.getSparkJobName());
     }
 
     @Test
-    public void shouldThrowExceptionWhenJobNamePropertyNotSet() {
-        System.clearProperty(SPARK_JOB_NAME_KEY);
+    void shouldThrowExceptionWhenJobNamePropertyNotSet() {
+        System.clearProperty(SPARK_JOB_NAME_PROPERTY);
         assertThrows(IllegalStateException.class, underTest::getSparkJobName);
+    }
+
+    @Test
+    void shouldReturnDriverMemoryWhenPropertyIsSet() {
+        assertEquals(DRIVER_MEMORY, underTest.getSparkDriverMemory());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDriverMemoryPropertyIsNotSet() {
+        System.clearProperty(SPARK_DRIVER_MEMORY_PROPERTY);
+        assertThrows(IllegalStateException.class, underTest::getSparkDriverMemory);
+    }
+
+    @Test
+    void shouldReturnExecutorMemoryWhenPropertyIsSet() {
+        assertEquals(EXECUTOR_MEMORY, underTest.getSparkExecutorMemory());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenExecutorMemoryPropertyIsNotSet() {
+        System.clearProperty(SPARK_EXECUTOR_MEMORY_PROPERTY);
+        assertThrows(IllegalStateException.class, underTest::getSparkExecutorMemory);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/job/CompactionJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/CompactionJobTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.exception.ConfigServiceException;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.MaintenanceService;
@@ -39,6 +40,8 @@ class CompactionJobTest extends BaseSparkTest {
     @Mock
     private JobArguments arguments;
     @Mock
+    private JobProperties properties;
+    @Mock
     private ConfigService configService;
     @Mock
     private MaintenanceService maintenanceService;
@@ -55,8 +58,8 @@ class CompactionJobTest extends BaseSparkTest {
 
     @BeforeEach
     public void setupTest() {
-        reset(arguments, configService, maintenanceService);
-        underTest = new CompactionJob(maintenanceService, configService, sparkSessionProvider, arguments);
+        reset(arguments, configService, maintenanceService, properties);
+        underTest = new CompactionJob(maintenanceService, configService, sparkSessionProvider, arguments, properties);
     }
 
     @Test
@@ -64,6 +67,8 @@ class CompactionJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.of(TEST_CONFIG_KEY));
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         when(configService.getConfiguredTables(TEST_CONFIG_KEY))
                 .thenReturn(ImmutableSet.of(ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_1), ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_2)));
         doNothing().when(maintenanceService).compactDeltaTables(eq(spark), deltaPathCaptor.capture(), eq(0));
@@ -83,6 +88,8 @@ class CompactionJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.empty());
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         doNothing().when(maintenanceService).compactDeltaTables(eq(spark), any(), eq(RECURSE_MAX_DEPTH));
 
         underTest.run();
@@ -96,6 +103,8 @@ class CompactionJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.of(TEST_CONFIG_KEY));
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         doThrow(new ConfigServiceException("config error")).when(configService).getConfiguredTables(TEST_CONFIG_KEY);
 
         assertEquals(1, SystemLambda.catchSystemExit(() -> underTest.run()));
@@ -108,6 +117,8 @@ class CompactionJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.of(TEST_CONFIG_KEY));
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         when(configService.getConfiguredTables(TEST_CONFIG_KEY))
                 .thenReturn(ImmutableSet.of(ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_1), ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_2)));
         doThrow(new RuntimeException("Maintenance service exception"))
@@ -121,6 +132,8 @@ class CompactionJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.empty());
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         doThrow(new RuntimeException("Maintenance service exception"))
                 .when(maintenanceService).compactDeltaTables(eq(spark), any(), eq(RECURSE_MAX_DEPTH));
 

--- a/src/test/java/uk/gov/justice/digital/job/SwitchHiveTableJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/SwitchHiveTableJobTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.exception.HiveSchemaServiceException;
 import uk.gov.justice.digital.provider.SparkSessionProvider;
 import uk.gov.justice.digital.service.ConfigService;
@@ -41,6 +42,8 @@ public class SwitchHiveTableJobTest extends BaseSparkTest {
     private HiveTableService mockHiveTableService;
     @Mock
     private JobArguments mockJobArguments;
+    @Mock
+    private JobProperties mockJobProperties;
     @Captor
     private ArgumentCaptor<ImmutableSet<ImmutablePair<String, String>>> argumentCaptor;
 
@@ -50,9 +53,8 @@ public class SwitchHiveTableJobTest extends BaseSparkTest {
 
     @BeforeEach
     public void setup() {
-        reset(mockConfigService, mockHiveTableService, mockJobArguments);
-
-        underTest = new SwitchHiveTableJob(mockConfigService, mockHiveTableService, sparkSessionProvider, mockJobArguments);
+        reset(mockConfigService, mockHiveTableService, mockJobArguments, mockJobProperties);
+        underTest = new SwitchHiveTableJob(mockConfigService, mockHiveTableService, sparkSessionProvider, mockJobArguments, mockJobProperties);
     }
 
     @Test
@@ -63,6 +65,8 @@ public class SwitchHiveTableJobTest extends BaseSparkTest {
         expectedTables.add(new ImmutablePair<>("schema_2", "table_3"));
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobProperties.getSparkDriverMemory()).thenReturn("2g");
+        when(mockJobProperties.getSparkExecutorMemory()).thenReturn("2g");
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(expectedTables));
         when(mockHiveTableService.switchPrisonsTableDataSource(any(SparkSession.class), argumentCaptor.capture())).thenReturn(Collections.emptySet());
 
@@ -76,6 +80,8 @@ public class SwitchHiveTableJobTest extends BaseSparkTest {
         ImmutableSet<ImmutablePair<String, String>> failedTables = ImmutableSet.of(ImmutablePair.of("schema", "failed-table-1"));
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobProperties.getSparkDriverMemory()).thenReturn("2g");
+        when(mockJobProperties.getSparkExecutorMemory()).thenReturn("2g");
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(failedTables));
         when(mockHiveTableService.switchPrisonsTableDataSource(any(SparkSession.class), any())).thenReturn(failedTables);
 
@@ -87,6 +93,8 @@ public class SwitchHiveTableJobTest extends BaseSparkTest {
         ImmutableSet<ImmutablePair<String, String>> table = ImmutableSet.of(ImmutablePair.of("schema_1", "table_1"));
 
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobProperties.getSparkDriverMemory()).thenReturn("2g");
+        when(mockJobProperties.getSparkExecutorMemory()).thenReturn("2g");
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.copyOf(table));
         when(mockHiveTableService.switchPrisonsTableDataSource(any(SparkSession.class), any())).thenThrow(new HiveSchemaServiceException("Schema service exception"));
 
@@ -96,6 +104,8 @@ public class SwitchHiveTableJobTest extends BaseSparkTest {
     @Test
     public void shouldFailWhenConfigServiceThrowsAnException() throws Exception {
         when(mockJobArguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(mockJobProperties.getSparkDriverMemory()).thenReturn("2g");
+        when(mockJobProperties.getSparkExecutorMemory()).thenReturn("2g");
         when(mockConfigService.getConfiguredTables(TEST_CONFIG_KEY)).thenThrow(new RuntimeException("Config service error"));
 
         SystemLambda.catchSystemExit(() -> underTest.run());

--- a/src/test/java/uk/gov/justice/digital/job/VacuumJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/VacuumJobTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.config.BaseSparkTest;
 import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
 import uk.gov.justice.digital.exception.ConfigServiceException;
 import uk.gov.justice.digital.service.ConfigService;
 import uk.gov.justice.digital.service.MaintenanceService;
@@ -39,6 +40,8 @@ class VacuumJobTest extends BaseSparkTest {
     @Mock
     private JobArguments arguments;
     @Mock
+    private JobProperties properties;
+    @Mock
     private ConfigService configService;
     @Mock
     private MaintenanceService maintenanceService;
@@ -55,8 +58,8 @@ class VacuumJobTest extends BaseSparkTest {
 
     @BeforeEach
     public void setupTest() {
-        reset(arguments, configService, maintenanceService);
-        underTest = new VacuumJob(maintenanceService, configService, sparkSessionProvider, arguments);
+        reset(arguments, properties, configService, maintenanceService);
+        underTest = new VacuumJob(maintenanceService, configService, sparkSessionProvider, arguments, properties);
     }
 
     @Test
@@ -64,6 +67,8 @@ class VacuumJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.of(TEST_CONFIG_KEY));
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         when(configService.getConfiguredTables(TEST_CONFIG_KEY))
                 .thenReturn(ImmutableSet.of(ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_1), ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_2)));
         doNothing().when(maintenanceService).vacuumDeltaTables(eq(spark), deltaPathCaptor.capture(), eq(0));
@@ -83,6 +88,8 @@ class VacuumJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.empty());
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         doNothing().when(maintenanceService).vacuumDeltaTables(eq(spark), any(), eq(RECURSE_MAX_DEPTH));
 
         underTest.run();
@@ -96,6 +103,8 @@ class VacuumJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.of(TEST_CONFIG_KEY));
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         doThrow(new ConfigServiceException("config error")).when(configService).getConfiguredTables(TEST_CONFIG_KEY);
 
         assertEquals(1, SystemLambda.catchSystemExit(() -> underTest.run()));
@@ -108,6 +117,8 @@ class VacuumJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.of(TEST_CONFIG_KEY));
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         when(configService.getConfiguredTables(TEST_CONFIG_KEY))
                 .thenReturn(ImmutableSet.of(ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_1), ImmutablePair.of(DOMAIN_CONFIG_PATH, DOMAIN_CONFIG_TABLE_2)));
         doThrow(new RuntimeException("Maintenance service exception"))
@@ -121,6 +132,8 @@ class VacuumJobTest extends BaseSparkTest {
         when(arguments.getMaintenanceTablesRootPath()).thenReturn(ROOT_PATH);
         when(arguments.getMaintenanceListTableRecurseMaxDepth()).thenReturn(RECURSE_MAX_DEPTH);
         when(arguments.getOptionalConfigKey()).thenReturn(Optional.empty());
+        when(properties.getSparkDriverMemory()).thenReturn("2g");
+        when(properties.getSparkExecutorMemory()).thenReturn("2g");
         doThrow(new RuntimeException("Maintenance service exception"))
                 .when(maintenanceService).vacuumDeltaTables(eq(spark), any(), eq(RECURSE_MAX_DEPTH));
 


### PR DESCRIPTION
This PR creates a `dpr.adjust.spark.memory` flag to enable adjusting the memory used by the spark job to a higher value.

The flag defaults to false thereby maintaining default memory value i.e. the value injected by glue.

When the flag is set to true, the spark memory is adjusted to 0.75% instead of 0.625% of the Glue worker memory. This gives spark jobs which are spilling to disk more memory to work with.