### PR TITLE
DPR2-1930: Make spark.sql.files.maxRecordsPerFile configurable with a default

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -32,6 +32,7 @@ import static uk.gov.justice.digital.common.RegexPatterns.matchAllFiles;
 import static uk.gov.justice.digital.common.RegexPatterns.parquetFileRegex;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS;
+import static uk.gov.justice.digital.config.JobArguments.DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE;
 import static uk.gov.justice.digital.config.JobArguments.RECONCILIATION_CHECKS_TO_RUN_DEFAULT;
 import static uk.gov.justice.digital.config.JobArguments.STREAMING_JOB_DEFAULT_MAX_FILES_PER_TRIGGER;
 import static uk.gov.justice.digital.config.JobArguments.DEFAULT_RAW_FILE_RETENTION_PERIOD_AMOUNT;
@@ -102,6 +103,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, "0.01" },
             { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, "5" },
             { JobArguments.ADJUST_SPARK_MEMORY, "true" },
+            { JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE, "50000" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -170,6 +172,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_RELATIVE_PERCENTAGE, Double.toString(validArguments.getReconciliationChangeDataCountsToleranceRelativePercentage()) },
                 { JobArguments.RECONCILIATION_CHANGE_DATA_COUNTS_TOLERANCE_ABSOLUTE, Long.toString(validArguments.getReconciliationChangeDataCountsToleranceAbsolute()) },
                 { JobArguments.ADJUST_SPARK_MEMORY, validArguments.adjustSparkMemory() },
+                { JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE, Integer.toString(validArguments.getSparkSqlMaxRecordsPerFile()) },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -560,7 +563,15 @@ class JobArgumentsIntegrationTest {
         HashMap<String, String> args = cloneTestArguments();
         args.remove(JobArguments.SPARK_BROADCAST_TIMEOUT_SECONDS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(jobArguments.getBroadcastTimeoutSeconds(), DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS);
+        assertEquals(DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS, jobArguments.getBroadcastTimeoutSeconds());
+    }
+
+    @Test
+    public void defaultSparkSqlMaxRecordsPerFileWhenMissing() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertEquals(DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE, jobArguments.getSparkSqlMaxRecordsPerFile());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -143,6 +143,11 @@ public class JobArguments {
     static final long DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS = 60;
     static final String SPARK_BROADCAST_TIMEOUT_SECONDS = "dpr.spark.broadcast.timeout.seconds";
     public static final Integer DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS = 300;
+    // For maxrecordsperfile 100,000 is a good first guess if you're not sure about input record sizes.
+    // This should give you roughly the following output file sizes:
+    // ~50MB for ~0.5KB records
+    // ~200MB for ~2KB records
+    // ~500MB for ~5KB records
     static final String SPARK_SQL_MAX_RECORDS_PER_FILE = "dpr.spark.sql.maxrecordsperfile";
     public static final int DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE = 0;
     static final String DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD = "dpr.disable.auto.broadcast.join.threshold";

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -144,7 +144,7 @@ public class JobArguments {
     static final String SPARK_BROADCAST_TIMEOUT_SECONDS = "dpr.spark.broadcast.timeout.seconds";
     public static final Integer DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS = 300;
     static final String SPARK_SQL_MAX_RECORDS_PER_FILE = "dpr.spark.sql.maxrecordsperfile";
-    public static final int DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE = 100000;
+    public static final int DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE = 0;
     static final String DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD = "dpr.disable.auto.broadcast.join.threshold";
     static final String GLUE_TRIGGER_NAME = "dpr.glue.trigger.name";
     static final String ACTIVATE_GLUE_TRIGGER = "dpr.glue.trigger.activate";

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -143,6 +143,8 @@ public class JobArguments {
     static final long DEFAULT_CDC_TRIGGER_INTERVAL_SECONDS = 60;
     static final String SPARK_BROADCAST_TIMEOUT_SECONDS = "dpr.spark.broadcast.timeout.seconds";
     public static final Integer DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS = 300;
+    static final String SPARK_SQL_MAX_RECORDS_PER_FILE = "dpr.spark.sql.maxrecordsperfile";
+    public static final int DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE = 100000;
     static final String DISABLE_AUTO_BROADCAST_JOIN_THRESHOLD = "dpr.disable.auto.broadcast.join.threshold";
     static final String GLUE_TRIGGER_NAME = "dpr.glue.trigger.name";
     static final String ACTIVATE_GLUE_TRIGGER = "dpr.glue.trigger.activate";
@@ -493,6 +495,10 @@ public class JobArguments {
 
     public Integer getBroadcastTimeoutSeconds() {
         return getArgument(SPARK_BROADCAST_TIMEOUT_SECONDS, DEFAULT_SPARK_BROADCAST_TIMEOUT_SECONDS);
+    }
+
+    public Integer getSparkSqlMaxRecordsPerFile() {
+        return getArgument(SPARK_SQL_MAX_RECORDS_PER_FILE, DEFAULT_SPARK_SQL_MAX_RECORDS_PER_FILE);
     }
 
     public boolean disableAutoBroadcastJoinThreshold() {

--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -49,6 +49,7 @@ public class SparkSessionProvider {
                 .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
                 .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
                 .set("spark.sql.legacy.charVarcharAsString", "true")
+                .set("spark.sql.files.maxRecordsPerFile", arguments.getSparkSqlMaxRecordsPerFile().toString())
                 // Do not fail when a file gets deleted/archived after it has been read and converted into a dataframe
                 .set("spark.sql.files.ignoreMissingFiles", "true")
                 // We can write dates as is since we will always be using Spark 3+. See SQLConf for context.


### PR DESCRIPTION
- Added configurable spark.sql.files.maxRecordsPerFile to avoid the problem of very large files when the CDC job processes a large backlog.
- This defaults to 0 (unlimited) as before so there is no change unless it is explicitly set to another value. 
- We can configure this on CDC jobs in the domains repo to a reasonable finger in the air value and then override it for specific pipelines as needed.