### PR TITLE
DPR2-1499: Allow create reload diff job to use 'now' as checkpoint col timestamp when configured to do so

### DIFF
--- a/src/it/java/uk/gov/justice/digital/job/CreateReloadDiffJobE2ESmokeIT.java
+++ b/src/it/java/uk/gov/justice/digital/job/CreateReloadDiffJobE2ESmokeIT.java
@@ -59,6 +59,7 @@ public class CreateReloadDiffJobE2ESmokeIT extends E2ETestBase {
         givenPathsAreConfigured(arguments);
         givenTableConfigIsConfigured(arguments, configService);
         givenRetrySettingsAreConfigured(arguments);
+        when(arguments.shouldUseNowAsCheckpointForReloadJob()).thenReturn(false);
         when(arguments.getTempReloadOutputFolder()).thenReturn("diffs");
         when(arguments.getDmsTaskId()).thenReturn(DMS_TASK_ID);
         when(arguments.getBatchLoadFileGlobPattern()).thenReturn("*.parquet");

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -137,6 +137,7 @@ public class JobArguments {
     static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";
     static final String DMS_REPLICATION_TASK_ID = "dpr.dms.replication.task.id";
     static final String CDC_DMS_REPLICATION_TASK_ID = "dpr.cdc.dms.replication.task.id";
+    static final String RELOAD_JOB_USE_NOW_AS_CHECKPOINT = "dpr.reload.checkpoint.use.now";
     static final String MAX_S3_PAGE_SIZE = "dpr.s3.max.page.size";
     static final Integer DEFAULT_MAX_S3_PAGE_SIZE = 1000;
     static final String CLEAN_CDC_CHECKPOINT = "dpr.clean.cdc.checkpoint";
@@ -475,6 +476,10 @@ public class JobArguments {
 
     public String getCdcDmsTaskId() {
         return getArgument(CDC_DMS_REPLICATION_TASK_ID);
+    }
+
+    public boolean shouldUseNowAsCheckpointForReloadJob() {
+        return getArgument(RELOAD_JOB_USE_NOW_AS_CHECKPOINT, false);
     }
 
     public boolean isOperationalDataStoreWriteEnabled() {


### PR DESCRIPTION
- Previously we had used the DMS task start timestamp as the checkpoint_col to provide ordering guarantees to AP
- The File Transfer in batch pipeline doesn't have a DMS task so we can't use a DMS task start time in these pipelines
- This allows configuring the job to use 'now' for the checkpoint_col when appropriate
- Using 'now' as seen by the job is fine in the case of File Transfer In batch pipelines