### PR TITLE
DHS-409: Fix CDC merge into ODS when a table only has primary key columns

### DIFF
--- a/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccessService.java
+++ b/src/main/java/uk/gov/justice/digital/service/operationaldatastore/dataaccess/OperationalDataStoreDataAccessService.java
@@ -175,11 +175,11 @@ public class OperationalDataStoreDataAccessService {
 
     private Optional<String> maybeMatchedUpdate(SourceReference sourceReference, String[] lowerCaseFieldNames) {
         String updateAssignments = buildUpdateAssignments(sourceReference, lowerCaseFieldNames);
-        if (updateAssignments.isEmpty()) {
-            return Optional.empty();
-        } else {
-            return Optional.of("    WHEN MATCHED AND source.op = 'U' THEN UPDATE SET " + updateAssignments + "\n");
-        }
+
+        return Optional
+                .of(updateAssignments)
+                .filter(s -> !s.isEmpty())
+                .map(s -> "    WHEN MATCHED AND source.op = 'U' THEN UPDATE SET " + s + "\n");
     }
 
     private String buildUpdateAssignments(SourceReference sourceReference, String[] lowerCaseFieldNames) {


### PR DESCRIPTION
When we have a table managed in the Operational Datastore that contains only primary key columns then the CDC job fails when trying to merge the data in. The Batch job is unaffected.

For example, the `prisonregister_prison_category` table is affected because it has only 2 columns which together make up a composite primary key.

The cause is that our code expects there to be non-primary key columns that require an update. Because there are no primary key columns we end up with an empty set of columns after `THEN UPDATE SET`(see below). 



```
MERGE INTO prisons.prisonregister_prison_category destination
USING loading.prisonregister_prison_category source ON source.category = destination.category and source.prison_id = destination.prison_id
    WHEN MATCHED AND source.op = 'D' THEN DELETE
    WHEN MATCHED AND source.op = 'U' THEN UPDATE SET
    WHEN NOT MATCHED AND (source.op = 'I' OR source.op = 'U') THEN INSERT (category, prison_id) VALUES (source.category, source.prison_id)
```

This PR removes the `WHEN MATCHED AND source.op = 'U' THEN UPDATE SET ...` line from the merge SQL when there are no non-primary key columns requiring updates.