### PR TITLE
DHS-423: Default dpr.orchestration.wait.interval.seconds to 40

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  reporting: ministryofjustice/hmpps-reporting@1.0.38
+  reporting: ministryofjustice/hmpps-reporting@1.0.68
   slack: circleci/slack@4.12.5  
 
 workflows:

--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -470,7 +470,7 @@ class JobArgumentsIntegrationTest {
         HashMap<String, String> args = cloneTestArguments();
         args.remove(JobArguments.ORCHESTRATION_WAIT_INTERVAL_SECONDS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(10, jobArguments.orchestrationWaitIntervalSeconds());
+        assertEquals(40, jobArguments.orchestrationWaitIntervalSeconds());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -131,7 +131,7 @@ public class JobArguments {
     static final String ALLOWED_S3_FILE_NAME_REGEX = "dpr.allowed.s3.file.regex";
     public static final String DEFAULT_FILE_NAME_REGEX = ".+";
     static final String ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.orchestration.wait.interval.seconds";
-    static final int DEFAULT_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 10;
+    static final int DEFAULT_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 40;
     static final String ORCHESTRATION_MAX_ATTEMPTS = "dpr.orchestration.max.attempts";
     static final int DEFAULT_ORCHESTRATION_MAX_ATTEMPTS = 20;
     static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";


### PR DESCRIPTION
This PR increases the default timeout for the DMS orchestration job by setting `dpr.orchestration.wait.interval.seconds` to 40. This is done to prevent the job from timing out for the clustered domain.