### PR TITLE
DHS-411: Handle addition of nullable column(s)

### DIFF
--- a/src/main/java/uk/gov/justice/digital/exception/BackfillException.java
+++ b/src/main/java/uk/gov/justice/digital/exception/BackfillException.java
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.exception;
+
+public class BackfillException extends RuntimeException {
+    private static final long serialVersionUID = -2244810603090098293L;
+
+    public BackfillException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/ArchiveBackfillJob.java
+++ b/src/main/java/uk/gov/justice/digital/job/ArchiveBackfillJob.java
@@ -1,0 +1,113 @@
+package uk.gov.justice.digital.job;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import lombok.val;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import uk.gov.justice.digital.client.s3.S3DataProvider;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.exception.BackfillException;
+import uk.gov.justice.digital.exception.SchemaNotFoundException;
+import uk.gov.justice.digital.job.batchprocessing.ArchiveBackfillProcessor;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.SourceReferenceService;
+import uk.gov.justice.digital.service.TableDiscoveryService;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
+
+/**
+ * Job that creates a copy of the archive data retroactively processed to ensure data consistency without compromising integrity.
+ * For example, when nullable columns are added to the schema contract, a back-fill is created with the new columns but with a default value of null.
+ */
+@CommandLine.Command(name = "ArchiveBackfillJob")
+public class ArchiveBackfillJob implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(ArchiveBackfillJob.class);
+    private final JobArguments jobArguments;
+    private final JobProperties properties;
+    private final ConfigService configService;
+    private final S3DataProvider dataProvider;
+    private final SparkSessionProvider sparkSessionProvider;
+    private final TableDiscoveryService tableDiscoveryService;
+    private final ArchiveBackfillProcessor archiveBackfillProcessor;
+    private final SourceReferenceService sourceReferenceService;
+
+    @Inject
+    public ArchiveBackfillJob(
+            JobArguments jobArguments,
+            JobProperties properties,
+            ConfigService configService,
+            S3DataProvider dataProvider,
+            SparkSessionProvider sparkSessionProvider,
+            TableDiscoveryService tableDiscoveryService,
+            ArchiveBackfillProcessor archiveBackfillProcessor,
+            SourceReferenceService sourceReferenceService
+    ) {
+        this.jobArguments = jobArguments;
+        this.dataProvider = dataProvider;
+        this.properties = properties;
+        this.configService = configService;
+        this.sparkSessionProvider = sparkSessionProvider;
+        this.tableDiscoveryService = tableDiscoveryService;
+        this.archiveBackfillProcessor = archiveBackfillProcessor;
+        this.sourceReferenceService = sourceReferenceService;
+    }
+
+    public static void main(String[] args) {
+        PicocliMicronautExecutor.execute(ArchiveBackfillJob.class, args);
+    }
+
+    @Override
+    public void run() {
+        SparkJobRunner.run("ArchiveBackfillJob", jobArguments, properties, sparkSessionProvider, logger, this::runJob);
+    }
+
+    @VisibleForTesting
+    void runJob(SparkSession sparkSession) throws RuntimeException {
+        String configKey = jobArguments.getConfigKey();
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = configService.getConfiguredTables(configKey);
+        List<SourceReference> sourceReferences = sourceReferenceService.getAllSourceReferences(configuredTables);
+
+        if (sourceReferences.isEmpty()) {
+            String errorMessage = String.format("No schemas found for domain %s", configKey);
+            logger.warn(errorMessage);
+            throw new SchemaNotFoundException(errorMessage);
+        } else {
+            val archiveFilesPathsByTable = tableDiscoveryService
+                    .discoverBatchFilesToLoad(jobArguments.getRawArchiveS3Path(), sparkSession);
+
+            for (val sourceReference : sourceReferences) {
+                val source = sourceReference.getSource();
+                val table = sourceReference.getTable();
+                val tableKey = ImmutablePair.of(source, table);
+
+                if (archiveFilesPathsByTable.containsKey(tableKey)) {
+                    logger.info("Creating back-filled archive for table {}.{}", source, table);
+                    val archiveFilePaths = Optional.ofNullable(archiveFilesPathsByTable.get(tableKey))
+                            .orElse(Collections.emptyList());
+
+                    val outputPath = createValidatedPath(jobArguments.getTempReloadS3Path(), jobArguments.getTempReloadOutputFolder());
+                    if (archiveFilePaths.isEmpty()) {
+                        throw new BackfillException("No archive files discovered for table " + source + "." + table);
+                    } else {
+                        val archiveDataset = dataProvider.getBatchSourceData(sparkSession, archiveFilePaths);
+                        archiveBackfillProcessor.createBackfilledArchiveData(sourceReference, outputPath, archiveDataset);
+                    }
+                } else {
+                    logger.info("Excluding table {}.{} which is not in archive", source, table);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/job/batchprocessing/ArchiveBackfillProcessor.java
+++ b/src/main/java/uk/gov/justice/digital/job/batchprocessing/ArchiveBackfillProcessor.java
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.job.batchprocessing;
+
+import jakarta.inject.Inject;
+import lombok.val;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.exception.BackfillException;
+import uk.gov.justice.digital.service.DataStorageService;
+
+import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.spark.sql.functions.lit;
+import static uk.gov.justice.digital.common.ResourcePath.createValidatedPath;
+
+@Singleton
+public class ArchiveBackfillProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(ArchiveBackfillProcessor.class);
+    private final DataStorageService storageService;
+
+    @Inject
+    public ArchiveBackfillProcessor(DataStorageService storageService) {
+        this.storageService = storageService;
+    }
+
+
+    public void createBackfilledArchiveData(SourceReference sourceReference, String outputBasePath, Dataset<Row> archiveDataset) {
+        String source = sourceReference.getSource();
+        String table = sourceReference.getTable();
+        logger.debug("Back-filling archive records with nullable columns for table {}.{}", source, table);
+        final Dataset<Row> backfilledArchiveRecords = backfillNullableColumns(sourceReference, archiveDataset);
+
+        logger.debug("Writing back-filled archive records for table {}.{}", source, table);
+        String backfillOutputPath = createValidatedPath(outputBasePath, source, table);
+
+        if (backfilledArchiveRecords.isEmpty()) {
+            throw new BackfillException("Computed back-fill data is empty for table " + source + "." + table);
+        } else {
+            storageService.overwriteParquet(backfillOutputPath, backfilledArchiveRecords);
+        }
+    }
+
+    private static Dataset<Row> backfillNullableColumns(SourceReference sourceReference, Dataset<Row> archiveDataset) {
+        val nonNullableColumns = Arrays.stream(sourceReference.getSchema().fields())
+                .filter(field -> !field.nullable())
+                .collect(Collectors.toMap(StructField::name, StructField::dataType));
+
+        val nullableColumns = Arrays.stream(sourceReference.getSchema().fields())
+                .filter(StructField::nullable)
+                .collect(Collectors.toMap(StructField::name, StructField::dataType));
+
+        val archiveDatasetColumns = Arrays.stream(archiveDataset.schema().fields())
+                .collect(Collectors.toMap(StructField::name, StructField::dataType));
+
+        val violatesNonNullableColumnRule = nonNullableColumns.entrySet().stream().anyMatch(column -> !archiveDatasetColumns.containsKey(column.getKey()));
+        if (violatesNonNullableColumnRule) {
+            String source = sourceReference.getSource();
+            String table = sourceReference.getTable();
+            throw new BackfillException("Mandatory column(s) in schema does not exist in archived data for table " + source + "." + table);
+        }
+
+        nullableColumns.keySet().removeAll(archiveDatasetColumns.keySet());
+
+        Map<String, Column> nullableColumnMap = nullableColumns
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, column -> lit(null).cast(column.getValue())));
+
+        return archiveDataset.withColumns(nullableColumnMap);
+    }
+}
+

--- a/src/test/java/uk/gov/justice/digital/job/ArchiveBackfillJobTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/ArchiveBackfillJobTest.java
@@ -1,0 +1,230 @@
+package uk.gov.justice.digital.job;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.client.s3.S3DataProvider;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.config.JobArguments;
+import uk.gov.justice.digital.config.JobProperties;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.exception.BackfillException;
+import uk.gov.justice.digital.exception.SchemaNotFoundException;
+import uk.gov.justice.digital.job.batchprocessing.ArchiveBackfillProcessor;
+import uk.gov.justice.digital.provider.SparkSessionProvider;
+import uk.gov.justice.digital.service.ConfigService;
+import uk.gov.justice.digital.service.SourceReferenceService;
+import uk.gov.justice.digital.service.TableDiscoveryService;
+
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
+import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
+import static uk.gov.justice.digital.test.MinimalTestData.PRIMARY_KEY_COLUMN;
+import static uk.gov.justice.digital.test.MinimalTestData.CHECKPOINT_COL_VALUE;
+import static uk.gov.justice.digital.test.MinimalTestData.createRow;
+import static uk.gov.justice.digital.test.TestHelpers.containsTheSameElementsInOrderAs;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveBackfillJobTest extends BaseSparkTest {
+    private static final String TEST_CONFIG_KEY = "test-domain";
+    private static final String ARCHIVE_PATH = "s3://raw-archive-bucket/";
+    private static final String TEMP_RELOAD_PATH = "s3://temp-reload-bucket/";
+    private static final String OUTPUT_FOLDER = "temp-reload-output";
+    private static final String PATH_1 = "archive-t1-file1";
+    private static final String PATH_2 = "archive-t2-file1";
+    private static final SparkSessionProvider sparkSessionProvider = new SparkSessionProvider();
+
+    private static final ImmutablePair<String, String> s1T1 = ImmutablePair.of("s1", "t1");
+    private static final ImmutablePair<String, String> s2T2 = ImmutablePair.of("s2", "t2");
+    private static final ImmutablePair<String, String> s3T3 = ImmutablePair.of("s3", "t3");
+    private static final ImmutablePair<String, String> s4T4 = ImmutablePair.of("s4", "t4");
+
+    private static final Map<ImmutablePair<String, String>, List<String>> discoveredArchivePathsByTable;
+
+    static {
+        discoveredArchivePathsByTable = new HashMap<>();
+        discoveredArchivePathsByTable.put(s1T1, Collections.singletonList(PATH_1));
+        discoveredArchivePathsByTable.put(s2T2, Collections.singletonList(PATH_2));
+    }
+
+    @Mock
+    private JobArguments arguments;
+    @Mock
+    private JobProperties properties;
+    @Mock
+    private ConfigService configService;
+    @Mock
+    private S3DataProvider dataProvider;
+    @Mock
+    private TableDiscoveryService tableDiscoveryService;
+    @Mock
+    private ArchiveBackfillProcessor archiveBackfillProcessor;
+    @Mock
+    private SourceReferenceService sourceReferenceService;
+    @Captor
+    private ArgumentCaptor<String> outputPathCaptor;
+    @Captor
+    private ArgumentCaptor<SourceReference> sourceRefCaptor;
+    @Captor
+    private ArgumentCaptor<Dataset<Row>> archiveDatasetCaptor;
+    private ArchiveBackfillJob underTest;
+
+    @BeforeEach
+    void setUp() {
+        reset(
+                arguments,
+                properties,
+                configService,
+                dataProvider,
+                tableDiscoveryService,
+                archiveBackfillProcessor,
+                sourceReferenceService
+        );
+
+        underTest = new ArchiveBackfillJob(
+                arguments,
+                properties,
+                configService,
+                dataProvider,
+                sparkSessionProvider,
+                tableDiscoveryService,
+                archiveBackfillProcessor,
+                sourceReferenceService
+        );
+    }
+
+    @Test
+    void shouldCreateArchiveBackfillOnlyForDiscoveredArchiveTablesContainedInConfiguredTables() {
+        when(arguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(arguments.getRawArchiveS3Path()).thenReturn(ARCHIVE_PATH);
+        when(arguments.getTempReloadS3Path()).thenReturn(TEMP_RELOAD_PATH);
+        when(arguments.getTempReloadOutputFolder()).thenReturn(OUTPUT_FOLDER);
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(s2T2, s1T1, s3T3);
+        when(configService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+        when(tableDiscoveryService.discoverBatchFilesToLoad(ARCHIVE_PATH, spark)).thenReturn(discoveredArchivePathsByTable);
+        mockSourceReferences(configuredTables);
+
+        Dataset<Row> archiveDataset1 = spark.createDataFrame(Collections.singletonList(
+                        createRow(5, "2023-11-13 10:50:00.123456", Insert, "archiveRecord_4_1")),
+                TEST_DATA_SCHEMA
+        );
+        Dataset<Row> archiveDataset2 = spark.createDataFrame(Arrays.asList(
+                        RowFactory.create(6, "2023-11-13 10:50:00.123456", Insert.getName(), "archiveRecord_5_1", CHECKPOINT_COL_VALUE),
+                        RowFactory.create(7, "2023-11-13 10:50:00.123456", Insert.getName(), "archiveRecord_6_1", CHECKPOINT_COL_VALUE)
+                ),
+                TEST_DATA_SCHEMA
+        );
+
+        when(dataProvider.getBatchSourceData(spark, Collections.singletonList(PATH_1))).thenReturn(archiveDataset1);
+        when(dataProvider.getBatchSourceData(spark, Collections.singletonList(PATH_2))).thenReturn(archiveDataset2);
+
+        underTest.runJob(spark);
+
+        verify(archiveBackfillProcessor, times(2)).createBackfilledArchiveData(
+                sourceRefCaptor.capture(),
+                outputPathCaptor.capture(),
+                archiveDatasetCaptor.capture()
+        );
+
+        List<String> expectedOutputPaths = Arrays.asList(TEMP_RELOAD_PATH + OUTPUT_FOLDER, TEMP_RELOAD_PATH + OUTPUT_FOLDER);
+        List<SourceReference> expectedSourceRefs = createSourceReferences(ImmutableSet.of(s2T2, s1T1));
+
+        assertThat(outputPathCaptor.getAllValues(), containsTheSameElementsInOrderAs(expectedOutputPaths));
+        assertThat(sourceRefCaptor.getAllValues(), containsTheSameElementsInOrderAs(expectedSourceRefs));
+        assertThat(
+                collectRecords(archiveDatasetCaptor.getAllValues()),
+                containsTheSameElementsInOrderAs(collectRecords(Arrays.asList(archiveDataset2, archiveDataset1)))
+        );
+    }
+
+    @Test
+    void shouldNotCallArchiveBackfillProcessorWhenNoDiscoveredArchiveTableIsInConfiguredTables() {
+        when(arguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(arguments.getRawArchiveS3Path()).thenReturn(ARCHIVE_PATH);
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(s3T3, s4T4);
+        when(configService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+        when(tableDiscoveryService.discoverBatchFilesToLoad(ARCHIVE_PATH, spark)).thenReturn(discoveredArchivePathsByTable);
+        mockSourceReferences(configuredTables);
+
+        underTest.runJob(spark);
+
+        verifyNoInteractions(archiveBackfillProcessor);
+    }
+
+    @Test
+    void shouldFailWhenUnableToRetrieveSchemasForDomain() {
+        when(arguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(configService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(ImmutableSet.of(s2T2, s1T1, s3T3, s4T4));
+        when(sourceReferenceService.getAllSourceReferences(any())).thenReturn(Collections.emptyList());
+
+        assertThrows(SchemaNotFoundException.class, () -> underTest.runJob(spark));
+    }
+
+    @Test
+    void shouldFailWhenAtLeastOneConfiguredTableHasNoArchivedFilesDiscovered() {
+        when(arguments.getConfigKey()).thenReturn(TEST_CONFIG_KEY);
+        when(arguments.getRawArchiveS3Path()).thenReturn(ARCHIVE_PATH);
+        when(arguments.getTempReloadS3Path()).thenReturn(TEMP_RELOAD_PATH);
+        when(arguments.getTempReloadOutputFolder()).thenReturn(OUTPUT_FOLDER);
+        ImmutableSet<ImmutablePair<String, String>> configuredTables = ImmutableSet.of(s2T2, s1T1, s3T3);
+        when(configService.getConfiguredTables(TEST_CONFIG_KEY)).thenReturn(configuredTables);
+        when(tableDiscoveryService.discoverBatchFilesToLoad(ARCHIVE_PATH, spark)).thenReturn(Collections.singletonMap(s2T2, Collections.emptyList()));
+        mockSourceReferences(configuredTables);
+
+        assertThrows(BackfillException.class, () -> underTest.runJob(spark));
+
+        verifyNoInteractions(archiveBackfillProcessor);
+    }
+
+    private void mockSourceReferences(ImmutableSet<ImmutablePair<String, String>> sourceTables) {
+        List<SourceReference> sourceReferences = createSourceReferences(sourceTables);
+        when(sourceReferenceService.getAllSourceReferences(sourceTables))
+                .thenReturn(sourceReferences);
+    }
+
+    @NotNull
+    private static List<SourceReference> createSourceReferences(ImmutableSet<ImmutablePair<String, String>> sourceTables) {
+        return sourceTables.stream().map(table -> new SourceReference(
+                table.left + "_" + table.right,
+                "prisons",
+                table.left,
+                table.right,
+                new SourceReference.PrimaryKey(PRIMARY_KEY_COLUMN),
+                "some-schema-version-v1",
+                TEST_DATA_SCHEMA,
+                new SourceReference.SensitiveColumns(Collections.emptyList())
+        )).collect(Collectors.toList());
+    }
+
+    @NotNull
+    private List<Row> collectRecords(List<Dataset<Row>> datasets) {
+        return datasets.stream()
+                .map(Dataset::collectAsList)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/job/batchprocessing/ArchiveBackfillProcessorTest.java
+++ b/src/test/java/uk/gov/justice/digital/job/batchprocessing/ArchiveBackfillProcessorTest.java
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.job.batchprocessing;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.config.BaseSparkTest;
+import uk.gov.justice.digital.datahub.model.SourceReference;
+import uk.gov.justice.digital.exception.BackfillException;
+import uk.gov.justice.digital.service.DataStorageService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static uk.gov.justice.digital.common.CommonDataFields.ShortOperationCode.Insert;
+import static uk.gov.justice.digital.test.MinimalTestData.TEST_DATA_SCHEMA;
+import static uk.gov.justice.digital.test.MinimalTestData.SCHEMA_WITHOUT_METADATA_FIELDS;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveBackfillProcessorTest extends BaseSparkTest {
+
+    @Mock
+    private DataStorageService dataStorageService;
+    @Mock
+    private SourceReference sourceReference;
+    @Captor
+    ArgumentCaptor<Dataset<Row>> datasetCaptor;
+    @Captor
+    ArgumentCaptor<String> outputPathCaptor;
+
+    private static final String SOURCE = "source";
+    private static final String TABLE = "table";
+    private static final String OUTPUT_BASE_PATH = "s3://bucket/output-folder";
+    private static final StructField nullableField = new StructField("new_column", DataTypes.StringType, true, Metadata.empty());
+    private static final StructField nonNullableField = new StructField("new_column", DataTypes.StringType, false, Metadata.empty());
+
+    private ArchiveBackfillProcessor underTest;
+
+    @BeforeEach
+    void setUp() {
+        reset(dataStorageService, sourceReference);
+        underTest = new ArchiveBackfillProcessor(dataStorageService);
+    }
+
+    @Test
+    void shouldHandleAdditionOfNullableColumns() {
+        Dataset<Row> archiveDataset = spark.createDataFrame(Arrays.asList(
+                RowFactory.create(1, "2023-11-13 10:50:00.123456", Insert.getName(), "1", "20240709"),
+                RowFactory.create(2, "2023-11-13 10:50:00.123456", Insert.getName(), "2", "20240709")
+        ), TEST_DATA_SCHEMA);
+
+        Dataset<Row> expectedDatasetToUpdate = spark.createDataFrame(Arrays.asList(
+                RowFactory.create(1, "2023-11-13 10:50:00.123456", Insert.getName(), "1", "20240709", null),
+                RowFactory.create(2, "2023-11-13 10:50:00.123456", Insert.getName(), "2", "20240709", null)
+        ), TEST_DATA_SCHEMA.add(nullableField));
+
+        mockSourceReferenceCallWithNewNullableField();
+
+        underTest.createBackfilledArchiveData(sourceReference, OUTPUT_BASE_PATH, archiveDataset);
+
+        verify(dataStorageService).overwriteParquet(outputPathCaptor.capture(), datasetCaptor.capture());
+
+        Dataset<Row> capturedRecords = datasetCaptor.getValue();
+        assertThat(capturedRecords.collectAsList(), containsInAnyOrder(expectedDatasetToUpdate.collectAsList().toArray()));
+
+        assertThat(outputPathCaptor.getValue(), is(equalTo(createPath())));
+    }
+
+    @Test
+    void shouldFailWhenNonNullableColumnsAreAdded() {
+        Dataset<Row> archiveDataset = spark.createDataFrame(Arrays.asList(
+                RowFactory.create(1, "2023-11-13 10:50:00.123456", Insert.getName(), "1", "20240709"),
+                RowFactory.create(2, "2023-11-13 10:50:00.123456", Insert.getName(), "2", "20240709")
+        ), TEST_DATA_SCHEMA);
+
+        when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS.add(nonNullableField));
+
+        assertThrows(
+                BackfillException.class, () ->
+                underTest.createBackfilledArchiveData(sourceReference, OUTPUT_BASE_PATH, archiveDataset)
+        );
+    }
+
+    @Test
+    void shouldFailWhenArchiveDataIsEmpty() {
+        Dataset<Row> emptyArchiveDataset = spark.createDataFrame(new ArrayList<>(), TEST_DATA_SCHEMA);
+
+        mockSourceReferenceCall();
+
+        assertThrows(BackfillException.class, () -> underTest.createBackfilledArchiveData(sourceReference, OUTPUT_BASE_PATH, emptyArchiveDataset));
+
+        verifyNoInteractions(dataStorageService);
+    }
+
+    private void mockSourceReferenceCall() {
+        when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS);
+        when(sourceReference.getSource()).thenReturn(SOURCE);
+        when(sourceReference.getTable()).thenReturn(TABLE);
+    }
+
+    private void mockSourceReferenceCallWithNewNullableField() {
+        when(sourceReference.getSchema()).thenReturn(SCHEMA_WITHOUT_METADATA_FIELDS.add(nullableField));
+        when(sourceReference.getSource()).thenReturn(SOURCE);
+        when(sourceReference.getTable()).thenReturn(TABLE);
+    }
+
+    @NotNull
+    private static String createPath() {
+        return OUTPUT_BASE_PATH + "/" + SOURCE + "/" + TABLE;
+    }
+}


### PR DESCRIPTION
This PR updates the reload job to handle permitted schema changes.
- When nullable columns are added to the schema, the reload job computes a back-filled version of the archive data by adding null values for the columns and then writes the result to a temp location in S3
- The original archive data will then be replaced by the back-filled version during the reload pipeline
- When a non-nullable column is added, the job fails since we would not know what default to use for the column. This scenario will require a re-ingestion.
- When a nullable column is removed the pipeline will fail because we do not know if a removed column is nullable without schema versioning which we have not implemented yet