### PR TITLE
DHS-447: Increase the default dpr.orchestration.max.attempts to 40

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -478,7 +478,7 @@ class JobArgumentsIntegrationTest {
         HashMap<String, String> args = cloneTestArguments();
         args.remove(JobArguments.ORCHESTRATION_MAX_ATTEMPTS);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertEquals(20, jobArguments.orchestrationMaxAttempts());
+        assertEquals(40, jobArguments.orchestrationMaxAttempts());
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -133,7 +133,7 @@ public class JobArguments {
     static final String ORCHESTRATION_WAIT_INTERVAL_SECONDS = "dpr.orchestration.wait.interval.seconds";
     static final int DEFAULT_ORCHESTRATION_WAIT_INTERVAL_SECONDS = 40;
     static final String ORCHESTRATION_MAX_ATTEMPTS = "dpr.orchestration.max.attempts";
-    static final int DEFAULT_ORCHESTRATION_MAX_ATTEMPTS = 20;
+    static final int DEFAULT_ORCHESTRATION_MAX_ATTEMPTS = 40;
     static final String STOP_GLUE_INSTANCE_JOB_NAME = "dpr.stop.glue.instance.job.name";
     static final String DMS_REPLICATION_TASK_ID = "dpr.dms.replication.task.id";
     static final String CDC_DMS_REPLICATION_TASK_ID = "dpr.cdc.dms.replication.task.id";


### PR DESCRIPTION
The clustered domain takes longer when stopping the DMS task thereby causing the maintenance pipeline to fail. To prevent this, the overall wait period can be increased by further increasing `dpr.orchestration.max.attempts` to a default value of 40.