### PR TITLE
DHS-627: Skip updating delta manifests when deletion vectors are enabled

### DIFF
--- a/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
+++ b/src/main/java/uk/gov/justice/digital/service/DataStorageService.java
@@ -268,6 +268,10 @@ public class DataStorageService {
     }
 
     protected void updateManifest(DeltaTable dt) {
+        if (jobArguments.areDeltaLakeDeletionVectorsEnabled()) {
+            logger.warn("Skipping updating manifest for table with deletion vectors enabled");
+            return;
+        }
         dt.generate("symlink_format_manifest");
     }
 

--- a/src/test/java/uk/gov/justice/digital/service/DataStorageServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/service/DataStorageServiceTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -260,6 +261,14 @@ class DataStorageServiceTest extends SparkTestBase {
         givenDeltaTableExists();
         underTest.updateDeltaManifestForTable(spark, tablePath);
         verifyManifestGeneratedWithExpectedModeString();
+    }
+
+    @Test
+    void shouldNotUpdateDeltaManifestForTableWhenDeletionVectorsAreEnabled() {
+        givenDeltaTableExists();
+        when(mockJobArguments.areDeltaLakeDeletionVectorsEnabled()).thenReturn(true);
+        underTest.updateDeltaManifestForTable(spark, tablePath);
+        verify(mockDeltaTable, never()).generate("symlink_format_manifest");
     }
 
     @Test


### PR DESCRIPTION
This is because generating symlink manifests is not supported and causes an error when deletion vectors are enabled.