### PR TITLE
DHS-683: Allow parallel delete during vacuum

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -114,6 +114,7 @@ class JobArgumentsIntegrationTest {
             { JobArguments.ADJUST_SPARK_MEMORY, "true" },
             { JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE, "50000" },
             { JobArguments.FILE_TRANSFER_USE_DEFAULT_PARALLELISM, "false" },
+            { JobArguments.VACUUM_PARALLEL_DELETION, "false" },
     }).collect(Collectors.toMap(e -> e[0], e -> e[1]));
 
     private static final JobArguments validArguments = new JobArguments(givenAContextWithArguments(testArguments));
@@ -190,6 +191,7 @@ class JobArgumentsIntegrationTest {
                 { JobArguments.ADJUST_SPARK_MEMORY, validArguments.adjustSparkMemory() },
                 { JobArguments.SPARK_SQL_MAX_RECORDS_PER_FILE, Integer.toString(validArguments.getSparkSqlMaxRecordsPerFile()) },
                 { JobArguments.FILE_TRANSFER_USE_DEFAULT_PARALLELISM, validArguments.fileTransferUseDefaultParallelism() },
+                { JobArguments.VACUUM_PARALLEL_DELETION, validArguments.vacuumParallelDeletion() },
         }).collect(Collectors.toMap(entry -> entry[0].toString(), entry -> entry[1].toString()));
 
         assertEquals(testArguments, actualArguments);
@@ -949,6 +951,14 @@ class JobArgumentsIntegrationTest {
         args.remove(JobArguments.DMS_IS_SPLIT_PIPELINE);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
         assertFalse(jobArguments.isSplitPipeline());
+    }
+
+    @Test
+    void vacuumParallelDeletionShouldDefaultToTrue() {
+        HashMap<String, String> args = cloneTestArguments();
+        args.remove(JobArguments.VACUUM_PARALLEL_DELETION);
+        JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
+        assertTrue(jobArguments.vacuumParallelDeletion());
     }
 
     private static ApplicationContext givenAContextWithArguments(Map<String, String> m) {

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -205,6 +205,8 @@ public class JobArguments {
     static final long CLOUDWATCH_METRICS_REPORTING_PERIOD_SECONDS_DEFAULT = 30L;
     static final String CLOUDWATCH_METRICS_SHUTDOWN_FLUSH_TIMEOUT_SECONDS = "dpr.cloudwatch.metrics.shutdown.flush.timeout.seconds";
     static final long CLOUDWATCH_METRICS_SHUTDOWN_FLUSH_TIMEOUT_SECONDS_DEFAULT = 5L;
+    static final String VACUUM_PARALLEL_DELETION = "dpr.vacuum.parallel.deletion";
+    static final boolean VACUUM_PARALLEL_DELETION_DEFAULT = true;
     private final Map<String, String> config;
 
     @Inject
@@ -678,6 +680,10 @@ public class JobArguments {
 
     public double getApproxDataSizeGigaBytes() {
         return getArgument(APPROX_DATA_SIZE_GB, APPROX_DATA_SIZE_GB_DEFAULT);
+    }
+
+    public boolean vacuumParallelDeletion() {
+        return getArgument(VACUUM_PARALLEL_DELETION, VACUUM_PARALLEL_DELETION_DEFAULT);
     }
 
     private String getArgument(String argumentName) {

--- a/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
+++ b/src/main/java/uk/gov/justice/digital/provider/SparkSessionProvider.java
@@ -65,6 +65,10 @@ public class SparkSessionProvider {
                     .set("spark.sql.autoBroadcastJoinThreshold", "-1")
                     .set("spark.sql.adaptive.autoBroadcastJoinThreshold", "-1");
         }
+
+        if (arguments.vacuumParallelDeletion()) {
+            sparkConf.set("spark.databricks.delta.vacuum.parallelDelete.enabled", "true");
+        }
     }
 
     private static String getSparkMemory(JobArguments arguments, String memory) {


### PR DESCRIPTION
This PR provides the argument `--dpr.vacuum.parallel.deletion` (defaults to true) to enable the vacuum/retention job delete files in parallel thereby reducing the run duration.