### PR TITLE
DPR2-2901: Default liquid clustering to false.

### DIFF
--- a/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
+++ b/src/it/java/uk/gov/justice/digital/config/JobArgumentsIntegrationTest.java
@@ -274,17 +274,17 @@ class JobArgumentsIntegrationTest {
     @Test
     void shouldSetDeltaLakeLiquidClusteringEnabled() {
         HashMap<String, String> args = cloneTestArguments();
-        args.put(JobArguments.DELTA_LAKE_LIQUID_CLUSTERING_ENABLED, "false");
+        args.put(JobArguments.DELTA_LAKE_LIQUID_CLUSTERING_ENABLED, "true");
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertFalse(jobArguments.isDeltaLakeLiquidClusteringEnabled());
+        assertTrue(jobArguments.isDeltaLakeLiquidClusteringEnabled());
     }
 
     @Test
-    void shouldDefaultToTrueForDeltaLakeLiquidClusteringEnabled() {
+    void shouldDefaultToFalseForDeltaLakeLiquidClusteringEnabled() {
         HashMap<String, String> args = cloneTestArguments();
         args.remove(JobArguments.DELTA_LAKE_LIQUID_CLUSTERING_ENABLED);
         JobArguments jobArguments = new JobArguments(givenAContextWithArguments(args));
-        assertTrue(jobArguments.isDeltaLakeLiquidClusteringEnabled());
+        assertFalse(jobArguments.isDeltaLakeLiquidClusteringEnabled());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/digital/config/JobArguments.java
+++ b/src/main/java/uk/gov/justice/digital/config/JobArguments.java
@@ -123,7 +123,7 @@ public class JobArguments {
 
     // For Delta Lake storage
     public static final String DELTA_LAKE_LIQUID_CLUSTERING_ENABLED = "dpr.delta.lake.liquid.clustering.enabled";
-    public static final boolean DELTA_LAKE_LIQUID_CLUSTERING_ENABLED_DEFAULT = true;
+    public static final boolean DELTA_LAKE_LIQUID_CLUSTERING_ENABLED_DEFAULT = false;
     public static final String DELTA_LAKE_DELETION_VECTORS_ENABLED = "dpr.delta.lake.deletion.vectors.enabled";
     public static final boolean DELTA_LAKE_DELETION_VECTORS_ENABLED_DEFAULT = false;
 


### PR DESCRIPTION
Liquid clustering by primary key may help merges on the write path but it introduces inefficiencies during `optimize` that cause many small files. Therefore we are disabling it by default, with the caveat that we might in future enable optional liquid clustering by a date column in the future for fact style tables.